### PR TITLE
fix(meta): drop 25 support

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [ 16 ]
         databases: [ 'mysql' ]
-        server-versions: [ 'stable25', 'stable27', 'master' ]
+        server-versions: [ 'stable26', 'stable27', 'master' ]
         include:
           - php-versions: 8.1
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server-versions: ['stable25', 'stable27', 'master']
+        server-versions: ['stable26', 'stable27', 'master']
         php-versions: ['8.1']
         databases: ['mysql']
         include:

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -44,7 +44,7 @@ Have a good time and manage whatever you want.
 		<database>pgsql</database>
 		<database>mysql</database>
 		<database>sqlite</database>
-		<nextcloud min-version="25" max-version="29"/>
+		<nextcloud min-version="26" max-version="29"/>
 	</dependencies>
 	<repair-steps>
 		<post-migration>

--- a/lib/Service/TableTemplateService.php
+++ b/lib/Service/TableTemplateService.php
@@ -10,7 +10,6 @@ use OCA\Tables\Errors\PermissionError;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\DB\Exception;
-use OCP\IConfig;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
@@ -27,24 +26,15 @@ class TableTemplateService {
 
 	private ?string $userId;
 
-	private IConfig $config;
-
 	private string $textRichColumnTypeName = 'rich';
 
-	public function __construct(LoggerInterface $logger, IL10N $l, ColumnService $columnService, ?string $userId, RowService $rowService, ViewService $viewService, IConfig $config) {
+	public function __construct(LoggerInterface $logger, IL10N $l, ColumnService $columnService, ?string $userId, RowService $rowService, ViewService $viewService) {
 		$this->logger = $logger;
 		$this->l = $l;
 		$this->columnService = $columnService;
 		$this->rowService = $rowService;
 		$this->viewService = $viewService;
 		$this->userId = $userId;
-		$this->config = $config;
-
-		// if we are on NC25, wie have to use the old text-long column type
-		// this is because NC25 does not serve the text editor globally
-		if (version_compare($this->config->getSystemValueString('version', '0.0.0'), '26.0.0', '<')) {
-			$this->textRichColumnTypeName = 'long';
-		}
 	}
 
 	/**


### PR DESCRIPTION
for dependencies already PHP 8.x is required, contradicting NC 25 compatibility. Also, 25 is EOL.