### PR TITLE
fix(design): show edit column actions if shared as table manager

### DIFF
--- a/src/shared/components/ncTable/mixins/permissionsMixin.js
+++ b/src/shared/components/ncTable/mixins/permissionsMixin.js
@@ -7,7 +7,7 @@ export default {
 			if (!element.isShared) {
 				return true
 			}
-			if ((element.isShared && element?.onSharePermissions?.manageTable) || element?.ownership === getCurrentUser().uid) {
+			if ((element.isShared && element?.onSharePermissions?.manage) || element?.ownership === getCurrentUser().uid) {
 				return true
 			}
 			return false


### PR DESCRIPTION
- wrong identifier to ask for permissions

closes #557 

![SCR-20230914-lvyv](https://github.com/nextcloud/tables/assets/55329475/936281f5-92f1-4495-9fb9-fafb174699e9)
