### PR TITLE
feat(scrolling): Sticky table header and horizontal scrolling bar

### DIFF
--- a/src/modules/main/sections/TableDescription.vue
+++ b/src/modules/main/sections/TableDescription.vue
@@ -56,9 +56,6 @@ export default {
 }
 
 .row.first-row {
-	position: sticky;
-	left: 0;
-	top: 0;
 	z-index: 15;
 	background-color: var(--color-main-background-translucent);
 	align-items: baseline;

--- a/src/pages/DefaultMainView.vue
+++ b/src/pages/DefaultMainView.vue
@@ -1,8 +1,8 @@
 <template>
-	<div>
+	<div style="height:100%">
 		<div v-if="isLoading" class="icon-loading" />
 
-		<div v-if="!isLoading && activeTable">
+		<div v-if="!isLoading && activeTable" class="table-page-view">
 			<TableDescription />
 
 			<div class="table-wrapper">
@@ -142,3 +142,15 @@ export default {
 	},
 }
 </script>
+
+<style>
+.table-page-view {
+	display: flex;
+	flex-flow: column;
+	height: 100%;
+}
+
+.table-wrapper {
+	overflow: hidden;
+}
+</style>

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -39,7 +39,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 -->
 
 <template>
-	<div class="NcTable">
+	<div class="NcTable nctable-wrapper">
 		<div class="options row" style="padding-right: calc(var(--default-grid-baseline) * 2);">
 			<Options :rows="rows"
 				:columns="columns"
@@ -53,7 +53,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				@set-search-string="str => $emit('set-search-string', str)"
 				@delete-selected-rows="rowIds => $emit('delete-selected-rows', rowIds)" />
 		</div>
-		<div class="custom-table row">
+		<div class="custom-table row scrollable-view">
 			<CustomTable v-if="canReadTable(table)"
 				:columns="columns"
 				:rows="rows"
@@ -145,12 +145,20 @@ export default {
 <style scoped lang="scss">
 
 .options.row {
-	position: sticky;
-	top: 52px;
-	left: 0;
 	z-index: 15;
 	background-color: var(--color-main-background-translucent);
 	padding-top: 4px; // fix to show buttons completely
 	padding-bottom: 4px; // to make it nice with the padding-top
 }
+
+.nctable-wrapper {
+	display: flex;
+	flex-flow: column;
+	height: 100%;
+}
+
+.scrollable-view {
+	overflow: auto;
+}
+
 </style>

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -296,11 +296,6 @@ export default {
 
 <style lang="scss" scoped>
 
-.container {
-	//margin: auto;
-	overflow-x: auto;
-}
-
 :deep(table) {
 	position: relative;
 	border-collapse: collapse;
@@ -338,18 +333,15 @@ export default {
 
 	thead tr {
 		// text-align: left;
+		position: sticky;
+		top: 0;
+		z-index: 6;
 
 		th {
 			vertical-align: middle;
 			color: var(--color-text-maxcontrast);
-
-			// sticky head
-			// position: -webkit-sticky;
-			// position: sticky;
-			// top: 80px;
 			box-shadow: inset 0 -1px 0 var(--color-border); // use box-shadow instead of border to be compatible with sticky heads
 			background-color: var(--color-main-background-translucent);
-			z-index: 5;
 
 			// always fit to title
 			// min-width: max-content;


### PR DESCRIPTION
Closes #109

The table header is now sticky and does not disappear while scrolling in large tables.
Also the horizontal scrolling bar is now constantly visible and not only at the button of the page.

@datenangebot When scrolling up, the table options do not scroll a few pixels till they get sticky anymore but are directly fixed. Is this okay?


Tested on Chrome, Edge, Opera and Firefox.