### PR TITLE
fix: Update browser page title depending on current view/table

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ export default {
 	data() {
 		return {
 			loading: false,
+			defaultPageTitle: false,
 		}
 	},
 	computed: {
@@ -60,9 +61,28 @@ export default {
 			}
 			if (currentRoute.path.startsWith('/table/')) {
 				this.$store.commit('setActiveTableId', parseInt(currentRoute.params.tableId))
+				this.setPageTitle(this.$store.getters.activeTable.title)
 			} else if (currentRoute.path.startsWith('/view/')) {
 				this.$store.commit('setActiveViewId', parseInt(currentRoute.params.viewId))
+				this.setPageTitle(this.$store.getters.activeView.title)
 			}
+		},
+		setPageTitle(title) {
+			if (this.defaultPageTitle === false) {
+				const appTitle = t('tables', 'Tables')
+				this.defaultPageTitle = window.document.title
+				if (this.defaultPageTitle.indexOf(` - ${appTitle} - `) !== -1) {
+					this.defaultPageTitle = this.defaultPageTitle.substring(this.defaultPageTitle.indexOf(` - ${appTitle} - `) + 3)
+				}
+				if (this.defaultPageTitle.indexOf(`${appTitle} - `) !== 0) {
+					this.defaultPageTitle = `${appTitle} - ` + this.defaultPageTitle
+				}
+			}
+			let newTitle = this.defaultPageTitle
+			if (title !== '') {
+				newTitle = `${title} - ${newTitle}`
+			}
+			window.document.title = newTitle
 		},
 	},
 }


### PR DESCRIPTION
Make sure to update the browser window title with the current table or view title.

<img width="212" alt="Screenshot 2023-11-10 at 13 11 00" src="https://github.com/nextcloud/tables/assets/3404133/e0cb5456-44b3-48ce-8035-b869b6544ba7">
<img width="214" alt="Screenshot 2023-11-10 at 13 10 36" src="https://github.com/nextcloud/tables/assets/3404133/df2d6674-a651-4668-a5b2-9db0a36753e1">


Code is a shamless copy from deck ;)