### PR TITLE
enh(commands): occ cleanup row data sets

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -51,6 +51,7 @@ Have a good time and manage whatever you want.
 		<command>OCA\Tables\Command\RemoveTable</command>
 		<command>OCA\Tables\Command\RenameTable</command>
 		<command>OCA\Tables\Command\ChangeOwnershipTable</command>
+		<command>OCA\Tables\Command\Clean</command>
     </commands>
     <navigations>
         <navigation>

--- a/lib/Command/Clean.php
+++ b/lib/Command/Clean.php
@@ -110,6 +110,7 @@ class Clean extends Command {
 			$this->offset = $this->row->getId();
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->print('Error while fetching row', self::PRINT_LEVEL_ERROR);
+			$this->logger->error('Following error occurred during executing occ command "'.self::class.'"', ['exception' => $e]);
 		} catch (DoesNotExistException $e) {
 			$this->print("");
 			$this->print("No more rows found.", self::PRINT_LEVEL_INFO);
@@ -153,6 +154,7 @@ class Clean extends Command {
 				}
 			} catch (InternalError $e) {
 				$this->print("😱️ internal error while looking for column", self::PRINT_LEVEL_ERROR);
+				$this->logger->error('Following error occurred during executing occ command "'.self::class.'"', ['exception' => $e]);
 			} catch (NotFoundError $e) {
 				if($this->output->isVerbose()) {
 					$this->print("corresponding column not found.", self::PRINT_LEVEL_ERROR);
@@ -163,6 +165,7 @@ class Clean extends Command {
 				$this->deleteDataFromRow($date->columnId);
 			} catch (PermissionError $e) {
 				$this->print("😱️ permission error while looking for column", self::PRINT_LEVEL_ERROR);
+				$this->logger->error('Following error occurred during executing occ command "'.self::class.'"', ['exception' => $e]);
 			}
 		}
 	}
@@ -191,6 +194,7 @@ class Clean extends Command {
 			$this->print("Row successfully updated", self::PRINT_LEVEL_SUCCESS);
 		} catch (Exception $e) {
 			$this->print("Error while updating row to db.", self::PRINT_LEVEL_ERROR);
+			$this->logger->error('Following error occurred during executing occ command "'.self::class.'"', ['exception' => $e]);
 		}
 	}
 

--- a/lib/Db/Row.php
+++ b/lib/Db/Row.php
@@ -8,6 +8,7 @@ use OCP\AppFramework\Db\Entity;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
+ * @method getTableId()
  */
 class Row extends Entity implements JsonSerializable {
 	protected ?int $tableId = null;

--- a/lib/Db/RowMapper.php
+++ b/lib/Db/RowMapper.php
@@ -57,6 +57,22 @@ class RowMapper extends QBMapper {
 	}
 
 	/**
+	 * @throws MultipleObjectsReturnedException
+	 * @throws DoesNotExistException
+	 * @throws Exception
+	 */
+	public function findNext(int $offsetId = -1): Row {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->table)
+			->where($qb->expr()->gt('id', $qb->createNamedParameter($offsetId)))
+			->setMaxResults(1)
+			->orderBy('id', 'ASC');
+
+		return $this->findEntity($qb);
+	}
+
+	/**
 	 * @return int affected rows
 	 * @throws Exception
 	 */

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -60,13 +60,13 @@ class ColumnService extends SuperService {
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	public function find(int $id): Column {
+	public function find(int $id, string $userId = null): Column {
 		try {
 			$column = $this->mapper->find($id);
 
 			// security
 			/** @noinspection PhpUndefinedMethodInspection */
-			if (!$this->permissionsService->canReadColumnsByTableId($column->getTableId())) {
+			if (!$this->permissionsService->canReadColumnsByTableId($column->getTableId(), $userId)) {
 				throw new PermissionError('PermissionError: can not read column with id '.$id);
 			}
 


### PR DESCRIPTION
- add occ command to clean up data sets from rows at db level

closes #200 

It might happen (route cause analysis runs in parallel) that the rows hold data from columns that are already deleted.
With this command is it possible to clean up the rows data. Use `occ tables:clean -d` for a dry run and `occ tables:clean -e` to print out only the errors.

## How to test
### Setup tables and open the web ui to create the tutorial table.

### Run `occ tables:clean`, should be all "green"
![SCR-20230612-ishe](https://github.com/nextcloud/tables/assets/55329475/b94a7540-009c-4530-90e1-68a56091bd77)

### Manipulate the db
- delete the column from `oc_tables_columns` with the id 1 (or whatever).

### Run `occ tables:clean -d`, should look like this
 
![SCR-20230612-iska](https://github.com/nextcloud/tables/assets/55329475/fa57be34-910c-48ea-a79c-e4c079e246fc)

### Run `occ tables:clean`, to clean up the data

![SCR-20230612-ismg](https://github.com/nextcloud/tables/assets/55329475/975a9ff7-085a-4093-a0d1-59cc77d1046d)

### Run `occ tables:clean -d` again, should be good again

![SCR-20230612-isnw](https://github.com/nextcloud/tables/assets/55329475/8bf2ea37-3a73-4e17-95de-651a428dff15)

