### PR TITLE
fix(table filtering): filter also for empty cell values

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionCheckMixin.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionCheckMixin.js
@@ -11,16 +11,14 @@ export default {
 				return (valueA - valueB) * factor
 			}
 		},
-		isFilterFoundForSelectionCheck(column, cell, filter) {
-			const yesPossibilities = ['yes', 'true', 'check', 'checked', 'y']
-			const noPossibilities = ['no', 'false', 'unchecked', 'uncheck', 'n']
-			const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-			if (filter.operator === 'is-equal' && cell.value === 'true' && yesPossibilities.findIndex(item => item === filterValue) !== -1) {
+		isFilterFoundForSelectionCheck(column, cell, filter) {
+			const filterValue = '' + filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+			if (filter.operator === 'is-equal' && cell?.value === 'true' && filterValue === 'yes') {
 				cell.filterFound = true
 				return true
 			}
-			if (filter.operator === 'is-equal' && cell.value === 'false' && noPossibilities.findIndex(item => item === filterValue) !== -1) {
+			if (filter.operator === 'is-equal' && cell?.value !== 'true' && filterValue === 'no') {
 				cell.filterFound = true
 				return true
 			}

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -157,16 +157,18 @@ export default {
 					const filters = this.getFiltersForColumn(column)
 					const cell = row.data.find(item => item.columnId === column.id)
 
+					// if we should filter
+					if (filters !== null) {
+						filters.forEach(fil => {
+							this.addMagicFieldsValues(fil)
+							if (filterStatus === null || filterStatus === true) {
+								filterStatus = this.isFilterFound(column, cell || {}, fil)
+							}
+						})
+					}
+
 					// if we don't have a value for this cell
 					if (cell === undefined) {
-
-						// if we have a filter for this column, but the cell is null/undefined, we only can have a match if the filter filters empty cells
-						if (filters !== null) {
-							filterStatus = filters.some(fil => fil.operator === 'is-empty')
-							if (debug && !filterStatus) {
-								console.debug('set row status to false (hard), cell is empty', { filters })
-							}
-						}
 						if (searchString) {
 							searchStatus = false
 						}
@@ -175,25 +177,15 @@ export default {
 						delete cell.searchStringFound
 						delete cell.filterFound
 
-						// if we should filter
-						if (filters !== null) {
-							filters.forEach(fil => {
-								this.addMagicFieldsValues(fil)
-								if (filterStatus === null || filterStatus === true) {
-									filterStatus = this.isFilterFound(column, cell, fil)
-								}
-								// filterStatus = filterStatus || this.isFilterFound(column, cell, fil)
-							})
-						}
 						// if we should search
 						if (searchString) {
 							console.debug('look for searchString', searchString)
 							searchStatus = this.isSearchStringFound(column, cell, searchString)
 						}
+					}
 
-						if (debug) {
-							console.debug('filterStatus for cell', { cell: cell.value, filterStatusCell: filterStatus, filterStatusRowBefore: filterStatusRow })
-						}
+					if (debug) {
+						console.debug('filterStatus for cell', { cell: cell?.value, filterStatusCell: filterStatus, filterStatusRowBefore: filterStatusRow })
 					}
 
 					// if filterStatus is null, this result should be ignored


### PR DESCRIPTION
closes #300 

you can now filter for values that does not exists. Example: filter for selection-check column type (radio button, yes/no)

| Starting point |
| --- |
| <img width="426" alt="SCR-20230608-ksef" src="https://github.com/nextcloud/tables/assets/55329475/7f444162-185e-4fe7-a42c-94b7055d1024"> |


| before | after |
| --- | --- |
| <img width="455" alt="SCR-20230608-kshr" src="https://github.com/nextcloud/tables/assets/55329475/69de7326-7702-4106-9e80-0288a52f07d9"> | <img width="455" alt="SCR-20230608-ksqc" src="https://github.com/nextcloud/tables/assets/55329475/7e57322c-b84e-422d-8083-fff32bbcb731"> |