### PR TITLE
Fix hide user status from owner avatar (issue #829)

### DIFF
--- a/src/modules/main/sections/Dashboard.vue
+++ b/src/modules/main/sections/Dashboard.vue
@@ -47,7 +47,8 @@
 										<NcAvatar
 											:display-name="share.receiverDisplayName"
 											:user="share.receiver"
-											:is-no-user="share.receiverType !== 'user'" />
+											:is-no-user="share.receiverType !== 'user'"
+											:show-user-status="false" />
 									</div>
 								</div>
 							</td>

--- a/src/modules/main/sections/ElementDescription.vue
+++ b/src/modules/main/sections/ElementDescription.vue
@@ -15,7 +15,7 @@
 		<div v-if="!isTable && activeElement.isShared" class="user-bubble">
 			<NcUserBubble
 				:display-name="activeElement.ownerDisplayName"
-				:show-user-status="true"
+				:show-user-status="false"
 				:user="activeElement.ownership" />
 		</div>
 	</div>

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -22,7 +22,7 @@
 			</NcCounterBubble>
 			<NcActionButton v-if="table.hasShares" icon="icon-share" :class="{'margin-right': !(activeTable && table.id === activeTable.id)}" @click="actionShowShare" />
 			<div v-if="table.isShared && table.ownership !== userId" class="margin-left">
-				<NcAvatar :user="table.ownership" />
+				<NcAvatar :user="table.ownership" :show-user-status="false" />
 			</div>
 		</template>
 


### PR DESCRIPTION
Status icon removed from navigation sidebar as illustrated in issue #829 

![image](https://github.com/nextcloud/tables/assets/23369449/2ab6b70b-cd33-40c3-96e8-fabb052c7145)

Also removed from other places which I thought were not needed, such as next to the table title, the share list when sharing the table, and the views dashboard:

![image](https://github.com/nextcloud/tables/assets/23369449/defd1a5d-8b94-492f-bb76-380c957fe1aa)
![image](https://github.com/nextcloud/tables/assets/23369449/9e36b3a9-05f1-44e0-91a7-327df9889672)
![image](https://github.com/nextcloud/tables/assets/23369449/e37bc0f0-63d3-4dab-bbea-dc2300af016a)

If these additional changes are unnecessary or should not have been changed, it can easily be rolled back to only remove the icon from the navigation sidebar as shown in the original issue.
