### PR TITLE
feat: Add backend for table archive and favorite flag

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,7 +17,7 @@ return [
 		// -> tables
 		['name' => 'api1#index', 'url' => '/api/1/tables', 'verb' => 'GET'],
 		['name' => 'api1#createTable',	'url' => '/api/1/tables', 'verb' => 'POST'],
-		['name' => 'api1#updateTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'PUT'], // needs archived
+		['name' => 'api1#updateTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'PUT'],
 		['name' => 'api1#getTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'GET'],
 		['name' => 'api1#deleteTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'DELETE'],
 		// -> views
@@ -61,7 +61,7 @@ return [
 		['name' => 'table#index', 'url' => '/table', 'verb' => 'GET'],
 		['name' => 'table#show', 'url' => '/table/{id}', 'verb' => 'GET'],
 		['name' => 'table#create', 'url' => '/table', 'verb' => 'POST'],
-		['name' => 'table#update', 'url' => '/table/{id}', 'verb' => 'PUT'],  // needs archived
+		['name' => 'table#update', 'url' => '/table/{id}', 'verb' => 'PUT'],
 		['name' => 'table#destroy', 'url' => '/table/{id}', 'verb' => 'DELETE'],
 
 		// view
@@ -115,7 +115,7 @@ return [
 		['name' => 'ApiTables#index', 'url' => '/api/2/tables', 'verb' => 'GET'],
 		['name' => 'ApiTables#show', 'url' => '/api/2/tables/{id}', 'verb' => 'GET'],
 		['name' => 'ApiTables#create', 'url' => '/api/2/tables', 'verb' => 'POST'],
-		['name' => 'ApiTables#update', 'url' => '/api/2/tables/{id}', 'verb' => 'PUT'],  // needs archived
+		['name' => 'ApiTables#update', 'url' => '/api/2/tables/{id}', 'verb' => 'PUT'],
 		['name' => 'ApiTables#destroy', 'url' => '/api/2/tables/{id}', 'verb' => 'DELETE'],
 		['name' => 'ApiTables#transfer', 'url' => '/api/2/tables/{id}/transfer', 'verb' => 'PUT'],
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -126,7 +126,7 @@ return [
 		['name' => 'ApiColumns#createSelectionColumn', 'url' => '/api/2/columns/selection', 'verb' => 'POST'],
 		['name' => 'ApiColumns#createDatetimeColumn', 'url' => '/api/2/columns/datetime', 'verb' => 'POST'],
 
-		['name' => 'ApiFavorite#create', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'POST'],
-		['name' => 'ApiFavorite#destroy', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'DELETE'],
+		['name' => 'ApiFavorite#create', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'POST', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],
+		['name' => 'ApiFavorite#destroy', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'DELETE', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],
 	]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,7 +17,7 @@ return [
 		// -> tables
 		['name' => 'api1#index', 'url' => '/api/1/tables', 'verb' => 'GET'],
 		['name' => 'api1#createTable',	'url' => '/api/1/tables', 'verb' => 'POST'],
-		['name' => 'api1#updateTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'PUT'],
+		['name' => 'api1#updateTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'PUT'], // needs archived
 		['name' => 'api1#getTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'GET'],
 		['name' => 'api1#deleteTable',	'url' => '/api/1/tables/{tableId}', 'verb' => 'DELETE'],
 		// -> views
@@ -61,7 +61,7 @@ return [
 		['name' => 'table#index', 'url' => '/table', 'verb' => 'GET'],
 		['name' => 'table#show', 'url' => '/table/{id}', 'verb' => 'GET'],
 		['name' => 'table#create', 'url' => '/table', 'verb' => 'POST'],
-		['name' => 'table#update', 'url' => '/table/{id}', 'verb' => 'PUT'],
+		['name' => 'table#update', 'url' => '/table/{id}', 'verb' => 'PUT'],  // needs archived
 		['name' => 'table#destroy', 'url' => '/table/{id}', 'verb' => 'DELETE'],
 
 		// view
@@ -115,7 +115,7 @@ return [
 		['name' => 'ApiTables#index', 'url' => '/api/2/tables', 'verb' => 'GET'],
 		['name' => 'ApiTables#show', 'url' => '/api/2/tables/{id}', 'verb' => 'GET'],
 		['name' => 'ApiTables#create', 'url' => '/api/2/tables', 'verb' => 'POST'],
-		['name' => 'ApiTables#update', 'url' => '/api/2/tables/{id}', 'verb' => 'PUT'],
+		['name' => 'ApiTables#update', 'url' => '/api/2/tables/{id}', 'verb' => 'PUT'],  // needs archived
 		['name' => 'ApiTables#destroy', 'url' => '/api/2/tables/{id}', 'verb' => 'DELETE'],
 		['name' => 'ApiTables#transfer', 'url' => '/api/2/tables/{id}/transfer', 'verb' => 'PUT'],
 
@@ -125,5 +125,8 @@ return [
 		['name' => 'ApiColumns#createTextColumn', 'url' => '/api/2/columns/text', 'verb' => 'POST'],
 		['name' => 'ApiColumns#createSelectionColumn', 'url' => '/api/2/columns/selection', 'verb' => 'POST'],
 		['name' => 'ApiColumns#createDatetimeColumn', 'url' => '/api/2/columns/datetime', 'verb' => 'POST'],
+
+		['name' => 'ApiFavorite#create', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'POST'],
+		['name' => 'ApiFavorite#destroy', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'DELETE'],
 	]
 ];

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
-		"psalm": "./vendor/bin/psalm.phar --show-info=true --no-cache",
+		"psalm": "./vendor/bin/psalm.phar --show-info=false --no-cache",
 		"psalm:update-baseline": "./vendor/bin/psalm.phar --update-baseline",
 		"psalm:fix": "./vendor/bin/psalm.phar --no-cache --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType",
 		"psalm:fix:dry": "./vendor/bin/psalm.phar --no-cache --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType --dry-run",

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -46,7 +46,7 @@ class Capabilities implements ICapability {
 
 	/**
 	 *
-	 * @return array{tables: array{enabled: bool, version: string, apiVersions: string[], column_types: string[]}}
+	 * @return array{tables: array{enabled: bool, version: string, apiVersions: string[], features: string[], column_types: string[]}}
 	 *
 	 * @inheritDoc
 	 */
@@ -62,6 +62,10 @@ class Capabilities implements ICapability {
 				'version' => $this->appManager->getAppVersion('tables'),
 				'apiVersions' => [
 					'1.0'
+				],
+				'features' => [
+					'favorite',
+					'archive',
 				],
 				'column_types' => [
 					'text-line',

--- a/lib/Command/RenameTable.php
+++ b/lib/Command/RenameTable.php
@@ -45,7 +45,7 @@ class RenameTable extends Command {
 	protected function configure(): void {
 		$this
 			->setName('tables:update')
-			->setAliases('tables:rename')
+			->setAliases(['tables:rename'])
 			->setDescription('Rename a table.')
 			->addArgument(
 				'ID',

--- a/lib/Command/RenameTable.php
+++ b/lib/Command/RenameTable.php
@@ -44,7 +44,8 @@ class RenameTable extends Command {
 
 	protected function configure(): void {
 		$this
-			->setName('tables:rename')
+			->setName('tables:update')
+			->setAliases('tables:rename')
 			->setDescription('Rename a table.')
 			->addArgument(
 				'ID',
@@ -62,6 +63,12 @@ class RenameTable extends Command {
 				InputOption::VALUE_OPTIONAL,
 				'New emoji.'
 			)
+			->addOption(
+				'archived',
+				'a',
+				InputOption::VALUE_NONE,
+				'Archived'
+			)
 		;
 	}
 
@@ -74,9 +81,10 @@ class RenameTable extends Command {
 		$id = $input->getArgument('ID');
 		$title = $input->getArgument('title');
 		$emoji = $input->getOption('emoji');
+		$archived = $input->getOption('archived');
 
 		try {
-			$table = $this->tableService->update($id, $title, $emoji, '');
+			$table = $this->tableService->update($id, $title, $emoji, $archived, '');
 
 			$arr = $table->jsonSerialize();
 			unset($arr['hasShares']);

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -178,9 +178,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
-	public function updateTable(int $tableId, string $title = null, string $emoji = null): DataResponse {
+	public function updateTable(int $tableId, string $title = null, string $emoji = null, ?bool $archived = false): DataResponse {
 		try {
-			return new DataResponse($this->tableService->update($tableId, $title, $emoji, $this->userId)->jsonSerialize());
+			return new DataResponse($this->tableService->update($tableId, $title, $emoji, $archived, $this->userId)->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage());
 			$message = ['message' => $e->getMessage()];

--- a/lib/Controller/ApiFavoriteController.php
+++ b/lib/Controller/ApiFavoriteController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OCA\Tables\Controller;
+
+use Exception;
+use OCA\Tables\Errors\InternalError;
+use OCA\Tables\Errors\NotFoundError;
+use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\ResponseDefinitions;
+use OCA\Tables\Service\FavoritesService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @psalm-import-type TablesTable from ResponseDefinitions
+ */
+class ApiFavoriteController extends AOCSController {
+	private FavoritesService $service;
+
+	public function __construct(
+		IRequest $request,
+		LoggerInterface $logger,
+		FavoritesService $service,
+		IL10N $n,
+		string $userId) {
+		parent::__construct($request, $logger, $n, $userId);
+		$this->service = $service;
+	}
+
+	/**
+	 * [api v2] Create a new table and return it
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $title Title of the table
+	 * @param string|null $emoji Emoji for the table
+	 * @param string $template Template to use if wanted
+	 *
+	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Tables returned
+	 */
+	public function create(int $nodeType, int $nodeId): DataResponse {
+		try {
+			$this->service->addFavorite($nodeType, $nodeId);
+			return new DataResponse(['ok']);
+		} catch (InternalError|Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+
+
+	/**
+	 * [api v2] Delete a table
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param int $id Table ID
+	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 *
+	 * 200: Deleted table returned
+	 * 403: No permissions
+	 * 404: Not found
+	 */
+	public function destroy(int $nodeType, int $nodeId): DataResponse {
+		try {
+			$this->service->removeFavorite($nodeType, $nodeId);
+			return new DataResponse(['ok']);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (InternalError $e) {
+			return $this->handleError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		}
+	}
+}

--- a/lib/Controller/ApiFavoriteController.php
+++ b/lib/Controller/ApiFavoriteController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\Tables\Controller;
 
 use Exception;

--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -106,9 +106,9 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
-	public function update(int $id, string $title = null, string $emoji = null): DataResponse {
+	public function update(int $id, ?string $title = null, ?string $emoji = null, ?bool $archived = null): DataResponse {
 		try {
-			return new DataResponse($this->service->update($id, $title, $emoji, $this->userId)->jsonSerialize());
+			return new DataResponse($this->service->update($id, $title, $emoji, $archived, $this->userId)->jsonSerialize());
 		} catch (PermissionError $e) {
 			return $this->handlePermissionError($e);
 		} catch (InternalError $e) {

--- a/lib/Controller/TableController.php
+++ b/lib/Controller/TableController.php
@@ -70,9 +70,9 @@ class TableController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function update(int $id, string $title = null, string $emoji = null): DataResponse {
-		return $this->handleError(function () use ($id, $title, $emoji) {
-			return $this->service->update($id, $title, $emoji, $this->userId);
+	public function update(int $id, string $title = null, string $emoji = null, ?bool $archived = null): DataResponse {
+		return $this->handleError(function () use ($id, $title, $emoji, $archived) {
+			return $this->service->update($id, $title, $emoji, $archived, $this->userId);
 		});
 	}
 }

--- a/lib/Db/Table.php
+++ b/lib/Db/Table.php
@@ -16,6 +16,8 @@ use OCP\AppFramework\Db\Entity;
  * @method setTitle(string $title)
  * @method getEmoji(): string
  * @method setEmoji(string $emoji)
+ * @method getArchived(): bool
+ * @method setArchived(bool $archived)
  * @method getOwnership(): string
  * @method setOwnership(string $ownership)
  * @method getOwnerDisplayName(): string
@@ -26,6 +28,8 @@ use OCP\AppFramework\Db\Entity;
  * @method setOnSharePermissions(array $onSharePermissions)
  * @method getHasShares(): bool
  * @method setHasShares(bool $hasShares)
+ * @method getFavorite(): bool
+ * @method setFavorite(bool $favorite)
  * @method getRowsCount(): int
  * @method setRowsCount(int $rowsCount)
  * @method getColumnsCount(): int
@@ -52,10 +56,12 @@ class Table extends Entity implements JsonSerializable {
 	protected ?string $createdAt = null;
 	protected ?string $lastEditBy = null;
 	protected ?string $lastEditAt = null;
+	protected bool $archived = false;
 	protected ?bool $isShared = null;
 	protected ?array $onSharePermissions = null;
 
 	protected ?bool $hasShares = false;
+	protected ?bool $favorite = false;
 	protected ?int $rowsCount = 0;
 	protected ?int $columnsCount = 0;
 	protected ?array $views = null;
@@ -63,6 +69,7 @@ class Table extends Entity implements JsonSerializable {
 
 	public function __construct() {
 		$this->addType('id', 'integer');
+		$this->addType('archived', 'boolean');
 	}
 
 	/**
@@ -79,7 +86,9 @@ class Table extends Entity implements JsonSerializable {
 			'createdAt' => $this->createdAt ?: '',
 			'lastEditBy' => $this->lastEditBy ?: '',
 			'lastEditAt' => $this->lastEditAt ?: '',
+			'archived' => $this->archived,
 			'isShared' => !!$this->isShared,
+			'favorite' => $this->favorite,
 			'onSharePermissions' => $this->getSharePermissions(),
 			'hasShares' => !!$this->hasShares,
 			'rowsCount' => $this->rowsCount ?: 0,

--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -35,6 +35,8 @@ use OCP\AppFramework\Db\Entity;
  * @method setOnSharePermissions(array $onSharePermissions)
  * @method getHasShares(): bool
  * @method setHasShares(bool $hasShares)
+ * @method getFavorite(): bool
+ * @method setFavorite(bool $favorite)
  * @method getRowsCount(): int
  * @method setRowsCount(int $rowCount)
  * @method getOwnership(): string
@@ -57,6 +59,7 @@ class View extends Entity implements JsonSerializable {
 	protected ?bool $isShared = null;
 	protected ?array $onSharePermissions = null;
 	protected ?bool $hasShares = false;
+	protected bool $favorite = false;
 	protected ?int $rowsCount = 0;
 	protected ?string $ownership = null;
 	protected ?string $ownerDisplayName = null;
@@ -137,6 +140,7 @@ class View extends Entity implements JsonSerializable {
 			'columns' => $this->getColumnsArray(),
 			'sort' => $this->getSortArray(),
 			'isShared' => !!$this->isShared,
+			'favorite' => $this->favorite,
 			'onSharePermissions' => $this->getSharePermissions(),
 			'hasShares' => !!$this->hasShares,
 			'rowsCount' => $this->rowsCount ?: 0,

--- a/lib/Migration/Version000800Date20240222000000.php
+++ b/lib/Migration/Version000800Date20240222000000.php
@@ -1,0 +1,59 @@
+<?php
+
+/** @noinspection PhpUnused */
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version000800Date20240222000000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws Exception
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('tables_tables')) {
+			$table = $schema->getTable('tables_tables');
+			$table->addColumn('archived', Types::BOOLEAN, [
+				'default' => false,
+				'notnull' => true,
+			]);
+		}
+
+		if (!$schema->hasTable('tables_favorites')) {
+			$table = $schema->createTable('tables_favorites');
+			$table->addColumn('id', Types::BIGINT, [
+				'notnull' => true,
+				'autoincrement' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('node_type', Types::SMALLINT, [
+				'notnull' => true,
+			]);
+			$table->addColumn('node_id', Types::BIGINT, [
+				'notnull' => true,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->setPrimaryKey(['id']);
+		}
+
+		return $schema;
+	}
+
+}

--- a/lib/Migration/Version000800Date20240222000000.php
+++ b/lib/Migration/Version000800Date20240222000000.php
@@ -51,6 +51,7 @@ class Version000800Date20240222000000 extends SimpleMigrationStep {
 				'length' => 64,
 			]);
 			$table->setPrimaryKey(['id']);
+			$table->addIndex(['user_id'], 'idx_tables_fav_uid');
 		}
 
 		return $schema;

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -23,6 +23,7 @@ namespace OCA\Tables;
  *  sort: list<array{columnId: int, mode: 'ASC'|'DESC'}>,
  *  filter: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'is-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}>>,
  * 	isShared: bool,
+ *	favorite: bool,
  * 	onSharePermissions: ?array{
  * 		read: bool,
  * 		create: bool,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -44,6 +44,8 @@ namespace OCA\Tables;
  * 	createdAt: string,
  * 	lastEditBy: string,
  * 	lastEditAt: string,
+ *	archived: bool,
+ *	favorite: bool,
  * 	isShared: bool,
  * 	onSharePermissions: ?array{
  * 		read: bool,

--- a/lib/Service/FavoritesService.php
+++ b/lib/Service/FavoritesService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Tables\Service;
+
+use OCP\Cache\CappedMemoryCache;
+use OCP\IDBConnection;
+
+class FavoritesService {
+
+	private CappedMemoryCache $cache;
+
+	public function __construct(private IDBConnection $connection, private ?string $userId) {
+		$this->cache = new CappedMemoryCache();
+	}
+
+	public function isFavorite(int $nodeType, int $id): bool {
+		if ($cached = $this->cache->get($this->userId . '_' . $nodeType . '_' . $id)) {
+			return $cached;
+		}
+
+		// We still might run this multiple times
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('tables_favorites')
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($this->userId)));
+
+		$result = $qb->executeQuery();
+		while ($row = $result->fetch()) {
+			$this->cache->set($this->userId . '_' . $row['node_type'] . '_' . $row['node_id'], true);
+		}
+
+		return $this->cache->get($this->userId . '_' . $nodeType . '_' . $id) ?? false;
+	}
+
+	public function addFavorite(int $nodeType, int $id): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('tables_favorites')
+			->values([
+				'user_id' => $qb->createNamedParameter($this->userId),
+				'node_type' => $qb->createNamedParameter($nodeType),
+				'node_id' => $qb->createNamedParameter($id),
+			]);
+		$qb->executeStatement();
+		$this->cache->set($this->userId . '_' . $nodeType . '_' . $id, true);
+	}
+
+	public function removeFavorite(int $nodeType, int $id): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('tables_favorites')
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($this->userId)))
+			->andWhere($qb->expr()->eq('node_type', $qb->createNamedParameter($nodeType)))
+			->andWhere($qb->expr()->eq('node_id', $qb->createNamedParameter($id)));
+		$qb->executeStatement();
+		$this->cache->set($this->userId . '_' . $nodeType . '_' . $id, false);
+	}
+
+}

--- a/lib/Service/FavoritesService.php
+++ b/lib/Service/FavoritesService.php
@@ -47,11 +47,12 @@ class FavoritesService {
 		$this->connection = $connection;
 		$this->permissionsService = $permissionsService;
 		$this->userId = $userId;
+		// The cache usage is currently not unique to the user id as only a memory cache is used
 		$this->cache = new CappedMemoryCache();
 	}
 
 	public function isFavorite(int $nodeType, int $id): bool {
-		$cacheKey = $this->userId . '_' . $nodeType . '_' . $id;
+		$cacheKey = $nodeType . '_' . $id;
 		if ($cached = $this->cache->get($cacheKey)) {
 			return $cached;
 		}
@@ -64,7 +65,7 @@ class FavoritesService {
 
 		$result = $qb->executeQuery();
 		while ($row = $result->fetch()) {
-			$this->cache->set($this->userId . '_' . $row['node_type'] . '_' . $row['node_id'], true);
+			$this->cache->set($row['node_type'] . '_' . $row['node_id'], true);
 		}
 
 		// Set the cache for not found matches still to avoid further queries
@@ -93,7 +94,7 @@ class FavoritesService {
 				'node_id' => $qb->createNamedParameter($id),
 			]);
 		$qb->executeStatement();
-		$this->cache->set($this->userId . '_' . $nodeType . '_' . $id, true);
+		$this->cache->set($nodeType . '_' . $id, true);
 	}
 
 	/**
@@ -112,7 +113,7 @@ class FavoritesService {
 			->andWhere($qb->expr()->eq('node_type', $qb->createNamedParameter($nodeType)))
 			->andWhere($qb->expr()->eq('node_id', $qb->createNamedParameter($id)));
 		$qb->executeStatement();
-		$this->cache->set($this->userId . '_' . $nodeType . '_' . $id, false);
+		$this->cache->set($nodeType . '_' . $id, false);
 	}
 
 	/**

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -6,6 +6,7 @@ namespace OCA\Tables\Service;
 
 use DateTime;
 
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Db\Table;
 use OCA\Tables\Db\TableMapper;
 use OCA\Tables\Errors\InternalError;
@@ -38,6 +39,9 @@ class TableService extends SuperService {
 
 	protected UserHelper $userHelper;
 
+	protected FavoritesService $favoritesService;
+
+
 	protected IL10N $l;
 
 	public function __construct(
@@ -51,6 +55,7 @@ class TableService extends SuperService {
 		ViewService $viewService,
 		ShareService $shareService,
 		UserHelper $userHelper,
+		FavoritesService $favoritesService,
 		IL10N $l
 	) {
 		parent::__construct($logger, $userId, $permissionsService);
@@ -61,6 +66,7 @@ class TableService extends SuperService {
 		$this->viewService = $viewService;
 		$this->shareService = $shareService;
 		$this->userHelper = $userHelper;
+		$this->favoritesService = $favoritesService;
 		$this->l = $l;
 	}
 
@@ -196,6 +202,11 @@ class TableService extends SuperService {
 			// add the corresponding views if it is an own table, or you have table manage rights
 			$table->setViews($this->viewService->findAll($table));
 		}
+
+		if ($this->favoritesService->isFavorite(Application::NODE_TYPE_TABLE, $table->getId())) {
+			$table->setFavorite(true);
+		}
+
 
 	}
 
@@ -420,7 +431,7 @@ class TableService extends SuperService {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
-	public function update(int $id, ?string $title, ?string $emoji, ?string $userId = null): Table {
+	public function update(int $id, ?string $title, ?string $emoji, ?bool $archived = null, ?string $userId = null): Table {
 		$userId = $this->permissionsService->preCheckUserId($userId);
 
 		try {
@@ -444,6 +455,9 @@ class TableService extends SuperService {
 		}
 		if ($emoji !== null) {
 			$table->setEmoji($emoji);
+		}
+		if ($archived !== null) {
+			$table->setArchived($archived);
 		}
 		$table->setLastEditBy($userId);
 		$table->setLastEditAt($time->format('Y-m-d H:i:s'));

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -7,6 +7,7 @@ namespace OCA\Tables\Service;
 use DateTime;
 use Exception;
 
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Db\Table;
 use OCA\Tables\Db\View;
 use OCA\Tables\Db\ViewMapper;
@@ -34,6 +35,8 @@ class ViewService extends SuperService {
 
 	protected UserHelper $userHelper;
 
+	protected FavoritesService $favoritesService;
+
 	protected IL10N $l;
 
 	public function __construct(
@@ -44,6 +47,7 @@ class ViewService extends SuperService {
 		ShareService $shareService,
 		RowService $rowService,
 		UserHelper $userHelper,
+		FavoritesService $favoritesService,
 		IL10N $l
 	) {
 		parent::__construct($logger, $userId, $permissionsService);
@@ -52,6 +56,7 @@ class ViewService extends SuperService {
 		$this->shareService = $shareService;
 		$this->rowService = $rowService;
 		$this->userHelper = $userHelper;
+		$this->favoritesService = $favoritesService;
 	}
 
 
@@ -394,6 +399,10 @@ class ViewService extends SuperService {
 							$rawSortArray));
 				}
 			}
+		}
+
+		if ($this->favoritesService->isFavorite(Application::NODE_TYPE_VIEW, $view->getId())) {
+			$view->setFavorite(true);
 		}
 	}
 

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -65,14 +65,27 @@
 					<Connection :size="20" />
 				</template>
 			</NcActionButton>
-			<NcActionButton v-if="canManageElement(table)"
+
+			<!-- ARCHIVE -->
+			<NcActionButton v-if="canManageElement(table) && !table.archived"
 				:close-after-click="true"
-				@click="archiveTable">
+				@click="toggleArchiveTable(true)">
 				{{ t('tables', 'Archive table') }}
 				<template #icon>
 					<ArchiveArrowDown :size="20" />
 				</template>
 			</NcActionButton>
+
+			<!-- UNARCHIVE -->
+			<NcActionButton v-if="canManageElement(table) && table.archived"
+				:close-after-click="true"
+				@click="toggleArchiveTable(false)">
+				{{ t('tables', 'Unarchive table') }}
+				<template #icon>
+					<ArchiveArrowUpOutline :size="20" />
+				</template>
+			</NcActionButton>
+
 			<NcActionButton v-if="canManageElement(table)"
 				icon="icon-delete"
 				:close-after-click="true"
@@ -94,6 +107,7 @@ import { mapGetters, mapState } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
 import Table from 'vue-material-design-icons/Table.vue'
 import ArchiveArrowDown from 'vue-material-design-icons/ArchiveArrowDown.vue'
+import ArchiveArrowUpOutline from 'vue-material-design-icons/ArchiveArrowUpOutline.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import { getCurrentUser } from '@nextcloud/auth'
 import Connection from 'vue-material-design-icons/Connection.vue'
@@ -109,6 +123,7 @@ export default {
 		// eslint-disable-next-line vue/no-reserved-component-names
 		Table,
 		ArchiveArrowDown,
+		ArchiveArrowUpOutline,
 		Import,
 		NavigationViewItem,
 		NcActionButton,
@@ -204,9 +219,17 @@ export default {
 				})
 			}
 		},
-		archiveTable() {
+		async toggleArchiveTable(archived) {
+			const res = await this.$store.dispatch('updateTable', {
+				id: this.table.id,
+				data: { archived },
+			})
+
 			// eslint-disable-next-line no-console
-			console.log(this.table)
+			if (!res) { console.log('failed to archive/unarchive table') }
+
+			// eslint-disable-next-line no-console
+			console.log('archived/unarchived table')
 		},
 	},
 

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -220,16 +220,10 @@ export default {
 			}
 		},
 		async toggleArchiveTable(archived) {
-			const res = await this.$store.dispatch('updateTable', {
+			await this.$store.dispatch('updateTable', {
 				id: this.table.id,
 				data: { archived },
 			})
-
-			// eslint-disable-next-line no-console
-			if (!res) { console.log('failed to archive/unarchive table') }
-
-			// eslint-disable-next-line no-console
-			console.log('archived/unarchived table')
 		},
 	},
 

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -78,7 +78,7 @@
 			<!-- FAVORITE -->
 			<NcActionButton v-if="canManageElement(table) && !table.favorite"
 				:close-after-click="true"
-				@click="() => {}">
+				@click="toggleFavoriteTable(true)">
 				{{ t('tables', 'Add to favorites') }}
 				<template #icon>
 					<Star :size="20" />
@@ -88,7 +88,7 @@
 			<!-- UNFAVORITE -->
 			<NcActionButton v-if="canManageElement(table) && table.favorite"
 				:close-after-click="true"
-				@click="() => {}">
+				@click="toggleFavoriteTable(false)">
 				{{ t('tables', 'Remove from favorites') }}
 				<template #icon>
 					<StarOutline :size="20" />
@@ -258,6 +258,17 @@ export default {
 				id: this.table.id,
 				data: { archived },
 			})
+		},
+		async toggleFavoriteTable(favorite) {
+			if (favorite) {
+				await this.$store.dispatch('favoriteTable', {
+					id: this.table.id,
+				})
+			} else {
+				await this.$store.dispatch('removeFavoriteTable', {
+					id: this.table.id,
+				})
+			}
 		},
 	},
 }

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -27,6 +27,7 @@
 		</template>
 
 		<template #actions>
+			<!-- EDIT -->
 			<NcActionButton v-if="canManageElement(table) "
 				:close-after-click="true"
 				@click="emit('tables:table:edit', table.id)">
@@ -35,6 +36,8 @@
 				</template>
 				{{ t('tables', 'Edit table') }}
 			</NcActionButton>
+
+			<!-- CREATE VIEW -->
 			<NcActionButton v-if="canManageElement(table)"
 				:close-after-click="true"
 				@click="createView">
@@ -43,12 +46,16 @@
 				</template>
 				{{ t('tables', 'Create view') }}
 			</NcActionButton>
+
+			<!-- SHARE -->
 			<NcActionButton v-if="canShareElement(table)"
 				icon="icon-share"
 				:close-after-click="true"
 				@click="actionShowShare">
 				{{ t('tables', 'Share') }}
 			</NcActionButton>
+
+			<!-- IMPORT -->
 			<NcActionButton v-if="canCreateRowInElement(table)"
 				:close-after-click="true"
 				@click="actionShowImport(table)">
@@ -57,12 +64,34 @@
 					<Import :size="20" />
 				</template>
 			</NcActionButton>
+
+			<!-- INTEGRATION -->
 			<NcActionButton
 				:close-after-click="true"
 				@click="actionShowIntegration">
 				{{ t('tables', 'Integration') }}
 				<template #icon>
 					<Connection :size="20" />
+				</template>
+			</NcActionButton>
+
+			<!-- FAVORITE -->
+			<NcActionButton v-if="canManageElement(table) && !table.favorite"
+				:close-after-click="true"
+				@click="() => {}">
+				{{ t('tables', 'Add to favorites') }}
+				<template #icon>
+					<Star :size="20" />
+				</template>
+			</NcActionButton>
+
+			<!-- UNFAVORITE -->
+			<NcActionButton v-if="canManageElement(table) && table.favorite"
+				:close-after-click="true"
+				@click="() => {}">
+				{{ t('tables', 'Remove from favorites') }}
+				<template #icon>
+					<StarOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -86,6 +115,7 @@
 				</template>
 			</NcActionButton>
 
+			<!-- DELETE -->
 			<NcActionButton v-if="canManageElement(table)"
 				icon="icon-delete"
 				:close-after-click="true"
@@ -106,6 +136,8 @@ import '@nextcloud/dialogs/dist/index.css'
 import { mapGetters, mapState } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
 import Table from 'vue-material-design-icons/Table.vue'
+import Star from 'vue-material-design-icons/Star.vue'
+import StarOutline from 'vue-material-design-icons/StarOutline.vue'
 import ArchiveArrowDown from 'vue-material-design-icons/ArchiveArrowDown.vue'
 import ArchiveArrowUpOutline from 'vue-material-design-icons/ArchiveArrowUpOutline.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
@@ -122,6 +154,8 @@ export default {
 		IconRename,
 		// eslint-disable-next-line vue/no-reserved-component-names
 		Table,
+		Star,
+		StarOutline,
 		ArchiveArrowDown,
 		ArchiveArrowUpOutline,
 		Import,
@@ -226,7 +260,6 @@ export default {
 			})
 		},
 	},
-
 }
 </script>
 <style lang="scss">

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -66,6 +66,14 @@
 				</template>
 			</NcActionButton>
 			<NcActionButton v-if="canManageElement(table)"
+				:close-after-click="true"
+				@click="archiveTable">
+				{{ t('tables', 'Archive table') }}
+				<template #icon>
+					<ArchiveArrowDown :size="20" />
+				</template>
+			</NcActionButton>
+			<NcActionButton v-if="canManageElement(table)"
 				icon="icon-delete"
 				:close-after-click="true"
 				@click="deleteTable()">
@@ -78,12 +86,14 @@
 			:show-share-sender="false" />
 	</NcAppNavigationItem>
 </template>
+
 <script>
 import { NcActionButton, NcAppNavigationItem, NcCounterBubble, NcAvatar } from '@nextcloud/vue'
 import '@nextcloud/dialogs/dist/index.css'
 import { mapGetters, mapState } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
 import Table from 'vue-material-design-icons/Table.vue'
+import ArchiveArrowDown from 'vue-material-design-icons/ArchiveArrowDown.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import { getCurrentUser } from '@nextcloud/auth'
 import Connection from 'vue-material-design-icons/Connection.vue'
@@ -98,6 +108,7 @@ export default {
 		IconRename,
 		// eslint-disable-next-line vue/no-reserved-component-names
 		Table,
+		ArchiveArrowDown,
 		Import,
 		NavigationViewItem,
 		NcActionButton,
@@ -192,6 +203,10 @@ export default {
 					open: false,
 				})
 			}
+		},
+		archiveTable() {
+			// eslint-disable-next-line no-console
+			console.log(this.table)
 		},
 	},
 

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -12,10 +12,12 @@
 			<template v-if="table.emoji">
 				{{ table.emoji }}
 			</template>
+
 			<template v-else>
 				<Table :size="20" />
 			</template>
 		</template>
+
 		<template #counter>
 			<NcCounterBubble v-if="canReadData(table)">
 				{{ n('tables', '%n row', '%n rows', table.rowsCount, {}) }}
@@ -76,7 +78,7 @@
 			</NcActionButton>
 
 			<!-- FAVORITE -->
-			<NcActionButton v-if="canManageElement(table) && !table.favorite"
+			<NcActionButton v-if="!table.favorite && !table.archived"
 				:close-after-click="true"
 				@click="toggleFavoriteTable(true)">
 				{{ t('tables', 'Add to favorites') }}
@@ -86,7 +88,7 @@
 			</NcActionButton>
 
 			<!-- UNFAVORITE -->
-			<NcActionButton v-if="canManageElement(table) && table.favorite"
+			<NcActionButton v-if="table.favorite"
 				:close-after-click="true"
 				@click="toggleFavoriteTable(false)">
 				{{ t('tables', 'Remove from favorites') }}
@@ -96,7 +98,7 @@
 			</NcActionButton>
 
 			<!-- ARCHIVE -->
-			<NcActionButton v-if="canManageElement(table) && !table.archived"
+			<NcActionButton v-if="canManageElement(table) && !table.archived && !table.favorite"
 				:close-after-click="true"
 				@click="toggleArchiveTable(true)">
 				{{ t('tables', 'Archive table') }}

--- a/src/modules/navigation/partials/NavigationViewItem.vue
+++ b/src/modules/navigation/partials/NavigationViewItem.vue
@@ -19,10 +19,11 @@
 			</NcCounterBubble>
 			<NcActionButton v-if="view.hasShares" icon="icon-share" :class="{'margin-right': !(activeView && view.id === activeView.id)}" @click="actionShowShare" />
 			<div v-if="view.isShared && view.ownership !== userId && !canManageTable(view) && showShareSender" class="margin-left">
-				<NcAvatar :user="view.ownership" />
+				<NcAvatar :user="view.ownership" :show-user-status="false" />
 			</div>
 		</template>
 		<template #actions>
+			<!-- EDIT -->
 			<NcActionButton v-if="canManageElement(view)"
 				:close-after-click="true"
 				@click="editView">
@@ -31,6 +32,8 @@
 				</template>
 				{{ t('tables', 'Edit view') }}
 			</NcActionButton>
+
+			<!-- DUPLICATE -->
 			<NcActionButton v-if="canManageTable(view)"
 				:close-after-click="true"
 				@click="cloneView">
@@ -39,12 +42,16 @@
 				</template>
 				{{ t('tables', 'Duplicate view') }}
 			</NcActionButton>
+
+			<!-- SHARE -->
 			<NcActionButton v-if="canShareElement(view)"
 				icon="icon-share"
 				:close-after-click="true"
 				@click="actionShowShare">
 				{{ t('tables', 'Share') }}
 			</NcActionButton>
+
+			<!-- IMPORT -->
 			<NcActionButton v-if="canCreateRowInElement(view)"
 				:close-after-click="true"
 				@click="actionShowImport(view)">
@@ -53,6 +60,8 @@
 					<Import :size="20" />
 				</template>
 			</NcActionButton>
+
+			<!-- INTEGRATION -->
 			<NcActionButton
 				:close-after-click="true"
 				@click="actionShowIntegration">
@@ -61,6 +70,28 @@
 					<Connection :size="20" />
 				</template>
 			</NcActionButton>
+
+			<!-- FAVORITE -->
+			<NcActionButton v-if="!view.favorite"
+				:close-after-click="true"
+				@click="() => {}">
+				{{ t('tables', 'Add to favorites') }}
+				<template #icon>
+					<Star :size="20" />
+				</template>
+			</NcActionButton>
+
+			<!-- UNFAVORITE -->
+			<NcActionButton v-if="view.favorite"
+				:close-after-click="true"
+				@click="() => {}">
+				{{ t('tables', 'Remove from favorites') }}
+				<template #icon>
+					<StarOutline :size="20" />
+				</template>
+			</NcActionButton>
+
+			<!-- DELETE -->
 			<NcActionButton v-if="canManageElement(view)"
 				icon="icon-delete"
 				:close-after-click="true"
@@ -77,6 +108,8 @@ import { getCurrentUser } from '@nextcloud/auth'
 import { mapGetters } from 'vuex'
 import { showError } from '@nextcloud/dialogs'
 import Table from 'vue-material-design-icons/Table.vue'
+import Star from 'vue-material-design-icons/Star.vue'
+import StarOutline from 'vue-material-design-icons/StarOutline.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import Connection from 'vue-material-design-icons/Connection.vue'
 import PlaylistPlay from 'vue-material-design-icons/PlaylistPlay.vue'
@@ -91,6 +124,8 @@ export default {
 		PlaylistEdit,
 		// eslint-disable-next-line vue/no-reserved-component-names
 		Table,
+		Star,
+		StarOutline,
 		NcAppNavigationItem,
 		NcCounterBubble,
 		NcActionButton,
@@ -178,6 +213,17 @@ export default {
 				}
 			} else {
 				showError(t('tables', 'Could not create new view'))
+			}
+		},
+		async toggleFavoriteView(favorite) {
+			if (favorite) {
+				await this.$store.dispatch('favoriteView', {
+					id: this.view.id,
+				})
+			} else {
+				await this.$store.dispatch('removeFavoriteView', {
+					id: this.view.id,
+				})
 			}
 		},
 	},

--- a/src/modules/navigation/partials/NavigationViewItem.vue
+++ b/src/modules/navigation/partials/NavigationViewItem.vue
@@ -74,7 +74,7 @@
 			<!-- FAVORITE -->
 			<NcActionButton v-if="!view.favorite"
 				:close-after-click="true"
-				@click="() => {}">
+				@click="toggleFavoriteView(true)">
 				{{ t('tables', 'Add to favorites') }}
 				<template #icon>
 					<Star :size="20" />
@@ -84,7 +84,7 @@
 			<!-- UNFAVORITE -->
 			<NcActionButton v-if="view.favorite"
 				:close-after-click="true"
-				@click="() => {}">
+				@click="toggleFavoriteView(false)">
 				{{ t('tables', 'Remove from favorites') }}
 				<template #icon>
 					<StarOutline :size="20" />

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -19,10 +19,13 @@
 						<NcActionButton :aria-label="t('tables', 'Create table')" icon="icon-add" @click.prevent="createTable" />
 					</template>
 				</NcAppNavigationCaption>
-				<NavigationTableItem v-for="table in getOwnTables"
-					:key="table.id"
-					:filter-string="filterString"
-					:table="table" />
+
+				<template v-for="table in getOwnTables">
+					<NavigationTableItem v-if="!table.archived"
+						:key="table.id"
+						:filter-string="filterString"
+						:table="table" />
+				</template>
 
 				<NcAppNavigationCaption v-if="getSharedTables.length > 0 || getSharedViews.length > 0"
 					:name="t('tables', 'Shared')" />
@@ -41,7 +44,9 @@
 				</template>
 
 				<template #counter>
-					{{ getArchivedTables.length }}
+					<NcCounterBubble>
+						{{ getArchivedTables.length }}
+					</NcCounterBubble>
 				</template>
 
 				<NavigationTableItem v-for="table in getArchivedTables"
@@ -66,7 +71,17 @@
 </template>
 
 <script>
-import { NcAppNavigation, NcAppNavigationItem, NcAppNavigationCaption, NcActionButton, NcTextField, NcButton, NcEmptyContent } from '@nextcloud/vue'
+import {
+	NcAppNavigation,
+	NcAppNavigationItem,
+	NcAppNavigationCaption,
+	NcActionButton,
+	NcTextField,
+	NcButton,
+	NcEmptyContent,
+	NcCounterBubble,
+} from '@nextcloud/vue'
+
 import NavigationViewItem from '../partials/NavigationViewItem.vue'
 import NavigationTableItem from '../partials/NavigationTableItem.vue'
 import { mapState } from 'vuex'
@@ -88,6 +103,7 @@ export default {
 		Magnify,
 		Archive,
 		NcButton,
+		NcCounterBubble,
 		NcEmptyContent,
 	},
 	data() {
@@ -103,10 +119,19 @@ export default {
 			return this.views.filter(item => item.isShared === true && item.ownership !== getCurrentUser().uid && !sharedTableIds.includes(item.tableId)).filter(view => view.title.toLowerCase().includes(this.filterString.toLowerCase())).sort((a, b) => a.tableId === b.tableId ? a.id - b.id : a.tableId - b.tableId)
 		},
 		getSharedTables() {
-			return this.getFilteredTables.filter((item) => { return item.isShared === true && item.ownership !== getCurrentUser().uid }).sort((a, b) => a.title.localeCompare(b.title))
+			return this.getFilteredTables.filter((item) => {
+				return item.isShared === true && item.ownership !== getCurrentUser().uid
+			}).sort((a, b) => a.title.localeCompare(b.title))
 		},
 		getOwnTables() {
-			return this.getFilteredTables.filter((item) => { return item.isShared === false || item.ownership === getCurrentUser().uid }).sort((a, b) => a.title.localeCompare(b.title))
+			return this.getFilteredTables.filter((item) => {
+				return item.isShared === false || item.ownership === getCurrentUser().uid
+			}).sort((a, b) => a.title.localeCompare(b.title))
+		},
+		getArchivedTables() {
+			return this.getFilteredTables.filter(item => {
+				return item.archived
+			}).sort((a, b) => a.title.localeCompare(b.title))
 		},
 		getFilteredTables() {
 			return this.tables.filter(table => {
@@ -116,11 +141,6 @@ export default {
 					return table.title.toLowerCase().includes(this.filterString.toLowerCase())
 						|| table.views?.some(view => view.title.toLowerCase().includes(this.filterString.toLowerCase()))
 				}
-			})
-		},
-		getArchivedTables() {
-			return this.tables.filter(item => {
-				return item.archived
 			})
 		},
 	},

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -35,6 +35,16 @@
 					:view="view" />
 			</ul>
 
+			<NcAppNavigationItem :name="t('tables', 'Archived tables')" :allow-collapse="true" :open="false">
+				<template #icon>
+					<Archive :size="24" />
+				</template>
+
+				<template #counter>
+					0
+				</template>
+			</NcAppNavigationItem>
+
 			<div v-if="filterString !== ''" class="search-info">
 				<NcEmptyContent :description="t('tables', 'Your results are filtered.')">
 					<template #icon>
@@ -52,12 +62,13 @@
 </template>
 
 <script>
-import { NcAppNavigation, NcAppNavigationCaption, NcActionButton, NcTextField, NcButton, NcEmptyContent } from '@nextcloud/vue'
+import { NcAppNavigation, NcAppNavigationItem, NcAppNavigationCaption, NcActionButton, NcTextField, NcButton, NcEmptyContent } from '@nextcloud/vue'
 import NavigationViewItem from '../partials/NavigationViewItem.vue'
 import NavigationTableItem from '../partials/NavigationTableItem.vue'
 import { mapState } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
+import Archive from 'vue-material-design-icons/Archive.vue'
 import { getCurrentUser } from '@nextcloud/auth'
 
 export default {
@@ -66,10 +77,12 @@ export default {
 		NavigationTableItem,
 		NavigationViewItem,
 		NcAppNavigation,
+		NcAppNavigationItem,
 		NcAppNavigationCaption,
 		NcActionButton,
 		NcTextField,
 		Magnify,
+		Archive,
 		NcButton,
 		NcEmptyContent,
 	},

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -38,7 +38,10 @@
 					:view="view" />
 			</ul>
 
-			<NcAppNavigationItem :name="t('tables', 'Archived tables')" :allow-collapse="true" :open="false">
+			<NcAppNavigationItem v-if="getArchivedTables.length > 0"
+				:name="t('tables', 'Archived tables')"
+				:allow-collapse="true"
+				:open="false">
 				<template #icon>
 					<Archive :size="20" />
 				</template>

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -42,7 +42,7 @@
 						:filter-string="filterString"
 						:table="node" />
 
-					<NavigationViewItem v-else-if="node.tableId && !node.favorite"
+					<NavigationViewItem v-else-if="node.tableId && !node.favorite && !viewAlreadyListed(node)"
 						:key="'view' + node.id"
 						:view="node" />
 				</template>
@@ -130,7 +130,14 @@ export default {
 	computed: {
 		...mapState(['tables', 'views', 'tablesLoading']),
 		getAllNodes() {
-			return [...this.getFilteredTables, ...this.getSharedViews]
+			return [...this.getFilteredTables, ...this.getOwnViews, ...this.getSharedViews]
+		},
+		getOwnViews() {
+			const sharedTableIds = this.getFilteredTables.map(table => table.id)
+
+			return this.views.filter(view => {
+				return !view.isShared && view.ownership === getCurrentUser().uid && sharedTableIds.includes(view.tableId)
+			}).filter(view => view.title.toLowerCase().includes(this.filterString.toLowerCase()))
 		},
 		getSharedViews() {
 			const sharedTableIds = this.getFilteredTables.map(table => table.id)
@@ -166,6 +173,9 @@ export default {
 					open: false,
 				})
 			}
+		},
+		viewAlreadyListed(view) {
+			return this.getFilteredTables.map(t => t.id).includes(view.tableId)
 		},
 	},
 }

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -37,12 +37,16 @@
 
 			<NcAppNavigationItem :name="t('tables', 'Archived tables')" :allow-collapse="true" :open="false">
 				<template #icon>
-					<Archive :size="24" />
+					<Archive :size="20" />
 				</template>
 
 				<template #counter>
-					0
+					{{ getArchivedTables.length }}
 				</template>
+
+				<NavigationTableItem v-for="table in getArchivedTables"
+					:key="table.id"
+					:table="table" />
 			</NcAppNavigationItem>
 
 			<div v-if="filterString !== ''" class="search-info">
@@ -112,6 +116,11 @@ export default {
 					return table.title.toLowerCase().includes(this.filterString.toLowerCase())
 						|| table.views?.some(view => view.title.toLowerCase().includes(this.filterString.toLowerCase()))
 				}
+			})
+		},
+		getArchivedTables() {
+			return this.tables.filter(item => {
+				return item.archived
 			})
 		},
 	},

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,0 +1,23 @@
+/*
+ * @copyright Copyright (c) 2024 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const NODE_TYPE_TABLE = 0
+export const NODE_TYPE_VIEW = 1

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -234,6 +234,36 @@ export default new Vuex.Store({
 			commit('setTables', [...tables])
 			return true
 		},
+		async favoriteTable({ state, commit, dispatch }, { id }) {
+			try {
+				await axios.post(generateOcsUrl('/apps/tables/api/2/favorites/tables/' + id))
+			} catch (e) {
+				displayError(e, t('tables', 'Could not favorite table'))
+				return false
+			}
+
+			const index = state.tables.findIndex(t => t.id === id)
+			const table = state.tables[index]
+			table.favorite = true
+			commit('setTable', table)
+
+			return true
+		},
+		async removeFavoriteTable({ state, commit, dispatch }, { id }) {
+			try {
+				await axios.delete(generateOcsUrl('/apps/tables/api/2/favorites/tables/' + id))
+			} catch (e) {
+				displayError(e, t('tables', 'Could not remove table from favorites'))
+				return false
+			}
+
+			const index = state.tables.findIndex(t => t.id === id)
+			const table = state.tables[index]
+			table.favorite = false
+			commit('setTable', table)
+
+			return true
+		},
 		async transferTable({ state, commit, dispatch }, { id, data }) {
 			try {
 				await axios.put(generateOcsUrl('/apps/tables/api/2/tables/' + id + '/transfer'), data)

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -234,6 +234,36 @@ export default new Vuex.Store({
 			commit('setTables', [...tables])
 			return true
 		},
+		async favoriteView({ state, commit, dispatch }, { id }) {
+			try {
+				await axios.post(generateOcsUrl('/apps/tables/api/2/favorites/views/' + id))
+			} catch (e) {
+				displayError(e, t('tables', 'Could not favorite view'))
+				return false
+			}
+
+			const index = state.views.findIndex(v => v.id === id)
+			const view = state.views[index]
+			view.favorite = true
+			commit('setView', view)
+
+			return true
+		},
+		async removeFavoriteView({ state, commit, dispatch }, { id }) {
+			try {
+				await axios.delete(generateOcsUrl('/apps/tables/api/2/favorites/views/' + id))
+			} catch (e) {
+				displayError(e, t('tables', 'Could not remove view from favorites'))
+				return false
+			}
+
+			const index = state.views.findIndex(v => v.id === id)
+			const view = state.views[index]
+			view.favorite = false
+			commit('setView', view)
+
+			return true
+		},
 		async favoriteTable({ state, commit, dispatch }, { id }) {
 			try {
 				await axios.post(generateOcsUrl('/apps/tables/api/2/favorites/tables/' + id))

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -6,6 +6,7 @@ import { showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/dist/index.css'
 import data from './data.js'
 import displayError from '../shared/utils/displayError.js'
+import { NODE_TYPE_TABLE, NODE_TYPE_VIEW } from '../shared/constants.js'
 
 Vue.use(Vuex)
 
@@ -236,7 +237,7 @@ export default new Vuex.Store({
 		},
 		async favoriteView({ state, commit, dispatch }, { id }) {
 			try {
-				await axios.post(generateOcsUrl('/apps/tables/api/2/favorites/views/' + id))
+				await axios.post(generateOcsUrl(`/apps/tables/api/2/favorites/${NODE_TYPE_VIEW}/${id}`))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not favorite view'))
 				return false
@@ -251,7 +252,7 @@ export default new Vuex.Store({
 		},
 		async removeFavoriteView({ state, commit, dispatch }, { id }) {
 			try {
-				await axios.delete(generateOcsUrl('/apps/tables/api/2/favorites/views/' + id))
+				await axios.delete(generateOcsUrl(`/apps/tables/api/2/favorites/${NODE_TYPE_VIEW}/${id}`))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not remove view from favorites'))
 				return false
@@ -266,7 +267,7 @@ export default new Vuex.Store({
 		},
 		async favoriteTable({ state, commit, dispatch }, { id }) {
 			try {
-				await axios.post(generateOcsUrl('/apps/tables/api/2/favorites/tables/' + id))
+				await axios.post(generateOcsUrl(`/apps/tables/api/2/favorites/${NODE_TYPE_TABLE}/${id}`))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not favorite table'))
 				return false
@@ -281,7 +282,7 @@ export default new Vuex.Store({
 		},
 		async removeFavoriteTable({ state, commit, dispatch }, { id }) {
 			try {
-				await axios.delete(generateOcsUrl('/apps/tables/api/2/favorites/tables/' + id))
+				await axios.delete(generateOcsUrl(`/apps/tables/api/2/favorites/${NODE_TYPE_TABLE}/${id}`))
 			} catch (e) {
 				displayError(e, t('tables', 'Could not remove table from favorites'))
 				return false

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -2,6 +2,7 @@ Feature: APIv2
   Background:
     Given user "participant1-v2" exists
     Given user "participant2-v2" exists
+    Given user "participant3-v2" exists
 
   @api2
   Scenario: Test initial setup
@@ -15,10 +16,36 @@ Feature: APIv2
     Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
     Then user "participant1-v2" has the following tables via v2
       | Table 1 via api v2 |
+    And user "participant1-v2" sees the following table attributes on table "t1"
+      | archived | 0 |
     Then user "participant1-v2" updates table "t1" set title "updated title" and emoji "⛵︎" via v2
     Then user "participant1-v2" has the following tables via v2
       | updated title |
+    Then user "participant1-v2" updates table "t1" set archived 1 via v2
+    And user "participant1-v2" sees the following table attributes on table "t1"
+      | archived | 1 |
+    Then user "participant1-v2" updates table "t1" set archived 0 via v2
+    And user "participant1-v2" sees the following table attributes on table "t1"
+      | archived | 0 |
     Then user "participant1-v2" deletes table "t1" via v2
+
+  @api2
+  Scenario: Favorite tables
+    Given table "Own table" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And user "participant1-v2" shares table with user "participant2-v2"
+    And user "participant1-v2" adds the table "t1" to favorites
+    And user "participant1-v2" sees the following table attributes on table "t1"
+      | favorite | 1 |
+    And user "participant2-v2" fetches table info for table "t1"
+    And user "participant2-v2" sees the following table attributes on table "t1"
+      | favorite | 0 |
+    When user "participant1-v2" removes the table "t1" from favorites
+    And user "participant1-v2" sees the following table attributes on table "t1"
+      | favorite | 0 |
+    When user "participant3-v2" adds the table "t1" to favorites
+    Then the last response should have a "403" status code
+
+
 
   @api2
   Scenario: Basic column actions


### PR DESCRIPTION
Resolves #469 

- [ ] Backend
  - [x] Adjust database layout
    - [x] Add archived flag to tables ~and views~
    - [x] Add favorites table that stores if a node (table/view) is favorited by a user
  - [x] Expose archived flag as an option to set through existing API endpoints when updating tables/views
  - [x] Add Controller and Favorite service to mark as favorite and remove favorite
  - [x] First working endpoints
  - [x] Cleanup a bit
  - [x] Adapt other api endpoints that have a comment in routes
  - [x] Proper response format for favorites
  - [x] Add capability for favorites api endpoints
  - [x] Check open api spec annotations
  - [x] Write integration tests
- [ ] Frontend
  - [x] Navigation
    - [x] Remove categories from navigation and just show a plain list (sort favorites first, then by last modification time)
    - [x] Hide archived tables/views in a collapsible entry (like in deck)
  - [x] Archiving
    - [x] Add button to archive/unarchive in the edit table and edit view dialogs
  - [x] Favorites
    - [x] Add action to the menu to mark as favorite and remove from favorites 
  - [ ] Cypress tests for adding/removing favorites
  - [ ] Cypress test for archiving/unarchiving

