### PR TITLE
fix: Pass all table columns along as we need them for filtering the rows

### DIFF
--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -65,7 +65,8 @@ class RowService extends SuperService {
 	public function findAllByTable(int $tableId, string $userId, ?int $limit = null, ?int $offset = null): array {
 		try {
 			if ($this->permissionsService->canReadRowsByElementId($tableId, 'table', $userId)) {
-				return $this->row2Mapper->findAll($this->columnMapper->findAllByTable($tableId), $tableId, $limit, $offset, null, null, $userId);
+				$tableColumns = $this->columnMapper->findAllByTable($tableId);
+				return $this->row2Mapper->findAll($tableColumns, $tableColumns, $tableId, $limit, $offset, null, null, $userId);
 			} else {
 				throw new PermissionError('no read access to table id = '.$tableId);
 			}
@@ -91,8 +92,10 @@ class RowService extends SuperService {
 			if ($this->permissionsService->canReadRowsByElementId($viewId, 'view', $userId)) {
 				$view = $this->viewMapper->find($viewId);
 				$columnsArray = $view->getColumnsArray();
-				$columns = $this->columnMapper->findAll($columnsArray);
-				return $this->row2Mapper->findAll($columns, $view->getTableId(), $limit, $offset, $view->getFilterArray(), $view->getSortArray(), $userId);
+				$filterColumns = $this->columnMapper->findAll($columnsArray);
+				$tableColumns = $this->columnMapper->findAllByTable($view->getTableId());
+
+				return $this->row2Mapper->findAll($tableColumns, $filterColumns, $view->getTableId(), $limit, $offset, $view->getFilterArray(), $view->getSortArray(), $userId);
 			} else {
 				throw new PermissionError('no read access to view id = '.$viewId);
 			}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/tables/issues/827

Fix for an internal finding

To reproduce:
- Create a table with a single select and some other fields
- Create a view to filter for the single select but don't include it in the visible columns list
- Load the view

Would be good to cover this case with a test, but pushed to have CI running already to be able to apply a patch as a quick fix