### PR TITLE
Enh/column type text rich

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -7,10 +7,15 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 use OCP\Util;
+use OCA\Text\Event\LoadEditor;
+use OCP\EventDispatcher\IEventDispatcher;
 
 class PageController extends Controller {
-	public function __construct(IRequest $request) {
+	private IEventDispatcher $eventDispatcher;
+
+	public function __construct(IRequest $request, IEventDispatcher $eventDispatcher) {
 		parent::__construct(Application::APP_ID, $request);
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -24,6 +29,10 @@ class PageController extends Controller {
 		Util::addStyle(Application::APP_ID, 'grid');
 		Util::addStyle(Application::APP_ID, 'modal');
 		Util::addStyle(Application::APP_ID, 'tiptap');
+
+		if (class_exists(LoadEditor::class)) {
+			$this->eventDispatcher->dispatchTyped(new LoadEditor());
+		}
 
 		return new TemplateResponse(Application::APP_ID, 'main');
 	}

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,6 +86,10 @@ export default {
 		padding-bottom: 7px;
 	}
 
+	.editor-wrapper p, .editor-wrapper .p {
+		padding: 0;
+	}
+
 	p span, .p span, p .span, .p .span, .p.span, p.span, .light {
 		color: var(--color-text-maxcontrast);
 	}

--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -297,7 +297,8 @@ export default {
 			}
 		},
 		reset() {
-			this.type = null
+			this.type = 'text'
+			this.subtype = 'line'
 			this.title = ''
 			this.description = ''
 			this.numberPrefix = null

--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -50,7 +50,7 @@
 							<NcCheckboxRadioSwitch :checked.sync="subtype" value="long" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Simple text') }}
 							</NcCheckboxRadioSwitch>
-							<NcCheckboxRadioSwitch :checked.sync="subtype" value="rich" name="textTypeSelection" type="radio">
+							<NcCheckboxRadioSwitch v-if="textAppAvailable" :checked.sync="subtype" value="rich" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Rich text') }}
 							</NcCheckboxRadioSwitch>
 						</div>
@@ -169,6 +169,7 @@ export default {
 	},
 	data() {
 		return {
+			textAppAvailable: !!window.OCA?.Text?.createEditor,
 			addNewAfterSave: false,
 			type: 'text',
 			subtype: 'line',

--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -47,9 +47,6 @@
 							<NcCheckboxRadioSwitch :checked.sync="subtype" value="line" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Text line') }}
 							</NcCheckboxRadioSwitch>
-							<NcCheckboxRadioSwitch :checked.sync="subtype" value="long" name="textTypeSelection" type="radio">
-								{{ t('tables', 'Simple text') }}
-							</NcCheckboxRadioSwitch>
 							<NcCheckboxRadioSwitch v-if="textAppAvailable" :checked.sync="subtype" value="rich" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Rich text') }}
 							</NcCheckboxRadioSwitch>
@@ -58,9 +55,6 @@
 						<TextLineForm v-if="subtype === 'line'"
 							:text-default.sync="textDefault"
 							:text-allowed-pattern.sync="textAllowedPattern"
-							:text-max-length.sync="textMaxLength" />
-						<TextLongForm v-if="subtype === 'long'"
-							:text-default.sync="textDefault"
 							:text-max-length.sync="textMaxLength" />
 						<TextRichForm v-if="subtype === 'rich'"
 							:text-default.sync="textDefault" />
@@ -126,7 +120,6 @@ import NumberForm from '../../../shared/components/ncTable/partials/columnTypePa
 import NumberStarsForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberStarsForm.vue'
 import NumberProgressForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberProgressForm.vue'
 import TextLineForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLineForm.vue'
-import TextLongForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLongForm.vue'
 import SelectionCheckForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/SelectionCheckForm.vue'
 import MainForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue'
 import DatetimeForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/DatetimeForm.vue'
@@ -148,7 +141,6 @@ export default {
 		NcModal,
 		NumberForm,
 		TextLineForm,
-		TextLongForm,
 		TextRichForm,
 		MainForm,
 		NumberStarsForm,

--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -50,6 +50,9 @@
 							<NcCheckboxRadioSwitch :checked.sync="subtype" value="long" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Simple text') }}
 							</NcCheckboxRadioSwitch>
+							<NcCheckboxRadioSwitch :checked.sync="subtype" value="rich" name="textTypeSelection" type="radio">
+								{{ t('tables', 'Rich text') }}
+							</NcCheckboxRadioSwitch>
 						</div>
 
 						<TextLineForm v-if="subtype === 'line'"
@@ -59,6 +62,8 @@
 						<TextLongForm v-if="subtype === 'long'"
 							:text-default.sync="textDefault"
 							:text-max-length.sync="textMaxLength" />
+						<TextRichForm v-if="subtype === 'rich'"
+							:text-default.sync="textDefault" />
 					</div>
 
 					<div v-if="type === 'selection'" class="row no-padding-on-mobile space-L">
@@ -134,6 +139,7 @@ import { showError, showInfo, showSuccess, showWarning } from '@nextcloud/dialog
 import '@nextcloud/dialogs/dist/index.css'
 import { mapGetters } from 'vuex'
 import ColumnTypeSelection from '../partials/ColumnTypeSelection.vue'
+import TextRichForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextRichForm.vue'
 
 export default {
 	name: 'CreateColumn',
@@ -143,6 +149,7 @@ export default {
 		NumberForm,
 		TextLineForm,
 		TextLongForm,
+		TextRichForm,
 		MainForm,
 		NumberStarsForm,
 		NumberProgressForm,

--- a/src/modules/main/modals/CreateRow.vue
+++ b/src/modules/main/modals/CreateRow.vue
@@ -18,6 +18,9 @@
 				<TextLinkForm v-if="column.type === 'text' && column.subtype === 'link'"
 					:column="column"
 					:value.sync="row[column.id]" />
+				<TextRichForm v-if="column.type === 'text' && column.subtype === 'rich'"
+					:column="column"
+					:value.sync="row[column.id]" />
 				<NumberForm v-if="column.type === 'number' && !column.subtype"
 					:column="column"
 					:value.sync="row[column.id]" />
@@ -79,6 +82,7 @@ import SelectionMultiForm from '../../../shared/components/ncTable/partials/rowT
 import DatetimeForm from '../../../shared/components/ncTable/partials/rowTypePartials/DatetimeForm.vue'
 import DatetimeDateForm from '../../../shared/components/ncTable/partials/rowTypePartials/DatetimeDateForm.vue'
 import DatetimeTimeForm from '../../../shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue'
+import TextRichForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue'
 
 export default {
 	name: 'CreateRow',
@@ -90,6 +94,7 @@ export default {
 		TextLineForm,
 		TextLongForm,
 		TextLinkForm,
+		TextRichForm,
 		NumberForm,
 		NumberStarsForm,
 		NumberProgressForm,

--- a/src/modules/main/modals/EditColumns.vue
+++ b/src/modules/main/modals/EditColumns.vue
@@ -44,6 +44,8 @@
 						<TextLongForm v-if="editColumn.type === 'text' && editColumn.subtype === 'long'"
 							:text-default.sync="editColumn.textDefault"
 							:text-max-length.sync="editColumn.textMaxLength" />
+						<TextRichForm v-if="editColumn.type === 'text' && editColumn.subtype === 'rich'"
+							:text-default.sync="editColumn.textDefault" />
 						<SelectionForm v-if="editColumn.type === 'selection' && !editColumn.subtype"
 							:selection-options.sync="editColumn.selectionOptions"
 							:selection-default.sync="editColumn.selectionDefault" />
@@ -97,6 +99,10 @@
 							{{ (column.mandatory) ? t('tables', 'Textline') + ', ' + t('tables', 'Mandatory'): t('tables', 'Textline') }}
 						</span>
 
+						<span v-if="column.type === 'text' && column.subtype === 'rich'" class="block">
+							{{ (column.mandatory) ? t('tables', 'Rich text') + ', ' + t('tables', 'Mandatory'): t('tables', 'Rich text') }}
+						</span>
+
 						<span v-if="column.type === 'text' && column.subtype === 'link'" class="block">
 							{{ (column.mandatory) ? t('tables', 'Link') + ', ' + t('tables', 'Mandatory'): t('tables', 'Link') }}
 						</span>
@@ -136,6 +142,7 @@
 								<NumberProgressTableDisplay v-if="column.type === 'number' && column.subtype === 'progress'" :column="column" />
 								<TextLineTableDisplay v-if="column.type === 'text' && column.subtype === 'line'" :column="column" />
 								<TextLongTableDisplay v-if="column.type === 'text' && column.subtype === 'long'" :column="column" />
+								<TextRichTableDisplay v-if="column.type === 'text' && column.subtype === 'rich'" :column="column" />
 								<TextLinkTableDisplay v-if="column.type === 'text' && column.subtype === 'link'" :column="column" />
 								<SelectionTableDisplay v-if="column.type === 'selection' && !column.subtype" :column="column" />
 								<SelectionMultiTableDisplay v-if="column.type === 'selection' && column.subtype === 'multi'" :column="column" />
@@ -194,12 +201,14 @@ import NumberStarsTableDisplay from '../../../shared/components/ncTable/partials
 import NumberProgressTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/NumberProgressTableDisplay.vue'
 import TextLineTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextLineTableDisplay.vue'
 import TextLongTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextLongTableDisplay.vue'
+import TextRichTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextRichTableDisplay.vue'
 import TextLinkTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextLinkTableDisplay.vue'
 import NumberForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberForm.vue'
 import NumberStarsForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberStarsForm.vue'
 import NumberProgressForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberProgressForm.vue'
 import TextLineForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLineForm.vue'
 import TextLongForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLongForm.vue'
+import TextRichForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextRichForm.vue'
 import MainForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue'
 import SelectionCheckTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/SelectionCheckTableDisplay.vue'
 import SelectionTableDisplay from '../../../shared/components/ncTable/partials/columnTypePartials/tableDisplay/SelectionTableDisplay.vue'
@@ -234,12 +243,14 @@ export default {
 		NumberProgressTableDisplay,
 		TextLineTableDisplay,
 		TextLongTableDisplay,
+		TextRichTableDisplay,
 		TextLinkTableDisplay,
 		NumberForm,
 		NumberStarsForm,
 		NumberProgressForm,
 		TextLineForm,
 		TextLongForm,
+		TextRichForm,
 		MainForm,
 		SelectionForm,
 		SelectionMultiForm,

--- a/src/modules/main/modals/EditColumns.vue
+++ b/src/modules/main/modals/EditColumns.vue
@@ -92,11 +92,11 @@
 						</span>
 
 						<span v-if="column.type === 'text' && column.subtype === 'line'" class="block">
-							{{ (column.mandatory) ? t('tables', 'Textline') + ', ' + t('tables', 'Mandatory'): t('tables', 'Textline') }}
+							{{ (column.mandatory) ? t('tables', 'Text-line') + ', ' + t('tables', 'Mandatory'): t('tables', 'Text-line') }}
 						</span>
 
 						<span v-if="column.type === 'text' && column.subtype === 'long'" class="block">
-							{{ (column.mandatory) ? t('tables', 'Textline') + ', ' + t('tables', 'Mandatory'): t('tables', 'Textline') }}
+							{{ (column.mandatory) ? t('tables', 'Text long') + ', ' + t('tables', 'Mandatory'): t('tables', 'Text long') }}
 						</span>
 
 						<span v-if="column.type === 'text' && column.subtype === 'rich'" class="block">

--- a/src/modules/main/modals/EditRow.vue
+++ b/src/modules/main/modals/EditRow.vue
@@ -13,6 +13,9 @@
 				<TextLongForm v-if="column.type === 'text' && column.subtype === 'long'"
 					:column="column"
 					:value.sync="localRow[column.id]" />
+				<TextRichForm v-if="column.type === 'text' && column.subtype === 'rich'"
+					:column="column"
+					:value.sync="localRow[column.id]" />
 				<TextLinkForm v-if="column.type === 'text' && column.subtype === 'link'"
 					:column="column"
 					:value.sync="localRow[column.id]" />
@@ -74,6 +77,7 @@ import '@nextcloud/dialogs/dist/index.css'
 import { mapGetters } from 'vuex'
 import TextLineForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextLineForm.vue'
 import TextLongForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextLongForm.vue'
+import TextRichForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue'
 import TextLinkForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextLinkForm.vue'
 import NumberForm from '../../../shared/components/ncTable/partials/rowTypePartials/NumberForm.vue'
 import NumberStarsForm from '../../../shared/components/ncTable/partials/rowTypePartials/NumberStarsForm.vue'
@@ -95,6 +99,7 @@ export default {
 		NcModal,
 		TextLineForm,
 		TextLongForm,
+		TextRichForm,
 		TextLinkForm,
 		NumberForm,
 		NumberStarsForm,

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -4,14 +4,27 @@
 			<div ref="editor" />
 		</div>
 		<div v-else>
-			{{ t('tables', 'Could not load editor.') }}
+			<NcEmptyContent
+				:title="t('tables', 'Error')"
+				:description="t('tables', 'Could not load editor, text not available.')">
+				<template #icon>
+					<Alert :size="20" />
+				</template>
+			</NcEmptyContent>
 		</div>
 	</div>
 </template>
 
 <script>
+import { NcEmptyContent } from '@nextcloud/vue'
+import Alert from 'vue-material-design-icons/Alert.vue'
 
 export default {
+
+	components: {
+		NcEmptyContent,
+		Alert,
+	},
 
 	props: {
 		canEdit: {

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -115,6 +115,7 @@ export default {
 	.editor-wrapper {
 		width: 100%;
 	}
+
 	.editor-wrapper.border {
 		border: 2px solid var(--color-border-maxcontrast);
 		border-radius: var(--border-radius-large);

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -40,28 +40,34 @@ export default {
 		return {
 			textAppAvailable: !!window.OCA?.Text?.createEditor,
 			editor: null,
+			localValue: '',
 		}
 	},
 
 	computed: {
 		localText: {
 			get() {
-				return this.text
+				return this.localValue
 			},
 			set(v) {
+				this.localValue = v
 				this.$emit('update:text', v)
 			},
 		},
 	},
 
 	watch: {
-		localText(value) {
-			this.editor.setContent(value, false)
+		text(value) {
+			if (value.trim() !== this.localValue.trim()) {
+				this.editor.setContent(value, false)
+			}
 		},
 	},
 
-	mounted() {
-		this.setupEditor()
+	async mounted() {
+		await this.setupEditor()
+		this.localValue = this.text
+		this.editor.setContent(this.localValue, false)
 	},
 
 	beforeDestroy() {

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -114,6 +114,7 @@ export default {
 
 	.editor-wrapper {
 		width: 100%;
+		min-width: 200px;
 	}
 
 	.editor-wrapper.border {

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -1,0 +1,113 @@
+<template>
+	<div class="editor-wrapper" :class="{ border: showBorder, 'hide-readonly-bar': !showReadonlyBar, 'height-small': height === 'small' }">
+		<div v-if="textAppAvailable">
+			<div ref="editor" />
+		</div>
+		<div v-else>
+			{{ t('tables', 'Could not load editor.') }}
+		</div>
+	</div>
+</template>
+
+<script>
+
+export default {
+
+	props: {
+		canEdit: {
+		      type: Boolean,
+		      default: true,
+		    },
+		text: {
+		      type: String,
+		      default: '',
+		    },
+		showBorder: {
+		      type: Boolean,
+		      default: true,
+		    },
+		showReadonlyBar: {
+		      type: Boolean,
+		      default: true,
+		    },
+		height: {
+		      type: String,
+		      default: null, // null, 'small'
+		    },
+	},
+
+	data() {
+		return {
+			textAppAvailable: !!window.OCA?.Text?.createEditor,
+			editor: null,
+		}
+	},
+
+	computed: {
+		localText: {
+			get() {
+				return this.text
+			},
+			set(v) {
+				this.$emit('update:text', v)
+			},
+		},
+	},
+
+	watch: {
+		localText(value) {
+			this.editor.setContent(value, false)
+		},
+	},
+
+	mounted() {
+		this.setupEditor()
+	},
+
+	beforeDestroy() {
+		this?.editor?.destroy()
+	},
+
+	methods: {
+		async setupEditor() {
+			this?.editor?.destroy()
+			if (this.textAppAvailable) {
+				this.editor = await window.OCA.Text.createEditor({
+					el: this.$refs.editor,
+					content: this.localText,
+					readOnly: !this.canEdit,
+					onUpdate: ({ markdown }) => {
+						this.localText = markdown
+					},
+				})
+			} else {
+				console.debug('try to load editor, but not initialized')
+			}
+		},
+	},
+}
+</script>
+<style scoped>
+
+	:deep(.text-editor__wrapper button.entry-action__image-upload) {
+		display: none;
+	}
+
+	.editor-wrapper {
+		width: 100%;
+	}
+	.editor-wrapper.border {
+		border: 2px solid var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-large);
+	}
+
+	:deep(.text-readonly-bar) {
+		display: none !important;
+	}
+
+	.height-small {
+		max-height: 320px;
+		overflow-y: auto;
+	}
+
+</style>

--- a/src/shared/components/ncTable/mixins/columnsTypes/textRichMixin.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textRichMixin.js
@@ -1,0 +1,22 @@
+export default {
+
+	methods: {
+		isSearchStringFoundForTextRich(column, cell, searchString) {
+			if (cell.value.includes(searchString)) {
+				cell.searchStringFound = true
+				return true
+			}
+			return false
+		},
+		isFilterFoundForTextRich(column, cell, filter) {
+			const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+
+			if (filter.operator === 'contains' && cell.value.includes(filterValue)) {
+				cell.filterFound = true
+				return true
+			}
+			return false
+		},
+
+	},
+}

--- a/src/shared/components/ncTable/mixins/searchAndFilterMixin.js
+++ b/src/shared/components/ncTable/mixins/searchAndFilterMixin.js
@@ -12,7 +12,7 @@ export default {
 					icon: 'icon-add',
 					source: 'operators',
 					subline: t('tables', 'Filter operator'),
-					goodFor: ['text-line', 'text-long', 'selection', 'selection-multi', 'text-link'],
+					goodFor: ['text-line', 'text-long', 'selection', 'selection-multi', 'text-link', 'text-rich'],
 				},
 				'operator-begins-with': {
 					id: 'operator-begins-with',
@@ -78,7 +78,7 @@ export default {
 					icon: 'icon-user',
 					source: 'magic-fields',
 					subline: t('tables', 'Magic field'),
-					goodFor: ['text-line', 'selection', 'selection-multi'],
+					goodFor: ['text-line', 'selection', 'selection-multi', 'text-rich'],
 					replace: getCurrentUser().uid,
 				},
 				'magic-field-my-name': {
@@ -87,7 +87,7 @@ export default {
 					icon: 'icon-user',
 					source: 'magic-fields',
 					subline: t('tables', 'Magic field'),
-					goodFor: ['text-line', 'selection', 'selection-multi'],
+					goodFor: ['text-line', 'selection', 'selection-multi', 'text-rich'],
 					replace: getCurrentUser().displayName,
 				},
 				'magic-field-checked': {

--- a/src/shared/components/ncTable/partials/FilterAndSearchSelection.vue
+++ b/src/shared/components/ncTable/partials/FilterAndSearchSelection.vue
@@ -141,10 +141,10 @@ export default {
 
 }
 </script>
-<style lang="scss" scoped>
+<style scoped>
 
 .rich-contenteditable__input {
-	width: 30vw;
+	width: 30vw !important;
 	border-color: var(--color-primary-element);
 }
 

--- a/src/shared/components/ncTable/partials/TableCellEditor.vue
+++ b/src/shared/components/ncTable/partials/TableCellEditor.vue
@@ -1,0 +1,43 @@
+<template>
+	<NcEditor v-if="value !== '' && value !== null" :can-edit="false" :text="value" :show-border="false" :show-readonly-bar="false" />
+</template>
+
+<script>
+import NcEditor from '../../ncEditor/NcEditor.vue'
+
+export default {
+	name: 'TableCellEditor',
+
+	components: {
+		NcEditor,
+	},
+
+	props: {
+		column: {
+			type: Object,
+			default: () => {},
+		},
+		rowId: {
+			type: Number,
+			default: null,
+		},
+		value: {
+			type: String,
+			default: '',
+		},
+	},
+}
+</script>
+
+<style scoped>
+
+div {
+	max-height: calc(var(--default-line-height) * 6);
+	overflow-y: scroll;
+	min-width: 100px;
+	white-space: pre-wrap;
+	margin-top: calc(var(--default-grid-baseline) * 2);
+	margin-bottom: calc(var(--default-grid-baseline) * 2);
+}
+
+</style>

--- a/src/shared/components/ncTable/partials/TableCellEditor.vue
+++ b/src/shared/components/ncTable/partials/TableCellEditor.vue
@@ -1,5 +1,9 @@
 <template>
-	<NcEditor v-if="value !== '' && value !== null" :can-edit="false" :text="value" :show-border="false" :show-readonly-bar="false" />
+	<NcEditor v-if="value !== '' && value !== null"
+		:can-edit="false"
+		:text="value"
+		:show-border="false"
+		:show-readonly-bar="false" />
 </template>
 
 <script>

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -38,6 +38,10 @@
 				:column="col"
 				:row-id="row.id"
 				:value="getCellValue(col.id)" />
+			<TableCellTextRich v-else-if="col.type === 'text' && col.subtype === 'rich'"
+				:column="col"
+				:row-id="row.id"
+				:value="getCellValue(col.id, false)" />
 			<TableCellHtml v-else
 				:value="getCellValue(col.id)"
 				:row-id="row.id"
@@ -66,6 +70,7 @@ import TableCellDateTime from './TableCellDateTime.vue'
 import TableCellTextLine from './TableCellTextLine.vue'
 import TableCellSelection from './TableCellSelection.vue'
 import TableCellMultiSelection from './TableCellMultiSelection.vue'
+import TableCellTextRich from './TableCellEditor.vue'
 
 export default {
 	name: 'TableRow',
@@ -83,6 +88,7 @@ export default {
 		TableCellTextLine,
 		TableCellSelection,
 		TableCellMultiSelection,
+		TableCellTextRich,
 	},
 	props: {
 		row: {

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/TextRichForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/TextRichForm.vue
@@ -1,0 +1,40 @@
+<template>
+	<div style="width: 100%">
+		<!-- default -->
+		<div class="row">
+			<div class="fix-col-4">
+				{{ t('tables', 'Default') }}
+			</div>
+			<div class="fix-col-4 space-B">
+				<NcEditor :text.sync="defaultText" height="small" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcEditor from '../../../../ncEditor/NcEditor.vue'
+
+export default {
+	name: 'TextRichForm',
+
+	components: {
+		NcEditor,
+	},
+
+	props: {
+		textDefault: {
+			type: String,
+			default: '',
+		},
+	},
+
+	computed: {
+		defaultText: {
+			get() { return this.textDefault },
+			set(defaultText) { this.$emit('update:textDefault', defaultText) },
+		},
+	},
+
+}
+</script>

--- a/src/shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextRichTableDisplay.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/tableDisplay/TextRichTableDisplay.vue
@@ -1,0 +1,35 @@
+<template>
+	<table v-if="column" style="width: 100%;">
+		<tr>
+			<td>{{ t('tables', 'Default') }}</td>
+			<td v-if="column.textDefault">
+				{{ t('tables', 'Default text is set') }}
+			</td>
+			<td v-if="!column.textDefault">
+				{{ t('tables', 'No default text') }}
+			</td>
+		</tr>
+	</table>
+</template>
+
+<script>
+
+export default {
+	name: 'TextRichTableDisplay',
+
+	props: {
+		column: {
+			type: Object,
+			default: null,
+		},
+	},
+
+}
+</script>
+<style scoped>
+
+table td {
+	padding-right: 10px;
+}
+
+</style>

--- a/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
@@ -1,13 +1,18 @@
 <template>
 	<div class="row space-T">
-		<div class="fix-col-4">
-			<div class="title">
-				{{ title }}<span v-if="mandatory" :title="t('tables', 'This field is mandatory')">*</span>
+		<div :class="{ 'fix-col-3': hasHeadSlot, 'fix-col-4': !hasHeadSlot }">
+			<div class="row">
+				<div class="title fix-col-4">
+					{{ title }}<span v-if="mandatory" :title="t('tables', 'This field is mandatory')">*</span>
+				</div>
+				<p v-if="description" class="fix-col-4 span">
+					{{ description }}
+				</p>
 			</div>
 		</div>
-		<p v-if="description" class="fix-col-4 span">
-			{{ description }}
-		</p>
+		<div v-if="hasHeadSlot" class="fix-col-1 end">
+			<slot name="head" />
+		</div>
 		<div :class="[ `fix-col-${width}` ]" class="slot">
 			<slot />
 		</div>
@@ -18,6 +23,7 @@
 
 export default {
 	name: 'RowFormWrapper',
+
 	props: {
 		mandatory: {
 			type: Boolean,
@@ -42,6 +48,12 @@ export default {
 		width: {
 			type: Number,
 			default: 4,
+		},
+	},
+
+	computed: {
+		hasHeadSlot() {
+			return !!this.$slots.head?.[0]
 		},
 	},
 }

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
@@ -8,7 +8,7 @@
 					</template>
 					{{ t('tables', 'Show big editor') }}
 				</NcButton>
-				<NcModal v-if="showBigEditorModal" size="large" :title="column.title" @close="showBigEditorModal = false">
+				<NcModal v-if="showBigEditorModal" :close-button-contained="true" size="large" :title="column.title" @close="showBigEditorModal = false">
 					<div class="row">
 						<div class="fix-col-4 space-T-big">
 							<NcEditor :text.sync="localValue" :show-border="false" />
@@ -75,6 +75,7 @@ export default {
 			},
 		},
 	},
+
 }
 </script>
 <style lang="scss" scoped>

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
@@ -11,18 +11,16 @@
 					<Fullscreen :size="20" />
 				</template>
 			</NcButton>
-			<NcModal v-if="showBigEditorModal" :close-button-contained="true" size="large" :title="column.title" @close="showBigEditorModal = false">
+			<NcModal v-if="showBigEditorModal" :close-button-contained="true" size="full" :title="column.title" @close="showBigEditorModal = false">
 				<div class="row">
-					<div class="fix-col-4 space-T-big">
+					<div class="fix-col-4">
 						<NcEditor :text.sync="localValue" :show-border="false" />
 					</div>
-					<div class="col-4 end space-R space-B">
-						<div class="end">
-							<NcButton @click="showBigEditorModal = false">
-								{{ t('tables', 'Close editor') }}
-							</NcButton>
-						</div>
-					</div>
+				</div>
+				<div class="closeModalButton">
+					<NcButton @click="showBigEditorModal = false">
+						{{ t('tables', 'Close editor') }}
+					</NcButton>
 				</div>
 			</NcModal>
 		</template>
@@ -77,18 +75,3 @@ export default {
 
 }
 </script>
-<style lang="scss" scoped>
-
-	.space-R {
-		padding-right: calc(var(--default-grid-baseline) * 2);
-	}
-
-	.end {
-		float: right;
-	}
-
-	.space-T-big {
-		padding-top: 40px;
-	}
-
-</style>

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
@@ -1,0 +1,94 @@
+<template>
+	<RowFormWrapper :title="column.title" :mandatory="column.mandatory" :description="column.description">
+		<div class="row">
+			<div class="fix-col-4 end space-B-small">
+				<NcButton @click="showBigEditorModal = true">
+					<template #icon>
+						<Fullscreen :size="20" />
+					</template>
+					{{ t('tables', 'Show big editor') }}
+				</NcButton>
+				<NcModal v-if="showBigEditorModal" size="large" :title="column.title" @close="showBigEditorModal = false">
+					<div class="row">
+						<div class="fix-col-4 space-T-big">
+							<NcEditor :text.sync="localValue" :show-border="false" />
+						</div>
+						<div class="col-4 end space-R space-B">
+							<div class="end">
+								<NcButton @click="showBigEditorModal = false">
+									{{ t('tables', 'Close editor') }}
+								</NcButton>
+							</div>
+						</div>
+					</div>
+				</NcModal>
+			</div>
+			<div class="fix-col-4">
+				<NcEditor v-if="!showBigEditorModal" :text.sync="localValue" height="small" />
+			</div>
+		</div>
+	</RowFormWrapper>
+</template>
+
+<script>
+import RowFormWrapper from './RowFormWrapper.vue'
+import NcEditor from '../../../ncEditor/NcEditor.vue'
+import { NcButton, NcModal } from '@nextcloud/vue'
+import Fullscreen from 'vue-material-design-icons/Fullscreen.vue'
+
+export default {
+	components: {
+		Fullscreen,
+		RowFormWrapper,
+		NcEditor,
+		NcButton,
+		NcModal,
+	},
+
+	props: {
+		column: {
+			type: Object,
+			default: null,
+		},
+		value: {
+			type: String,
+			default: null,
+		},
+	},
+
+	data() {
+		return {
+			showBigEditorModal: false,
+		}
+	},
+	computed: {
+		localValue: {
+			get() {
+				return (this.value !== null)
+					? this.value
+					: ((this.column.textDefault !== undefined)
+						? this.column.textDefault
+						: '')
+			},
+			set(v) {
+				this.$emit('update:value', v)
+			},
+		},
+	},
+}
+</script>
+<style lang="scss" scoped>
+
+	.space-R {
+		padding-right: calc(var(--default-grid-baseline) * 2);
+	}
+
+	.end {
+		float: right;
+	}
+
+	.space-T-big {
+		padding-top: 40px;
+	}
+
+</style>

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue
@@ -1,32 +1,31 @@
 <template>
 	<RowFormWrapper :title="column.title" :mandatory="column.mandatory" :description="column.description">
 		<div class="row">
-			<div class="fix-col-4 end space-B-small">
-				<NcButton @click="showBigEditorModal = true">
-					<template #icon>
-						<Fullscreen :size="20" />
-					</template>
-					{{ t('tables', 'Show big editor') }}
-				</NcButton>
-				<NcModal v-if="showBigEditorModal" :close-button-contained="true" size="large" :title="column.title" @close="showBigEditorModal = false">
-					<div class="row">
-						<div class="fix-col-4 space-T-big">
-							<NcEditor :text.sync="localValue" :show-border="false" />
-						</div>
-						<div class="col-4 end space-R space-B">
-							<div class="end">
-								<NcButton @click="showBigEditorModal = false">
-									{{ t('tables', 'Close editor') }}
-								</NcButton>
-							</div>
-						</div>
-					</div>
-				</NcModal>
-			</div>
 			<div class="fix-col-4">
 				<NcEditor v-if="!showBigEditorModal" :text.sync="localValue" height="small" />
 			</div>
 		</div>
+		<template #head>
+			<NcButton type="tertiary" @click="showBigEditorModal = true">
+				<template #icon>
+					<Fullscreen :size="20" />
+				</template>
+			</NcButton>
+			<NcModal v-if="showBigEditorModal" :close-button-contained="true" size="large" :title="column.title" @close="showBigEditorModal = false">
+				<div class="row">
+					<div class="fix-col-4 space-T-big">
+						<NcEditor :text.sync="localValue" :show-border="false" />
+					</div>
+					<div class="col-4 end space-R space-B">
+						<div class="end">
+							<NcButton @click="showBigEditorModal = false">
+								{{ t('tables', 'Close editor') }}
+							</NcButton>
+						</div>
+					</div>
+				</div>
+			</NcModal>
+		</template>
 	</RowFormWrapper>
 </template>
 

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -46,6 +46,7 @@ import datetimeTimeMixin from '../mixins/columnsTypes/datetimeTimeMixin.js'
 import datetimeMixin from '../mixins/columnsTypes/datetimeMixin.js'
 import generalHelper from '../../../mixins/generalHelper.js'
 import searchAndFilterMixin from '../mixins/searchAndFilterMixin.js'
+import textRichMixin from '../mixins/columnsTypes/textRichMixin.js'
 
 export default {
 	name: 'CustomTable',
@@ -58,6 +59,7 @@ export default {
 	mixins: [
 		textLineMixin,
 		textLongMixin,
+		textRichMixin,
 		selectionMixin,
 		selectionMultiMixin,
 		numberMixin,

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -364,7 +364,7 @@ export default {
 			border-bottom: 1px solid var(--color-border);
 		}
 
-		tr:active, tr:hover, tr:focus {
+		tr:active, tr:hover, tr:focus, tr:hover .editor-wrapper .editor {
 			background-color: var(--color-background-dark);
 		}
 


### PR DESCRIPTION
This pull adds a new column type "text-rich".
The used editor component is the main text component from nextcloud overall.
On the create and edit modal is a full-screen option to edit in full mode.

The option for inserting files and images is hidden by css.

<img width="781" alt="Screenshot 2023-04-26 at 12 23 18" src="https://user-images.githubusercontent.com/55329475/234547773-99764cb1-4b28-40ec-a944-06d0566d9374.png">
<img width="558" alt="Screenshot 2023-04-26 at 12 23 53" src="https://user-images.githubusercontent.com/55329475/234547782-2b1caf13-caf7-4feb-b724-4edee1c0a0d6.png">
