### PR TITLE
bugfix: #236 load default value for text-long on create row with "add more" mode

### DIFF
--- a/src/modules/main/modals/CreateRow.vue
+++ b/src/modules/main/modals/CreateRow.vue
@@ -121,6 +121,7 @@ export default {
 	methods: {
 		actionCancel() {
 			this.reset()
+			this.addNewAfterSave = false
 			this.$emit('close')
 		},
 		isValueValidForColumn(value, column) {

--- a/src/shared/components/ncTable/partials/TiptapMenuBar.vue
+++ b/src/shared/components/ncTable/partials/TiptapMenuBar.vue
@@ -152,6 +152,16 @@ export default {
 		}
 	},
 
+	watch: {
+		value(value) {
+			const isSame = this.editor.getHTML() === value
+			if (isSame) {
+				return
+			}
+			this.editor.commands.setContent(value, false)
+		},
+	},
+
 	mounted() {
 		this.editor = new Editor({
 			extensions: [

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextLongForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextLongForm.vue
@@ -29,7 +29,7 @@ export default {
 	computed: {
 		localValue: {
 			get() {
-				return (this.value)
+				return (this.value !== null)
 					? this.value
 					: ((this.column.textDefault !== undefined)
 						? this.column.textDefault


### PR DESCRIPTION
- add a watcher to load the value
- make get method more precise if value is '' or false or 0
- reset "add more" state after closing modal

@juliushaertl This fix should be backported to stable0.4, whats the best way to do this?