### PR TITLE
chore(deps): limit the db backends to pgsql and mysql (mariadb)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,6 +37,8 @@ Have a good time and manage whatever you want.
     <screenshot>https://dl.datenangebot.de/nc%20tables/screenshots/v0.3.1/nc-tables-3.png</screenshot>
     <screenshot>https://dl.datenangebot.de/nc%20tables/screenshots/v0.3.1/nc-tables-4.png</screenshot>
 	<dependencies>
+		<database>pgsql</database>
+		<database>mysql</database>
         <nextcloud min-version="25" max-version="27"/>
     </dependencies>
     <commands>


### PR DESCRIPTION
- the tables app make use of special json operations within the db
- the db recommendations by nextcloud server make sure the db backends support json
- sqlite is not supported

related to #211 