### PR TITLE
fix(Options): prevents buttons to get cut off

### DIFF
--- a/src/shared/components/ncTable/partials/SearchForm.vue
+++ b/src/shared/components/ncTable/partials/SearchForm.vue
@@ -60,7 +60,6 @@ export default {
 <style scoped>
 
 :deep(.input-field input) {
-	width: 30vw !important;
 	border-color: var(--color-primary-element);
 }
 

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -33,7 +33,7 @@
 				<div style="padding: 10px; color: var(--color-text-maxcontrast);">
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
-				<NcActions type="secondary" :force-name="true" :inline="showFullOptions ? 2 : 0">
+				<NcActions type="secondary" :force-title="true" :inline="showFullOptions ? 2 : 0">
 					<NcActionButton
 						@click="exportCsv">
 						<template #icon>

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -132,6 +132,12 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			optionsDivWidth: null,
+		}
+	},
+
 	computed: {
 		getSelectedRows() {
 			const rows = []
@@ -144,11 +150,19 @@ export default {
 			return this.view?.searchString || ''
 		},
 		showFullOptions() {
-			 return this.wsize > 640
+			 return this.optionsDivWidth > 800
 		},
 	},
 
+	created() {
+		this.updateOptionsDivWidth()
+		window.addEventListener('resize', this.updateOptionsDivWidth)
+	},
+
 	methods: {
+		updateOptionsDivWidth() {
+			this.optionsDivWidth = document.getElementsByClassName('options row')[0]?.offsetWidth
+		},
 		exportCsv() {
 			this.$emit('download-csv', this.getSelectedRows)
 		},

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -1,8 +1,9 @@
 <template>
 	<div class="options">
 		<div v-if="showOptions && canReadTable(table)" class="fix-col-4" style="justify-content: space-between;">
-			<div :class="{'add-padding-left': isSmallMobile && selectedRows.length === 0 }" class="actionButtonsLeft">
-				<NcButton v-if="!isSmallMobile && canCreateRowInTable(table) && selectedRows.length === 0"
+			<div :class="{'add-padding-left': isSmallMobile }"
+				class="actionButtonsLeft">
+				<NcButton v-if="!isSmallMobile && canCreateRowInTable(table)"
 					:close-after-click="true"
 					type="tertiary"
 					@click="$emit('create-row')">
@@ -11,7 +12,7 @@
 						<Plus :size="25" />
 					</template>
 				</NcButton>
-				<NcButton v-if="isSmallMobile && canCreateRowInTable(table) && selectedRows.length === 0"
+				<NcButton v-if="isSmallMobile && canCreateRowInTable(table)"
 					:close-after-click="true"
 					type="tertiary"
 					@click="$emit('create-row')">
@@ -32,25 +33,37 @@
 				<div style="padding: 10px; color: var(--color-text-maxcontrast);">
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
-      &nbsp;&nbsp;
-				<NcButton v-if="!isSmallMobile"
-					icon="icon-download"
-					:title="t('tables', 'Export as CSV')"
+				<NcActions type="secondary">
+					<NcActionButton icon="icon-download"
+						@click="exportCsv">
+						<template #icon>
+							<Export :size="20" />
+						</template>
+						{{ t('tables', 'Export CSV') }}
+					</NcActionButton>
+					<NcActionButton v-if="canDeleteData(table)" icon="icon-delete"
+						@click="deleteSelectedRows">
+						{{ t('tables', 'Delete') }}
+						<template #icon>
+							<Delete :size="20" />
+						</template>
+					</NcActionButton>
+					<NcActionButton icon="icon-checkmark" @click="deselectAllRows">
+						{{ t('tables', 'Uncheck all') }}
+						<template #icon>
+							<Check :size="20" />
+						</template>
+					</NcActionButton>
+				</NcActions>
+				<!-- <NcButton v-if="!isSmallMobile"
+					icon="icon-download" :title="t('tables', 'Export as CSV')"
 					@click="exportCsv">
 					<template #icon>
 						<Export :size="20" />
 					</template>
 					{{ t('tables', 'Export CSV') }}
 				</NcButton>
-				<NcButton v-if="isSmallMobile"
-					icon="icon-download"
-					:title="t('tables', 'Export as CSV')"
-					@click="exportCsv">
-					<template #icon>
-						<Export :size="20" />
-					</template>
-				</NcButton>
-      &nbsp;&nbsp;
+				&nbsp;&nbsp;
 				<NcButton v-if="!isSmallMobile && canDeleteData(table)"
 					icon="icon-delete"
 					:title="t('tables', 'Delete')"
@@ -59,23 +72,17 @@
 					<template #icon>
 						<Delete :size="20" />
 					</template>
-				</NcButton>
-				<NcButton v-if="isSmallMobile && canDeleteData(table)"
-					icon="icon-delete"
-					:title="t('tables', 'Delete')"
-					@click="deleteSelectedRows">
-					<template #icon>
-						<Delete :size="20" />
-					</template>
-				</NcButton>
+				</NcButton> -->
 			</div>
 		</div>
 	</div>
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
+import { NcButton, NcActions, NcActionButton } from '@nextcloud/vue'
+import { emit } from '@nextcloud/event-bus'
 import Plus from 'vue-material-design-icons/Plus.vue'
+import Check from 'vue-material-design-icons/Check.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import Export from 'vue-material-design-icons/Export.vue'
 import viewportHelper from '../../../mixins/viewportHelper.js'
@@ -86,9 +93,12 @@ export default {
 	name: 'Options',
 
 	components: {
+		NcActions,
+		NcActionButton,
 		SearchForm,
 		NcButton,
 		Plus,
+		Check,
 		Delete,
 		Export,
 	},
@@ -113,13 +123,13 @@ export default {
 			default: () => {},
 		},
 		columns: {
-		      type: Array,
-		      default: null,
-		    },
+			type: Array,
+			default: null,
+		},
 		view: {
-		      type: Object,
-		      default: null,
-		    },
+			type: Object,
+			default: null,
+		},
 	},
 
 	computed: {
@@ -145,6 +155,9 @@ export default {
 		},
 		deleteSelectedRows() {
 			this.$emit('delete-selected-rows', this.selectedRows)
+		},
+		deselectAllRows() {
+			emit('tables:selected-rows:deselect', {})
 		},
 	},
 }
@@ -187,6 +200,7 @@ export default {
 .searchAndFilter {
 	margin-left: calc(var(--default-grid-baseline) * 3);
 	width: auto;
+	min-width: 100px;
 }
 
 </style>

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="options">
 		<div v-if="showOptions && canReadTable(table)" class="fix-col-4" style="justify-content: space-between;">
-			<div :class="{'add-padding-left': isSmallMobile }" class="actionButtonsLeft">
-				<NcButton v-if="!isSmallMobile && canCreateRowInTable(table)"
+			<div :class="{'add-padding-left': isSmallMobile && selectedRows.length === 0 }" class="actionButtonsLeft">
+				<NcButton v-if="!isSmallMobile && canCreateRowInTable(table) && selectedRows.length === 0"
 					:close-after-click="true"
 					type="tertiary"
 					@click="$emit('create-row')">
@@ -11,7 +11,7 @@
 						<Plus :size="25" />
 					</template>
 				</NcButton>
-				<NcButton v-if="isSmallMobile && canCreateRowInTable(table)"
+				<NcButton v-if="isSmallMobile && canCreateRowInTable(table) && selectedRows.length === 0"
 					:close-after-click="true"
 					type="tertiary"
 					@click="$emit('create-row')">
@@ -162,6 +162,9 @@ export default {
 .selected-rows-option {
 	justify-content: flex-end;
 	display: inline-flex;
+	white-space: nowrap;
+	overflow: hidden;
+	min-width: fit-content;
 }
 
 .add-padding-left {
@@ -183,6 +186,7 @@ export default {
 
 .searchAndFilter {
 	margin-left: calc(var(--default-grid-baseline) * 3);
+	width: auto;
 }
 
 </style>

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -33,26 +33,26 @@
 				<div style="padding: 10px; color: var(--color-text-maxcontrast);">
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
-				<NcActions type="secondary">
-					<NcActionButton icon="icon-download"
+				<NcActions type="secondary" :force-name="true" :inline="showFullOptions ? 2 : 0">
+					<NcActionButton
 						@click="exportCsv">
 						<template #icon>
 							<Export :size="20" />
 						</template>
 						{{ t('tables', 'Export CSV') }}
 					</NcActionButton>
-					<NcActionButton v-if="canDeleteData(table)" icon="icon-delete"
+					<NcActionButton v-if="canDeleteData(table)"
 						@click="deleteSelectedRows">
-						{{ t('tables', 'Delete') }}
 						<template #icon>
 							<Delete :size="20" />
 						</template>
+						{{ t('tables', 'Delete') }}
 					</NcActionButton>
-					<NcActionButton icon="icon-checkmark" @click="deselectAllRows">
-						{{ t('tables', 'Uncheck all') }}
+					<NcActionButton v-if="!showFullOptions" @click="deselectAllRows">
 						<template #icon>
 							<Check :size="20" />
 						</template>
+						{{ t('tables', 'Uncheck all') }}
 					</NcActionButton>
 				</NcActions>
 				<!-- <NcButton v-if="!isSmallMobile"
@@ -82,7 +82,7 @@
 import { NcButton, NcActions, NcActionButton } from '@nextcloud/vue'
 import { emit } from '@nextcloud/event-bus'
 import Plus from 'vue-material-design-icons/Plus.vue'
-import Check from 'vue-material-design-icons/Check.vue'
+import Check from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import Export from 'vue-material-design-icons/Export.vue'
 import viewportHelper from '../../../mixins/viewportHelper.js'
@@ -142,6 +142,9 @@ export default {
 		},
 		getSearchString() {
 			return this.view?.searchString || ''
+		},
+		showFullOptions() {
+			 return this.wsize > 640
 		},
 	},
 

--- a/src/shared/mixins/viewportHelper.js
+++ b/src/shared/mixins/viewportHelper.js
@@ -5,15 +5,27 @@ m <= 1024px
  */
 
 export default {
-	computed: {
-		isExtraSmallMobile() {
-			return window.innerWidth <= 460
-		},
-		isSmallMobile() {
-			return window.innerWidth <= 640
-		},
-		isMediumMobile() {
-			return window.innerWidth <= 1024
+	data() {
+		return {
+			isExtraSmallMobile: window.innerWidth <= 460,
+			isSmallMobile: window.innerWidth <= 640,
+			isMediumMobile: window.innerWidth <= 1024,
+			wsize: window.innerWidth,
+		}
+	},
+
+	created() {
+		window.addEventListener('resize', this.updateMobileSizes)
+	},
+	destroyed() {
+		window.removeEventListener('resize', this.updateMobileSizes)
+	},
+	methods: {
+		updateMobileSizes() {
+			this.isExtraSmallMobile = window.innerWidth <= 460
+			this.isSmallMobile = window.innerWidth <= 640
+			this.isMediumMobile = window.innerWidth <= 1024
+			this.wsize = window.innerWidth
 		},
 	},
 }


### PR DESCRIPTION
Closes #289 

When selecting a row in tables, the button can be cut with a specific screen width. This is solved by this fix.

The design should be reviewed. See #289 