### PR TITLE
fix: empty view configuration-object on table change

### DIFF
--- a/src/pages/DefaultMainView.vue
+++ b/src/pages/DefaultMainView.vue
@@ -124,6 +124,9 @@ export default {
 
 			if (this.activeTable.id !== this.lastActiveTableId) {
 				this.localLoading = true
+
+				await this.$store.dispatch('resetView')
+
 				await this.$store.dispatch('loadColumnsFromBE', { tableId: this.activeTable.id })
 
 				if (this.canReadTable(this.activeTable)) {

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -86,6 +86,10 @@ export default {
 			commit('setView', view)
 		},
 
+		resetView({ commit }) {
+			commit('setView', {})
+		},
+
 		// COLUMNS
 		async loadColumnsFromBE({ commit }, { tableId }) {
 			commit('setLoading', true)


### PR DESCRIPTION
- if not, the new active table gets the "old" view settings

closes #320 