### PR TITLE
fix(design): don't hide last column in ncTable used in widgets

### DIFF
--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -370,7 +370,7 @@ export default {
 		padding-right: 16px;
 	}
 
-	tr>td:last-child {
+	tr>td.sticky:last-child {
 		// visibility: hidden;
 		opacity: 0;
 	}


### PR DESCRIPTION
- this is needed because in widgets we don't have the edit-option as last column

closes #542 