### PR TITLE
fix: Filter returned entity result by view columns

### DIFF
--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -108,6 +108,16 @@ class Row2 implements JsonSerializable {
 	}
 
 	/**
+	 * @param int[] $columns
+	 */
+	public function filterDataByColumns(array $columns): array {
+		$this->data = array_values(array_filter($this->data, function ($entry) use ($columns) {
+			return in_array($entry['columnId'], $columns);
+		}));
+		return $this->data;
+	}
+
+	/**
 	 * @psalm-return TablesRow
 	 */
 	public function jsonSerialize(): array {

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -397,7 +397,7 @@ class RowService extends SuperService {
 			}
 		}
 
-		return $this->row2Mapper->update($item, $columns);
+		return $this->filterRowResult($view ?? null, $this->row2Mapper->update($item, $columns));
 	}
 
 	/**
@@ -450,7 +450,7 @@ class RowService extends SuperService {
 		}
 
 		try {
-			return $this->row2Mapper->delete($item);
+			return $this->filterRowResult($view ?? null, $this->row2Mapper->delete($item));
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
@@ -521,5 +521,15 @@ class RowService extends SuperService {
 		} else {
 			throw new PermissionError('no read access for counting to view id = '.$view->getId());
 		}
+	}
+
+	private function filterRowResult(?View $view, Row2 $row): Row2 {
+		if ($view === null) {
+			return $row;
+		}
+
+		$row->filterDataByColumns($view->getColumnsArray());
+
+		return $row;
 	}
 }


### PR DESCRIPTION
When updating rows in a view I noticed a but where the second update operation of the same row wold fail in the frontend.

It turned out that the first update would actually return a column that was not in the view itself which it tried to update then on the next attempt.

This PR introduces filtering for the actual columns of a view in places where we return its data (update/delete).

Steps to reproduce:
- Create a table with some entries
- Create a view that hides one table column
- Open the view and edit a row twice