### PR TITLE
refactor(design): redesign the filter form 

### DIFF
--- a/src/modules/main/partials/ColumnFormComponent.vue
+++ b/src/modules/main/partials/ColumnFormComponent.vue
@@ -75,7 +75,7 @@ export default {
 				group
 					.toUpperCase()
 					.replace('_', '')
-					.replace('-', '')
+					.replace('-', ''),
 			)
 			return str.charAt(0).toUpperCase() + str.slice(1)
 		},

--- a/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
+++ b/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
@@ -1,18 +1,22 @@
 <template>
-	<div class="filter-entry">
-		<div class="selection-fields">
+	<div class="row">
+		<div class="fix-col-2">
 			<NcSelect
 				v-model="selectedColumn"
 				class="select-field"
 				:options="columns"
 				label="title"
 				:placeholder="t('tables', 'Column')" />
+		</div>
+		<div class="fix-col-2">
 			<NcSelect
 				v-if="selectedColumn"
 				v-model="selectedOperator"
 				class="select-field"
 				:options="operators"
 				:placeholder="t('tables', 'Operator')" />
+		</div>
+		<div class="fix-col-2">
 			<NcSelect
 				v-if="selectedOperator && !selectedOperator.noSearchValue"
 				v-model="searchValue"
@@ -21,16 +25,18 @@
 				:placeholder="getValuePlaceholder"
 				@search="v => term = v" />
 		</div>
-		<NcButton
-			:close-after-click="true"
-			type="tertiary"
-			class="delete-button"
-			:aria-label="t('tables', 'Delete filter')"
-			@click="$emit('delete-filter')">
-			<template #icon>
-				<Delete :size="25" />
-			</template>
-		</NcButton>
+		<div class="fix-col-2 actions">
+			<NcButton
+				:close-after-click="true"
+				type="tertiary"
+				class="delete-button"
+				:aria-label="t('tables', 'Delete filter')"
+				@click="$emit('delete-filter')">
+				<template #icon>
+					<Delete :size="25" />
+				</template>
+			</NcButton>
+		</div>
 	</div>
 </template>
 
@@ -169,25 +175,32 @@ export default {
 }
 </script>
 
-<style>
-.filter-entry {
-	display: flex;
-	justify-content: space-between;
-}
+<style lang="scss" scoped>
 
-.select-field {
-	width: 30%;
-	padding: calc(var(--default-grid-baseline) * 2);
-	min-width: auto !important;
-}
+	.row {
+		margin-bottom: calc(var(--default-grid-baseline) * 4);
+		margin-top: var(--default-grid-baseline);
+		background-color: var(--color-primary-element-light);
+		border-radius: var(--border-radius-large);
+	}
 
-.selection-fields {
-	flex: 1;
-	display: flex;
-}
+	.row .fix-col-2 > div {
+		width: 100%;
+		padding: calc(var(--default-grid-baseline) * 2);
+	}
 
-.delete-button {
-	margin-left: auto;
-}
+	.row .fix-col-2 {
+		height: 63.32px;
+	}
+
+	.row .fix-col-2.actions {
+		align-items: center;
+	}
+
+	.actions button {
+		margin-right: calc(var(--default-grid-baseline) * 2);
+		margin-left: auto;
+		height: 44px;
+	}
 
 </style>

--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -213,7 +213,7 @@ export default {
 				group
 					.toUpperCase()
 					.replace('_', '')
-					.replace('-', '')
+					.replace('-', ''),
 			)
 			return str.charAt(0).toUpperCase() + str.slice(1)
 		},

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -140,7 +140,7 @@ export default {
 				group
 					.toUpperCase()
 					.replace('_', '')
-					.replace('-', '')
+					.replace('-', ''),
 			)
 			return str.charAt(0).toUpperCase() + str.slice(1)
 		},

--- a/src/modules/modals/Import.vue
+++ b/src/modules/modals/Import.vue
@@ -285,7 +285,7 @@ export default {
 				true, // modal
 				FilePickerType.Choose, // type
 				false, // directories
-				this.path // path
+				this.path, // path
 			)
 
 			filePicker.pick().then((file) => {

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/TextLinkForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/TextLinkForm.vue
@@ -123,7 +123,7 @@ export default {
 						id: item.id,
 						label: item.name,
 						active: this.isActive(item.id),
-					}
+					},
 				)
 			})
 			this.providers.sort((a, b) => {


### PR DESCRIPTION
- use grid layout
- split fields into 2 lines
- add background and spaces to separate different filters by design

closes #611 

| Before | After |
| --- | --- |
| <img width="576" alt="SCR-20231102-jcsx" src="https://github.com/nextcloud/tables/assets/55329475/518ff670-c93b-49d2-b62e-e32656788051"> | <img width="575" alt="SCR-20231102-izzo" src="https://github.com/nextcloud/tables/assets/55329475/fdd8a194-500d-4818-9626-57fba2a63807"> |
