### PR TITLE
fix: Select tile on enter

### DIFF
--- a/src/shared/components/NcTile/NcTile.vue
+++ b/src/shared/components/NcTile/NcTile.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :tabindex="tabbable ? 0 : null" class="tile" :class="{active: localeActive}" @click="$emit('set-template')">
+	<div :tabindex="tabbable ? 0 : null" class="tile" :class="{active: localeActive}" @click="$emit('set-template')" @keyup.enter="$emit('set-template')">
 		<h3>{{ title }}</h3>
 		<p>{{ body }}</p>
 	</div>


### PR DESCRIPTION
Follow up fix to close #248 

Tab navigation was possible but selecting a template using enter not