### PR TITLE
fix: Make sure to have a local value before initializing the editor

### DIFF
--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -79,8 +79,8 @@ export default {
 	},
 
 	async mounted() {
-		await this.setupEditor()
 		this.localValue = this.text
+		await this.setupEditor()
 		this.editor.setContent(this.localValue, false)
 	},
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/tables/issues/499

Otherwise the editor will be initialized with an empty string and would overwrite the local value due to an initial onUpdate call