### PR TITLE
fix(UI): add wrap to column type selection bar

### DIFF
--- a/src/modules/main/modals/CreateColumn.vue
+++ b/src/modules/main/modals/CreateColumn.vue
@@ -337,6 +337,7 @@ export default {
 
 .typeSelections {
 	display: inline-flex;
+	flex-wrap: wrap;
 }
 
 .typeSelections span {


### PR DESCRIPTION
| before | after |
| ------ | ----- |
| <img width="744" alt="SCR-20230608-kojk" src="https://github.com/nextcloud/tables/assets/55329475/a72a2430-570e-474a-85f4-7947aa0f86df"> | <img width="745" alt="SCR-20230608-kpqi" src="https://github.com/nextcloud/tables/assets/55329475/f62faee0-eece-40f4-9cc9-0929c6f35d1f"> |
