### PR TITLE
Fix : Translation call on start page

### DIFF
--- a/src/pages/Startpage.vue
+++ b/src/pages/Startpage.vue
@@ -6,8 +6,8 @@
 				<IconTables />
 			</template>
 			<template #action>
-				<NcButton :aria-label="t('table', 'Create new table')" type="primary" @click="addTable">
-					{{ t('table', 'Create new table') }}
+				<NcButton :aria-label="t('tables', 'Create new table')" type="primary" @click="addTable">
+					{{ t('tables', 'Create new table') }}
 				</NcButton>
 			</template>
 		</NcEmptyContent>


### PR DESCRIPTION
Call "tables" resource (Transifex) instead of "table" in order to fix : 
![2023-05-29_16-04](https://github.com/nextcloud/tables/assets/33763786/207f02ce-01d0-46be-8e48-dfb66bdf54e5)
