### PR TITLE
fix: No need to show toast messages on success

### DIFF
--- a/cypress/e2e/tables-share.cy.js
+++ b/cypress/e2e/tables-share.cy.js
@@ -32,7 +32,6 @@ describe('Manage a table', () => {
 		cy.get('.sharing input').type(localUser2.userId)
 		cy.wait(1000).get('.sharing input').type('{enter}')
 
-		cy.wait(10).get('.toastify.toast-success').should('be.visible')
 		cy.get('h3').contains('Shares').parent().find('ul').contains(localUser2.userId).should('exist')
 	})
 

--- a/src/modules/sidebar/mixins/shareAPI.js
+++ b/src/modules/sidebar/mixins/shareAPI.js
@@ -1,6 +1,5 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { showSuccess } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/dist/index.css'
 import displayError from '../../../shared/utils/displayError.js'
 
@@ -37,8 +36,7 @@ export default {
 				permissionManage: false,
 			}
 			try {
-				const res = await axios.post(generateUrl('/apps/tables/share'), data)
-				showSuccess(t('tables', 'Saved new share with "{userName}".', { userName: res.data.receiverDisplayName }))
+				await axios.post(generateUrl('/apps/tables/share'), data)
 			} catch (e) {
 				displayError(e, t('tables', 'Could not create share.'))
 				return false
@@ -50,7 +48,6 @@ export default {
 		async removeShareFromBE(shareId) {
 			try {
 				await axios.delete(generateUrl('/apps/tables/share/' + shareId))
-				showSuccess(t('tables', 'Share was deleted'))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not remove share.'))
 			}
@@ -59,7 +56,6 @@ export default {
 		async updateShareToBE(shareId, data) {
 			try {
 				await axios.put(generateUrl('/apps/tables/share/' + shareId + '/permission'), data)
-				showSuccess(t('tables', 'Share permission was updated'))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not update share.'))
 			}


### PR DESCRIPTION
As requested by @jancborchardt 

The checkbox indicating the value is enough and we should only show a toast in an error case.

Fix https://github.com/nextcloud/tables/issues/468