### PR TITLE
Fix : Translation of table column creation button's label

### DIFF
--- a/src/modules/main/sections/EmptyTable.vue
+++ b/src/modules/main/sections/EmptyTable.vue
@@ -6,7 +6,7 @@
 		</template>
 		<template #action>
 			<NcButton :aria-label="t('table', 'Create column')" type="primary" @click="$emit('create-column')">
-				{{ t('table', 'Create column') }}
+				{{ t('tables', 'Create column') }}
 			</NcButton>
 		</template>
 	</NcEmptyContent>


### PR DESCRIPTION
Call "tables" resource (Transifex) instead of "table" in order to fix :
![2023-05-29_16-25](https://github.com/nextcloud/tables/assets/33763786/cc34aa84-36e0-4c01-8e55-e1c8ac9338e5)