### PR TITLE
Data source for the Analytics app

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3,18 +3,31 @@
 namespace OCA\Tables\AppInfo;
 
 use OCA\Tables\Listener\UserDeletedListener;
+use OCA\Tables\Listener\AnalyticsDatasourceListener;
 use OCP\AppFramework\App;
-use OCP\EventDispatcher\IEventDispatcher;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
 use OCP\User\Events\BeforeUserDeletedEvent;
+use OCA\Analytics\Datasource\DatasourceEvent;
 
-class Application extends App {
-	public const APP_ID = 'tables';
+class Application extends App implements IBootstrap
+{
+    public const APP_ID = 'tables';
 
-	public function __construct() {
-		parent::__construct(self::APP_ID);
+    public function __construct()
+    {
+        parent::__construct(self::APP_ID);
+    }
 
-		/* @var IEventDispatcher $eventDispatcher */
-		$dispatcher = $this->getContainer()->get(IEventDispatcher::class);
-		$dispatcher->addServiceListener(BeforeUserDeletedEvent::class, UserDeletedListener::class);
-	}
+    public function register(IRegistrationContext $context): void
+    {
+        $context->registerEventListener(BeforeUserDeletedEvent::class, UserDeletedListener::class);
+        $context->registerEventListener(DatasourceEvent::class, AnalyticsDatasourceListener::class);
+    }
+
+    public function boot(IBootContext $context): void
+    {
+    }
 }

--- a/lib/Datasource/AnalyticsDatasource.php
+++ b/lib/Datasource/AnalyticsDatasource.php
@@ -105,12 +105,12 @@ class AnalyticsDatasource implements IDatasource
      *      'error' => 0,         // INT 0 = no error
      *  ]
      *
-     * @param array $option
+     * @param $option
      * @return array available options of the data source
      * @throws InternalError
      * @throws PermissionError
      */
-    public function readData(array $option): array
+    public function readData($option): array
     {
         // get the data for the selected table
         $tableId = $option['tableId'];
@@ -124,7 +124,7 @@ class AnalyticsDatasource implements IDatasource
         // get the selected columns from the data source options
         $selectedColumns = array();
         if (isset($option['columns']) && strlen($option['columns']) > 0) {
-            $selectedColumns = str_getcsv($option['columns'], ',');
+            $selectedColumns = str_getcsv($option['columns']);
         }
 
         $data = array();
@@ -157,7 +157,7 @@ class AnalyticsDatasource implements IDatasource
      * @param $row
      * @return array
      */
-    private function minimizeRow($selectedColumns, $row)
+    private function minimizeRow($selectedColumns, $row): array
     {
         $rowMinimized = array();
         foreach ($selectedColumns as $selectedColumn) {

--- a/lib/Datasource/AnalyticsDatasource.php
+++ b/lib/Datasource/AnalyticsDatasource.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Analytics data source
+ * Report Table App data with the Analytics App
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the LICENSE.md file.
+ *
+ * @author Marcel Scherello <analytics@scherello.de>
+ */
+
+namespace OCA\Tables\Datasource;
+
+use OCA\Analytics\Datasource\IDatasource;
+use OCA\Tables\Errors\InternalError;
+use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Service\TableService;
+use OCA\Tables\Api\V1Api;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+
+class AnalyticsDatasource implements IDatasource
+{
+    private LoggerInterface $logger;
+    private IL10N $l10n;
+    private TableService $tableService;
+    private V1Api $api;
+
+    public function __construct(
+        IL10N           $l10n,
+        LoggerInterface $logger,
+        TableService    $tableService,
+        V1Api           $api
+    )
+    {
+        $this->l10n = $l10n;
+        $this->logger = $logger;
+        $this->tableService = $tableService;
+        $this->api = $api;
+    }
+
+    /**
+     * @return string Display Name of the datasource
+     */
+    public function getName(): string
+    {
+        return 'Tables App';
+    }
+
+    /**
+     * @return int 2 digit unique datasource id
+     */
+    public function getId(): int
+    {
+        return 55;
+    }
+
+    /**
+     * available options of the data source
+     *
+     * return needs to be an array and can consist of many fields.
+     * every field needs to provide the following format
+     *  id          *mandatory*     = name of the option for the readData
+     *  name        *mandatory*     = displayed name of the input field in the UI
+     *  type        *optional*      = 'tf' to create a dropdown. Values need to be provided in the placeholder separated with "/".
+     *  placeholder *mandatory*     = help text for the input field in the UI
+     *                                for type=tf:
+     *                                  e.g. "true/false"
+     *                                  if value/text pairs are required for the dropdown/option, the values need to be separated with "-" in addition.
+     *                                  e.g. "eq-equal/gt-greater"
+     *                                  to avoid translation of the technical strings, separate them
+     *                                  'true-' - $this->l10n->t('Yes').'/false-'.$this->l10n->t('No')
+     *
+     *  example:
+     *  {['id' => 'datatype', 'name' => 'Type of Data', 'type' => 'tf', 'placeholder' => 'adaptation/absolute']}
+     *
+     * @return array
+     * @throws InternalError
+     */
+    public function getTemplate(): array
+    {
+        $tableString = '';
+        $template = array();
+
+        // get all tables for the current user and concatenate the placeholder string
+        $tables = $this->tableService->findAll();
+        foreach ($tables as $table) {
+            $tableString = $tableString . $table->jsonSerialize()['id'] . '-' . $table->jsonSerialize()['title'] . '/';
+        }
+
+        // add the tables to a dropdown in the data source settings
+        $template[] = ['id' => 'tableId', 'name' => $this->l10n->t('Select table'), 'type' => 'tf', 'placeholder' => $tableString];
+        $template[] = ['id' => 'columns', 'name' => $this->l10n->t('Select columns'), 'placeholder' => $this->l10n->t('e.g. 1,2,4 or leave empty')];
+        return $template;
+    }
+
+    /**
+     * Read the Data
+     *
+     * return needs to be an array
+     *  [
+     *      'header' => $header,  //array('column header 1', 'column header 2','column header 3')
+     *      'dimensions' => array_slice($header, 0, count($header) - 1),
+     *      'data' => $data,
+     *      'error' => 0,         // INT 0 = no error
+     *  ]
+     *
+     * @param array $option
+     * @return array available options of the data source
+     * @throws InternalError
+     * @throws PermissionError
+     */
+    public function readData(array $option): array
+    {
+        // get the data for the selected table
+        $tableId = $option['tableId'];
+        $data = $this->api->getData($tableId, null, null);
+
+        // extract the header from the first row
+        $header = $data[0];
+        // continue with the data without header
+        $rows = array_slice($data, 1);
+
+        // get the selected columns from the data source options
+        $selectedColumns = array();
+        if (isset($option['columns']) && strlen($option['columns']) > 0) {
+            $selectedColumns = str_getcsv($option['columns'], ',');
+        }
+
+        $data = array();
+        if (count($selectedColumns) !== 0) {
+            // if dedicated columns are selected, the others are removed
+            $header = $this->minimizeRow($selectedColumns, $header);
+            foreach ($rows as $row) {
+                $data[] = $this->minimizeRow($selectedColumns, $row);
+            }
+        } else {
+            foreach ($rows as $row) {
+                $data[] = $row;
+            }
+        }
+        unset($rows);
+
+        return [
+            'header' => $header,
+            'dimensions' => array_slice($header, 0, count($header) - 1),
+            'data' => $data,
+            'rawdata' => $data,
+            'error' => 0,
+        ];
+    }
+
+    /**
+     * filter only the selected columns in the given sequence
+     *
+     * @param $selectedColumns
+     * @param $row
+     * @return array
+     */
+    private function minimizeRow($selectedColumns, $row)
+    {
+        $rowMinimized = array();
+        foreach ($selectedColumns as $selectedColumn) {
+            if (is_numeric($selectedColumn)) {
+                $rowMinimized[] = $row[$selectedColumn - 1];
+            } else {
+                $rowMinimized[] = $selectedColumn;
+            }
+        }
+        return $rowMinimized;
+    }
+}

--- a/lib/Datasource/AnalyticsDatasource.php
+++ b/lib/Datasource/AnalyticsDatasource.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Analytics data source
- * Report Table App data with the Analytics App
+ * Report Table App data with the Analytics App.
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the LICENSE.md file.

--- a/lib/Datasource/AnalyticsDatasource.php
+++ b/lib/Datasource/AnalyticsDatasource.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Analytics data source
- * Report Table App data with the Analytics App.
+ * Report Table App data with the Analytics App
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the LICENSE.md file.

--- a/lib/Listener/AnalyticsDatasourceListener.php
+++ b/lib/Listener/AnalyticsDatasourceListener.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Analytics data source
+ * Report Table App data with the Analytics App
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the LICENSE.md file.
+ *
+ * @author Marcel Scherello <analytics@scherello.de>
+ */
+declare(strict_types=1);
+
+namespace OCA\Tables\Listener;
+
+use OCA\Tables\Datasource\AnalyticsDatasource;
+use OCA\Analytics\Datasource\DatasourceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+class AnalyticsDatasourceListener implements IEventListener
+{
+    public function handle(Event $event): void
+    {
+        if (!($event instanceof DatasourceEvent)) {
+            // Unrelated
+            return;
+        }
+        $event->registerDatasource(AnalyticsDatasource::class);
+    }
+}


### PR DESCRIPTION
Analytics accesses data via data sources.
This pull adds the data source logic to Tables.

Within Analytics, the data source "Tables App" can be selected. Additionally, the required columns can be restricted.

The following restrictions apply:
- when persisting data within the Analytics app (automation -> data load), only 3 columns can loaded and the last one has to be a key figure. This might change in the future
- when using realtime reporting, no column restrictions apply
- for most use cases, realtime reporting should be used to avoid double data storage
- for high-volume reporting, Analytics datasets should be used to store the data for high performance reporting and filtering

> ![Bildschirm­foto 2023-02-05 um 20 05 42](https://user-images.githubusercontent.com/13385119/216839531-c550bccb-46c0-48aa-b4ea-25773b92ee4c.png)