### PR TITLE
fix typo

### DIFF
--- a/APIv1.yaml
+++ b/APIv1.yaml
@@ -416,7 +416,7 @@ paths:
                 '404':
                     description: Not found
 
-    /column/{columnId}:
+    /columns/{columnId}:
         get:
             summary: Get a column
             description: Shipped with v0.4.0.


### PR DESCRIPTION
fix only for stable0.6, API docs gets replaced by the AAPI-extractor on main, shipped with 0.7

closes #383 