### PR TITLE
fix(Permissions): check against user provided in args

### DIFF
--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -98,10 +98,10 @@ class PermissionsService {
 
 	public function canAccessNodeById(int $nodeType, int $nodeId, ?string $userId = null): bool {
 		if ($nodeType === Application::NODE_TYPE_TABLE) {
-			return $this->canReadColumnsByTableId($nodeId, $this->userId);
+			return $this->canReadColumnsByTableId($nodeId, $userId);
 		}
 		if ($nodeType === Application::NODE_TYPE_VIEW) {
-			return $this->canReadColumnsByViewId($nodeId, $this->userId);
+			return $this->canReadColumnsByViewId($nodeId, $userId);
 		}
 
 		return false;
@@ -109,10 +109,10 @@ class PermissionsService {
 
 	public function canManageNodeById(int $nodeType, int $nodeId, ?string $userId = null): bool {
 		if ($nodeType === Application::NODE_TYPE_TABLE) {
-			return $this->canManageTableById($nodeId, $this->userId);
+			return $this->canManageTableById($nodeId, $userId);
 		}
 		if ($nodeType === Application::NODE_TYPE_VIEW) {
-			return $this->canManageViewById($nodeId, $this->userId);
+			return $this->canManageViewById($nodeId, $userId);
 		}
 
 		return false;


### PR DESCRIPTION
Follow up to #878 – the implantation would have used the user set to the instance state, not the one provided through the argument.