### PR TITLE
Avoid error on CORS requests

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -27,7 +27,7 @@ class Api1Controller extends ApiController {
 
 	private V1Api $v1Api;
 
-	private string $userId;
+	private ?string $userId;
 
 	protected LoggerInterface $logger;
 

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -45,7 +45,7 @@ class Api1Controller extends ApiController {
 		ViewMapper $viewMapper,
 		V1Api $v1Api,
 		LoggerInterface $logger,
-		string $userId
+		?string $userId
 	) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->tableService = $service;
@@ -55,7 +55,7 @@ class Api1Controller extends ApiController {
 		$this->importService = $importService;
 		$this->viewService = $viewService;
 		$this->viewMapper = $viewMapper;
-		$this->userId = $userId;
+		$this->userId = $userId ?? '';
 		$this->v1Api = $v1Api;
 		$this->logger = $logger;
 	}

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -55,7 +55,7 @@ class Api1Controller extends ApiController {
 		$this->importService = $importService;
 		$this->viewService = $viewService;
 		$this->viewMapper = $viewMapper;
-		$this->userId = $userId ?? '';
+		$this->userId = $userId;
 		$this->v1Api = $v1Api;
 		$this->logger = $logger;
 	}


### PR DESCRIPTION
Made constructor parameter $userId of type `?string` (= be optional)
If no userId is passed (aka. is null),
$this->userId is set to an empty string to not cause any problems or errors.

See #465 for more info