### PR TITLE
chore(dependencies): Exclude vue-router 4.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,10 @@
 			"allowedVersions": "<4"
 		},
 		{
+			"matchPackageNames": ["vue-router"],
+			"allowedVersions": "<4"
+		},
+		{
 			"matchPackageNames": ["@vue/test-utils"],
 			"allowedVersions": "<2"
 		}


### PR DESCRIPTION
As we are not using vue 3 for now, we can ignore this major