### PR TITLE
fix(EditorMenubar): Renders Rich Editor Menubar behind dropdowns

### DIFF
--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -131,4 +131,10 @@ export default {
 		overflow-y: auto;
 	}
 
+	/* This can be deleted when the patch from text is integrated,
+	that sets the z-index of the text-menubar to 1 by default*/
+	:deep(.text-menubar ) {
+		z-index: 1 !important;
+	}
+
 </style>


### PR DESCRIPTION
Closes #292 

Changes the z-index of the rich editor menubar to render dropdown in front of the menubar

Before:
![image](https://github.com/nextcloud/tables/assets/46924014/10282544-6af1-4a62-9919-12bf97b1974d)

After:
![image](https://github.com/nextcloud/tables/assets/46924014/205a30d6-e201-4874-be34-43091bedae4f)

The high z-index of the rich editor menubar is an artefact from a previous version in text and can now be changed in text as well. Therefore, the patch of the text app is available in tables, this change can be reverted.
