### PR TITLE
feat: Use simple input field instead of multiselect for plain URLs

### DIFF
--- a/cypress/e2e/column-text-link.cy.js
+++ b/cypress/e2e/column-text-link.cy.js
@@ -37,8 +37,7 @@ describe('Test column text-link', () => {
 
 		cy.loadTable('Test text-link')
 		cy.get('.NcTable').contains('Create row').click({ force: true })
-		cy.get('.modal__content .slot input').first().type('https://nextcloud.com').tick(500)
-		cy.get('.icon-label-container .labels').contains('https://nextcloud.com').click()
+		cy.get('.modal__content .slot input').first().type('https://nextcloud.com')
 
 		cy.intercept({ method: 'GET', url: '**/search/providers/files/*' }).as('filesResults')
 		cy.get('.modal__content .slot input').eq(1).type('pdf').tick(500)
@@ -58,8 +57,7 @@ describe('Test column text-link', () => {
 		cy.loadTable('Test text-link')
 		cy.get('.NcTable tr td button').click({ force: true })
 
-		cy.get('.modal__content .slot input').first().clear().type('https://github.com').tick(500)
-		cy.get('[data-cy*="github"]').click()
+		cy.get('.modal__content .slot input').first().clear().type('https://github.com')
 
 		cy.get('.modal__content .slot input').eq(1).type('photo-test').tick(500)
 		cy.get('[data-cy*="photo-test"]').first().click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -156,7 +156,9 @@ Cypress.Commands.add('createTextLinkColumn', (title, ressourceProvider, isFirstC
 	cy.get('.typeSelection span').contains('Url', { matchCase: false }).click()
 	cy.get('.typeSelection span').contains('Files').click()
 	// TODO is the contacts search provider deactivated by default beginning with nc28
-	// cy.get('.typeSelection span label').contains('Contacts').click()
+	if (['stable27'].includes(Cypress.env('ncVersion'))) {
+		cy.get('.typeSelection span').contains('Contacts').click()
+	}
 
 	ressourceProvider.forEach(provider =>
 		cy.get('.typeSelection span').contains(provider, { matchCase: false }).click(),

--- a/src/modules/sidebar/sections/SidebarIntegration.vue
+++ b/src/modules/sidebar/sections/SidebarIntegration.vue
@@ -48,9 +48,10 @@
 import { mapGetters, mapState } from 'vuex'
 import { generateUrl } from '@nextcloud/router'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
+import copyToClipboard from '../../../shared/mixins/copyToClipboard.js'
+
 import NcInputField from '@nextcloud/vue/dist/Components/NcInputField.js'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import { showError, showSuccess } from '@nextcloud/dialogs'
 
 export default {
 	components: {
@@ -58,7 +59,7 @@ export default {
 		ContentCopy,
 	},
 
-	mixins: [permissionsMixin],
+	mixins: [permissionsMixin, copyToClipboard],
 
 	data() {
 		return {
@@ -80,22 +81,7 @@ export default {
 	},
 	 methods: {
 		copyUrl() {
-			if (navigator?.clipboard) {
-				navigator.clipboard.writeText(this.apiEndpointUrl).then(function() {
-					showSuccess(t('files', 'Integration URL copied to clipboard'))
-				}, function(err) {
-					showError(t('files', 'Clipboard is not available'))
-					console.error('Async: Could not copy text: ', err)
-				})
-			} else {
-				try {
-					document.querySelector('input#urlTextField').select()
-					document.execCommand('copy')
-					showSuccess(t('files', 'Integration URL copied to clipboard'))
-				} catch (e) {
-					showError(t('files', 'Clipboard is not available'))
-				}
-			}
+			this.copyToClipboard(this.apiEndpointUrl, false)
 		},
 	 },
 }

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextLinkForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextLinkForm.vue
@@ -196,7 +196,9 @@ export default {
 			this.removeResultsByProviderId(providerId)
 
 			if (providerId === 'url') {
-				this.addUrlResult(term)
+				if (this.isValidUrl(term)) {
+					this.addUrlResult(term)
+				}
 				this.setProviderLoading(providerId, false)
 				return
 			}
@@ -225,6 +227,14 @@ export default {
 			}
 			this.results = this.results.concat(res.data?.ocs?.data?.entries)
 			this.setProviderLoading(providerId, false)
+		},
+
+		isValidUrl(string) {
+			try {
+				return new URL(string)
+			} catch (err) {
+				return false
+			}
 		},
 
 		addUrlResult(term) {

--- a/src/shared/components/ncTable/partials/rowTypePartials/TextLinkForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/TextLinkForm.vue
@@ -23,7 +23,7 @@
 						<LinkWidget :thumbnail-url="props.thumbnailUrl" :icon-url="props.icon" :title="props.title" :subline="props.subline" :icon-size="40" />
 					</template>
 					<template #selected-option="props">
-						<LinkWidget :thumbnail-url="props.thumbnailUrl" :icon-url="props.icon" :title="props.title" :subline="props.subline" :icon-size="40" />
+						<LinkWidget :thumbnail-url="props.thumbnailUrl" :icon-url="props.icon" :title="props.title" :icon-size="24" />
 					</template>
 				</NcSelect>
 				<NcButton type="tertiary" :disabled="!localValue" :title="t('tables', 'Copy link')" @click="copyLink">
@@ -262,10 +262,19 @@ export default {
 	},
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .link-input {
 	display: flex;
 	align-items: center;
-	margin-bottom: var(--default-grid-baseline)
+	margin-bottom: var(--default-grid-baseline);
+
+	:deep(.v-select:not(.vs--open) .vs__search) {
+		position: absolute;
+	}
+
+	:deep(.vs__selected) {
+		flex-grow: 1;
+		height: auto !important;
+	}
 }
 </style>

--- a/src/shared/mixins/copyToClipboard.js
+++ b/src/shared/mixins/copyToClipboard.js
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { showError, showSuccess } from '@nextcloud/dialogs'
+
+export default {
+	methods: {
+		async copyToClipboard(content, silent = true) {
+			try {
+				if (navigator?.clipboard) {
+					await navigator.clipboard.writeText(content)
+				} else {
+					throw new Error('Clipboard is not available')
+				}
+
+				if (!silent) {
+					showSuccess(t('files', 'Copied to clipboard.'))
+				}
+				return true
+			} catch (e) {
+				console.error('Error copying to clipboard', e)
+				if (!silent) {
+					showError(t('files', 'Clipboard is not available'))
+				}
+			}
+		},
+	},
+}


### PR DESCRIPTION
When no link provider (except URL) is enabled a multiselect field might be confusing to users, so this PR switches over to a simple input field in that case. As there are no suggestions then a multiselect does not make sense.

- In addition I added a copy and open link button to make it easier to access the link again (fixes https://github.com/nextcloud/tables/issues/1186)
- Move clipboard logic into a mixin so it can be reused
- Render a link preview in the edit modal

Styling of the multiselect is still a bit odd, but will check that separately as it seems to come from the component library.

[Kapture 2024-08-22 at 15.54.06.webm](https://github.com/user-attachments/assets/ced0c6dd-5f13-4ca1-9a61-ac76ff63eaa4)
