### PR TITLE
fix: Avoid sql error on postgres

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,21 +27,15 @@ jobs:
       fail-fast: false
       matrix:
         server-versions: ['stable25', 'stable27', 'master']
+        php-versions: ['8.1']
+        databases: ['mysql']
         include:
-          - php-versions: '8.1'
-          - server-versions: 'stable25'
-            databases: 'sqlite'
-          - server-versions: 'stable27'
-            databases: 'mysql'
           - server-versions: 'master'
-            databases: 'sqlite'
-          - server-versions: 'master'
-            databases: 'mysql'
-          - server-versions: 'master'
+            php-versions: '8.3'
             databases: 'pgsql'
           - server-versions: 'master'
             php-versions: '8.3'
-            databases: 'mysql'
+            databases: 'sqlite'
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,6 +112,11 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}/tests/integration
         run: ./run.sh
 
+      - name: Print logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
+
       - name: Query count
         if: ${{ matrix.databases == 'mysql' && matrix.php-versions == '8.2' && matrix.server-versions == 'master' && github.event_name == 'pull_request' }}
         uses: actions/github-script@v6

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -193,7 +193,8 @@ class Row2Mapper {
 		$qbSqlForColumnTypes = null;
 		foreach ($this->columnsHelper->columns as $columnType) {
 			$qbTmp = $this->db->getQueryBuilder();
-			$qbTmp->select('*')
+			$qbTmp->select('row_id', 'column_id', 'last_edit_at', 'last_edit_by')
+				->selectAlias($qb->expr()->castColumn('value', IQueryBuilder::PARAM_STR), 'value')
 				->from('tables_row_cells_'.$columnType)
 				->where($qb->expr()->in('column_id', $qb->createNamedParameter($columnIds, IQueryBuilder::PARAM_INT_ARRAY, ':columnIds')))
 				->andWhere($qb->expr()->in('row_id', $qb->createNamedParameter($rowIds, IQueryBuilder::PARAM_INT_ARRAY, ':rowsIds')));
@@ -208,7 +209,7 @@ class Row2Mapper {
 
 		$qb->select('row_id', 'column_id', 'created_by', 'created_at', 't1.last_edit_by', 't1.last_edit_at', 'value', 'table_id')
 			->from($qb->createFunction($qbSqlForColumnTypes), 't1')
-			->innerJoin('t1', 'tables_row_sleeves', 'rowSleeve', 'rowSleeve.id = t1.row_id');
+			->innerJoin('t1', 'tables_row_sleeves', 'rs', 'rs.id = t1.row_id');
 
 		try {
 			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());


### PR DESCRIPTION
Not the ideal approach probably, but should at least remove one blocker from releasing 0.7.0

- [x] ~Write a test case covering that~ Already there just never ran with postgres
- [x] Fix intergration test matrix to run all backends
- [x] Make tests pass

Fix #849 