### PR TITLE
fix: Only skip failing table data loading instead of full failure

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -271,6 +271,9 @@ class Row2Mapper {
 		$filterExpressions = [];
 		foreach ($filterGroup as $filter) {
 			$columnId = $filter['columnId'];
+			if (!isset($this->columns[$columnId]) && !isset($this->allColumns[$columnId])) {
+				throw new InternalError('No column found to build filter with for id ' . $columnId);
+			}
 			$column = $this->columns[$columnId] ?? $this->allColumns[$columnId];
 
 			// if is normal column

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -124,7 +124,6 @@ class TableService extends SuperService {
 					$this->enhanceTable($table, $userId);
 				} catch (InternalError|PermissionError $e) {
 					$this->logger->error($e->getMessage(), ['exception' => $e]);
-					throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
 				}
 				// if the table is shared with me, there are no other shares
 				// will avoid showing the shared icon in the FE nav


### PR DESCRIPTION
@enjeck mentioned that even with https://github.com/nextcloud/tables/pull/842 we could still have cases where the delete failed and we are left in a kind of broken state.

This commit makes sure that we do not throw a type error but a internal one that is logged and handled gracefully and we can just skip the failing table enhancement for listing the table. This way even if a deletion failed on a previous attempt, users can still use tables, list them and delete the orphaned entry with the fix from #842