### PR TITLE
enh: show cropped calendar popup

### DIFF
--- a/cypress/e2e/tables-rows.cy.js
+++ b/cypress/e2e/tables-rows.cy.js
@@ -21,7 +21,7 @@ describe('Rows for a table', () => {
 		cy.get('.modal__content .ProseMirror').first().clear()
 		cy.get('.modal__content .ProseMirror').first().type('My first description')
 		cy.get('.modal__content [aria-label="Increase stars"]').click().click()
-		cy.get('.modal-container button').contains('Save').click()
+		cy.get('.modal-container button').contains('Save').click({ force: true })
 
 		cy.get('.modal-container:visible').should('not.exist')
 		cy.get('.custom-table table').contains('My first task').should('exist')
@@ -64,7 +64,7 @@ describe('Rows for a table', () => {
 		cy.get('.modal__content .slot input').first().type('My first task')
 		cy.get('[data-cy="createRowModal"] .notecard--error').should('not.exist')
 		cy.get('[data-cy="createRowSaveButton"]').should('be.enabled')
-		cy.get('[data-cy="createRowSaveButton"]').click()
+		cy.get('[data-cy="createRowSaveButton"]').click({ force: true })
 
 		cy.get('.app-navigation-entry-link').contains('to do list').click({ force: true })
 		cy.get('.custom-table table').contains('My first task').parent().parent().find('[aria-label="Edit row"]').click()

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -142,4 +142,8 @@ export default {
 	padding-right: calc(var(--default-grid-baseline) * 3);
 }
 
+:deep(.modal-container) {
+	overflow: visible !important;
+}
+
 </style>


### PR DESCRIPTION
Calendar was hidden if the modal wasn't long enough. This PR ensures it isn't cropped. 

###  Before
![Screenshot from 2024-02-04 11-45-28](https://github.com/nextcloud/tables/assets/32180937/c703414e-3d8c-40c0-9c26-bd73af058cbd)



### After
![Screenshot from 2024-02-04 11-12-31](https://github.com/nextcloud/tables/assets/32180937/43b834bd-64cd-4530-91df-cf1b6395a26c)
