### PR TITLE
fix: properly delete tables with filtered view

### DIFF
--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -370,6 +370,16 @@ class TableService extends SuperService {
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
 		}
 
+		// delete all views for that table
+		// we must delete views before columns because we need columns
+		// while deleting views (in case we're deleting a table that has views)
+		try {
+			$this->viewService->deleteAllByTable($item, $userId);
+		} catch (InternalError|PermissionError $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+		}
+
 		// delete all columns for that table
 		try {
 			$columns = $this->columnService->findAllByTable($id, null, $userId);
@@ -386,13 +396,6 @@ class TableService extends SuperService {
 			}
 		}
 
-		// delete all views for that table
-		try {
-			$this->viewService->deleteAllByTable($item, $userId);
-		} catch (InternalError|PermissionError $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
-		}
 
 		// delete all shares for that table
 		$this->shareService->deleteAllForTable($item);


### PR DESCRIPTION
This fixes an issue with deleting Tables with have filtered Views. 

### To reproduce 
- Create a table
- Create a view with filters
- Try to delete the table

Video showing the problem:
[Screencast from 02-14-2024 12:46:02 PM.webm](https://github.com/nextcloud/tables/assets/32180937/8fbf5596-b8d2-49a5-a592-3ce4dff0deeb)

<details>
<summary>Error traces:</summary>

```
master-nextcloud-1  | {"reqId":"zp3aE2jxl2LhAy6hIRGP","level":3,"time":"2024-02-14T09:06:43+00:00","remoteAddr":"192.168.21.5","user":"admin","app":"index","method":"DELETE","url":"/index.php/apps/tables/table/1","message":"OCA\\Tables\\Db\\Row2Mapper::getFilterExpression(): Argument #2 ($column) must be of type OCA\\Tables\\Db\\Column, null given, called in /var/www/html/apps/tables/lib/Db/Row2Mapper.php on line 280 in file '/var/www/html/apps/tables/lib/Db/Row2Mapper.php' line 304","userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36","version":"29.0.0.5","exception":{"Exception":"Exception","Message":"OCA\\Tables\\Db\\Row2Mapper::getFilterExpression(): Argument #2 ($column) must be of type OCA\\Tables\\Db\\Column, null given, called in /var/www/html/apps/tables/lib/Db/Row2Mapper.php on line 280 in file '/var/www/html/apps/tables/lib/Db/Row2Mapper.php' line 304","Code":0,"Trace":[{"file":"/var/www/html/lib/private/AppFramework/App.php","line":184,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Tables\\Controller\\TableController"],"destroy"]},{"file":"/var/www/html/lib/private/Route/Router.php","line":315,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Tables\\Controller\\TableController","destroy",["OC\\AppFramework\\DependencyInjection\\DIContainer"],["1","tables.table.destroy"]]},{"file":"/var/www/html/lib/base.php","line":1069,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/tables/table/1"]},{"file":"/var/www/html/index.php","line":39,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","Line":170,"Previous":{"Exception":"TypeError","Message":"OCA\\Tables\\Db\\Row2Mapper::getFilterExpression(): Argument #2 ($column) must be of type OCA\\Tables\\Db\\Column, null given, called in /var/www/html/apps/tables/lib/Db/Row2Mapper.php on line 280","Code":0,"Trace":[{"file":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","line":280,"function":"getFilterExpression","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":[["OC\\DB\\QueryBuilder\\QueryBuilder"],null,"contains",""]},{"file":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","line":262,"function":"getFilter","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":[["OC\\DB\\QueryBuilder\\QueryBuilder"],[[2,"contains",""]]]},{"file":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","line":240,"function":"getFilterGroups","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":[["OC\\DB\\QueryBuilder\\QueryBuilder"],[[[2,"contains",""]]]]},{"file":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","line":143,"function":"addFilterToQuery","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":[["OC\\DB\\QueryBuilder\\QueryBuilder"],[[[2,"contains",""]]],"admin"]},{"file":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","line":783,"function":"getWantedRowIds","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":["admin",1,[[[2,"contains",""]]]]},{"file":"/var/www/html/apps/tables/lib/Service/RowService.php","line":516,"function":"countRowsForView","class":"OCA\\Tables\\Db\\Row2Mapper","type":"->","args":[["OCA\\Tables\\Db\\View",1],"admin",[]]},{"file":"/var/www/html/apps/tables/lib/Service/ViewService.php","line":367,"function":"getViewRowsCount","class":"OCA\\Tables\\Service\\RowService","type":"->","args":[["OCA\\Tables\\Db\\View",1],"admin"]},{"file":"/var/www/html/apps/tables/lib/Service/ViewService.php","line":76,"function":"enhanceView","class":"OCA\\Tables\\Service\\ViewService","type":"->","args":[["OCA\\Tables\\Db\\View",1],"admin"]},{"file":"/var/www/html/apps/tables/lib/Service/ViewService.php","line":412,"function":"findAll","class":"OCA\\Tables\\Service\\ViewService","type":"->","args":[["OCA\\Tables\\Db\\Table",1],"admin"]},{"file":"/var/www/html/apps/tables/lib/Service/TableService.php","line":391,"function":"deleteAllByTable","class":"OCA\\Tables\\Service\\ViewService","type":"->","args":[["OCA\\Tables\\Db\\Table",1],"admin"]},{"file":"/var/www/html/apps/tables/lib/Controller/TableController.php","line":66,"function":"delete","class":"OCA\\Tables\\Service\\TableService","type":"->","args":[1]},{"file":"/var/www/html/apps/tables/lib/Controller/Errors.php","line":16,"function":"OCA\\Tables\\Controller\\{closure}","class":"OCA\\Tables\\Controller\\TableController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/var/www/html/apps/tables/lib/Controller/TableController.php","line":67,"function":"handleError","class":"OCA\\Tables\\Controller\\TableController","type":"->","args":[["Closure"]]},{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":232,"function":"destroy","class":"OCA\\Tables\\Controller\\TableController","type":"->","args":[1]},{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":138,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Tables\\Controller\\TableController"],"destroy"]},{"file":"/var/www/html/lib/private/AppFramework/App.php","line":184,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Tables\\Controller\\TableController"],"destroy"]},{"file":"/var/www/html/lib/private/Route/Router.php","line":315,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Tables\\Controller\\TableController","destroy",["OC\\AppFramework\\DependencyInjection\\DIContainer"],["1","tables.table.destroy"]]},{"file":"/var/www/html/lib/base.php","line":1069,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/tables/table/1"]},{"file":"/var/www/html/index.php","line":39,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/html/apps/tables/lib/Db/Row2Mapper.php","Line":304},"message":"OCA\\Tables\\Db\\Row2Mapper::getFilterExpression(): Argument #2 ($column) must be of type OCA\\Tables\\Db\\Column, null given, called in /var/www/html/apps/tables/lib/Db/Row2Mapper.php on line 280 in file '/var/www/html/apps/tables/lib/Db/Row2Mapper.php' line 304","exception":{"xdebug_message":null},"CustomMessage":"OCA\\Tables\\Db\\Row2Mapper::getFilterExpression(): Argument #2 ($column) must be of type OCA\\Tables\\Db\\Column, null given, called in /var/www/html/apps/tables/lib/Db/Row2Mapper.php on line 280 in file '/var/www/html/apps/tables/lib/Db/Row2Mapper.php' line 304"}}
```

</details>
Similar error message as seen at #827

## Todo 
- [ ] cypress test