### PR TITLE
Update TableService.php

### DIFF
--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -93,7 +93,7 @@ class TableService extends SuperService {
 						}
 					}
 					if (!$found) {
-						$newSharedTables[] = $sharedTable;
+						$ownTables[] = $sharedTable;
 					}
 				}
 			}
@@ -105,16 +105,14 @@ class TableService extends SuperService {
 		}
 
 		// enhance table objects with additional data
-		$allTables = array_merge($ownTables, $newSharedTables);
 		if (!$skipTableEnhancement) {
-			foreach ($allTables as $table) {
+			foreach ($ownTables as $table) {
 				/** @var string $userId */
 				$this->enhanceTable($table, $userId);
 			}
 		}
 
-
-		return $allTables;
+		return $ownTables;
 	}
 
 	/**


### PR DESCRIPTION
fixes #438

check if sharetable is already in owntables and add to this array. by this, the total list is evaluated every time and double-shares are recognized

befor the fix every result of sharetable was only checked against owntables, but not against other sharetables.
by adding them one by one to the main array, the check is performed in all directions