### PR TITLE
design(create table modal): add focus trapping #248

### DIFF
--- a/src/modules/navigation/modals/CreateTable.vue
+++ b/src/modules/navigation/modals/CreateTable.vue
@@ -33,6 +33,7 @@
 						:title="t('tables', '🔧 Custom table')"
 						:body="t('tables', 'Custom table from scratch.')"
 						:active="templateChoice === 'custom'"
+						:tabbable="true"
 						@set-template="setTemplate('custom')" />
 				</div>
 				<div v-for="template in templates" :key="template.name" class="col-2 block space-R space-B">
@@ -40,6 +41,7 @@
 						:title="template.icon + ' ' + template.title"
 						:body="template.description"
 						:active="templateChoice === template.name"
+						:tabbable="true"
 						@set-template="setTemplate(template.name)" />
 				</div>
 			</div>

--- a/src/shared/components/NcTile/NcTile.vue
+++ b/src/shared/components/NcTile/NcTile.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="tile" :class="{active: localeActive}" @click="$emit('set-template')">
+	<div :tabindex="tabbable ? 0 : null" class="tile" :class="{active: localeActive}" @click="$emit('set-template')">
 		<h3>{{ title }}</h3>
 		<p>{{ body }}</p>
 	</div>
@@ -35,6 +35,10 @@ export default {
 			type: String,
 			default: '',
 		},
+		tabbable: {
+		      type: Boolean,
+		      default: false,
+		    },
 	},
 
 	computed: {
@@ -67,8 +71,12 @@ export default {
 	cursor: pointer;
 }
 
-.tile:hover {
+.tile:hover, .tile:focus {
 	border-color: var(--color-primary-element);
+}
+
+.tile:hover h3, .tile:focus h3 {
+	font-weight: bold;
 }
 
 .active {


### PR DESCRIPTION
- add tabbable
- add bold and border on hover/focus

You can now tab through the templates on the create table modal:
<img width="498" alt="Screenshot 2023-04-26 at 12 54 39" src="https://user-images.githubusercontent.com/55329475/234554464-b1729df6-72ca-416a-bf4b-cf526a372e95.png">
