### PR TITLE
chore: add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,99 @@
+name: Bug
+description: Have you encountered a bug? Submit a report and help us improve Nextcloud Tables.
+labels: ["bug", "0. Needs triage"]
+body:
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: |
+          Describe the steps to reproduce the bug.
+          The better your description is _(go 'here', click 'there'...)_ the fastest you'll get an _(accurate)_ answer.
+      value: |
+          1.
+          2.
+          3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Tell us what should happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Tell us what happens instead
+    validations:
+      required: true
+  - type: input
+    id: tables-app-version
+    attributes:
+      label: Tables app version
+      description: See apps admin page, e.g. 0.5.3
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: e.g Firefox 56
+  - type: input
+    id: client-os
+    attributes:
+      label: Client operating system
+      description: e.g. Windows
+  - type: markdown
+    attributes:
+      value: "## Server configuration"
+  - type: input
+    id: server-os
+    attributes:
+      label: Operating system
+      description: |
+          Write down the operating system where Nextcloud Tables app is installed.
+  - type: dropdown
+    id: webserver
+    attributes:
+      label: Web server
+      description: |
+        Select web server serving Nextcloud Server.
+        _Describe in the "Additional info" section if you chose "Other"._
+      options:
+        - "Apache"
+        - "Nginx"
+        - "Other"
+  - type: dropdown
+    id: php
+    attributes:
+      label: PHP engine version
+      description: |
+          Select PHP engine version serving Nextcloud Server.
+          _Describe in the "Additional info" section if you chose "Other"._
+      options:
+          - "PHP 7.3"
+          - "PHP 7.4"
+          - "PHP 8.0"
+          - "PHP 8.1"
+          - "PHP 8.2"
+          - "Other"
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      description: |
+          Select Database engine serving Nextcloud Server.
+          _Describe in the "Additional info" section if you chose "Other"._
+      options:
+          - "MySQL"
+          - "MariaDB"
+          - "PostgreSQL"
+          - "SQLite"
+          - "Oracle"
+          - "Other"
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional info
+      description: Any additional information related to the issue (ex. browser console errors, software versions).

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: You have a neat idea that should be implemented?
+labels: ["enhancement", "0. Needs triage"]
+body:
+  - type: textarea
+    id: description-problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: |
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  - type: textarea
+    id: description-solution
+    attributes:
+      label: Describe the solution you'd like
+      description: |
+        A clear and concise description of what you want to happen.
+  - type: textarea
+    id: description-alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: |
+        A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
After having reported some issues to this repo I stumbled upon the [list of required information for bugs reports](https://github.com/nextcloud/tables/wiki/Contribute#find-bugs). So I thought it would help others to have a form in place which asks for the relevant information.

When creating the issue forms I took a look at the issue forms in the [Mail app](https://github.com/nextcloud/mail/tree/main/.github/ISSUE_TEMPLATE) and [Contacts app](https://github.com/nextcloud/contacts/tree/main/.github/ISSUE_TEMPLATE).

---

With issue forms contributors tend to provide more detailed information which makes it easier for others to triage the issues.