### PR TITLE
fix(FE): parse values to ensure we have integer values

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/selection.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selection.js
@@ -28,10 +28,10 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 	sort(mode) {
 		const factor = mode === 'DESC' ? -1 : 1
 		return (rowA, rowB) => {
-			const selectionIdA = rowA.data.find(item => item.columnId === this.id)?.value ?? null
+			const selectionIdA = parseInt(rowA.data.find(item => item.columnId === this.id)?.value ?? null)
 			const vA = selectionIdA !== null ? this.selectionOptions.find(item => item.id === selectionIdA)?.label : ''
 			const valueA = this.removeEmoji(vA).trim()
-			const selectionIdB = rowB.data.find(item => item.columnId === this.id)?.value ?? null
+			const selectionIdB = parseInt(rowB.data.find(item => item.columnId === this.id)?.value ?? null)
 			const vB = selectionIdB !== null ? this.selectionOptions.find(item => item.id === selectionIdB)?.label : ''
 			const valueB = this.removeEmoji(vB).trim()
 			return ((valueA < valueB) ? -1 : (valueA > valueB) ? 1 : 0) * factor


### PR DESCRIPTION
- seems that in some older version we stored the ids as strings

closes #553 

Assuming we have some values as strings
<img width="707" alt="SCR-20230913-okup" src="https://github.com/nextcloud/tables/assets/55329475/f96ba442-0976-482b-9dba-d94a77502447">


Before
<img width="298" alt="SCR-20230913-oipp" src="https://github.com/nextcloud/tables/assets/55329475/f0053d9d-a0bb-4e44-bbf0-837567f11a94">

After
<img width="298" alt="SCR-20230913-ojye" src="https://github.com/nextcloud/tables/assets/55329475/b97ceee8-85ac-4d61-a54d-b9952f921374">
