### PR TITLE
fix(RichTextCell): Removed unnecessary padding

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellEditor.vue
+++ b/src/shared/components/ncTable/partials/TableCellEditor.vue
@@ -36,12 +36,16 @@ export default {
 <style scoped>
 
 div {
-	max-height: calc(var(--default-line-height) * 6);
-	overflow-y: scroll;
-	min-width: 100px;
-	white-space: pre-wrap;
-	margin-top: calc(var(--default-grid-baseline) * 2);
-	margin-bottom: calc(var(--default-grid-baseline) * 2);
+    max-height: calc(var(--default-line-height) * 6);
+    overflow-y: scroll;
+    min-width: 100px;
+    margin-top: calc(var(--default-grid-baseline) * 2);
+    margin-bottom: calc(var(--default-grid-baseline) * 2);
 }
-
+    :deep(.text-editor__wrapper div.ProseMirror) {
+        padding: 0px 0px 0px 0px
+    }
+    :deep(.editor__content) {
+        max-width: 100% !important
+    }
 </style>

--- a/src/shared/components/ncTable/partials/TableCellEditor.vue
+++ b/src/shared/components/ncTable/partials/TableCellEditor.vue
@@ -36,16 +36,18 @@ export default {
 <style scoped>
 
 div {
-    max-height: calc(var(--default-line-height) * 6);
-    overflow-y: scroll;
-    min-width: 100px;
-    margin-top: calc(var(--default-grid-baseline) * 2);
-    margin-bottom: calc(var(--default-grid-baseline) * 2);
+	max-height: calc(var(--default-line-height) * 6);
+	overflow-y: scroll;
+	min-width: 100px;
+	margin-top: calc(var(--default-grid-baseline) * 2);
+	margin-bottom: calc(var(--default-grid-baseline) * 2);
 }
-    :deep(.text-editor__wrapper div.ProseMirror) {
-        padding: 0px 0px 0px 0px
-    }
-    :deep(.editor__content) {
-        max-width: 100% !important
-    }
+
+:deep(.text-editor__wrapper div.ProseMirror) {
+	padding: 0px 0px 0px 0px
+}
+
+:deep(.editor__content) {
+	max-width: 100% !important
+}
 </style>


### PR DESCRIPTION
Closes #308 

Before: 
![image](https://github.com/nextcloud/tables/assets/46924014/2c6d6358-6b03-47e3-935d-d93d7fee76c6)

After:
![image](https://github.com/nextcloud/tables/assets/46924014/826842f8-09bd-46c3-940f-e32a5fa1b45a)

Removes the unecessary padding in the rich text cell.