### PR TITLE
fix(nc25 and text-editor): bring back column-type text-long for nc25

### DIFF
--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -47,6 +47,9 @@
 							<NcCheckboxRadioSwitch :checked.sync="subtype" value="line" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Text line') }}
 							</NcCheckboxRadioSwitch>
+							<NcCheckboxRadioSwitch v-if="!textAppAvailable" :checked.sync="subtype" value="long" name="textTypeSelection" type="radio">
+								{{ t('tables', 'Simple text') }}
+							</NcCheckboxRadioSwitch>
 							<NcCheckboxRadioSwitch v-if="textAppAvailable" :checked.sync="subtype" value="rich" name="textTypeSelection" type="radio">
 								{{ t('tables', 'Rich text') }}
 							</NcCheckboxRadioSwitch>
@@ -55,6 +58,9 @@
 						<TextLineForm v-if="subtype === 'line'"
 							:text-default.sync="textDefault"
 							:text-allowed-pattern.sync="textAllowedPattern"
+							:text-max-length.sync="textMaxLength" />
+						<TextLongForm v-if="subtype === 'long'"
+							:text-default.sync="textDefault"
 							:text-max-length.sync="textMaxLength" />
 						<TextRichForm v-if="subtype === 'rich'"
 							:text-default.sync="textDefault" />
@@ -120,6 +126,7 @@ import NumberForm from '../../../shared/components/ncTable/partials/columnTypePa
 import NumberStarsForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberStarsForm.vue'
 import NumberProgressForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/NumberProgressForm.vue'
 import TextLineForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLineForm.vue'
+import TextLongForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/TextLongForm.vue'
 import SelectionCheckForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/SelectionCheckForm.vue'
 import MainForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue'
 import DatetimeForm from '../../../shared/components/ncTable/partials/columnTypePartials/forms/DatetimeForm.vue'
@@ -141,6 +148,7 @@ export default {
 		NcModal,
 		NumberForm,
 		TextLineForm,
+		TextLongForm,
 		TextRichForm,
 		MainForm,
 		NumberStarsForm,


### PR DESCRIPTION
closes #299 

- nc25 does not provide the editor API used for text-rich columns, so we provide here the simple text as default for text columns