### PR TITLE
changed view filter reset icon (issue #884)

### DIFF
--- a/src/modules/main/sections/ElementDescription.vue
+++ b/src/modules/main/sections/ElementDescription.vue
@@ -8,8 +8,13 @@
 				<TextIcon :size="15" />
 				{{ t('tables', 'Filtered view') }}&nbsp;&nbsp;
 			</div>
-			<NcSmallButton v-if="isViewSettingSet" @click="resetLocalAdjustments">
-				🔙 {{ t('tables', 'Reset local adjustments') }}
+			<NcSmallButton
+				v-if="isViewSettingSet"
+				@click="resetLocalAdjustments">
+				<template #icon>
+					<FilterRemove :size="15" />
+				</template>
+				{{ t('tables', 'Reset local adjustments') }}
 			</NcSmallButton>
 		</div>
 		<div v-if="!isTable && activeElement.isShared" class="user-bubble">
@@ -25,6 +30,7 @@
 
 import { NcUserBubble } from '@nextcloud/vue'
 import TextIcon from 'vue-material-design-icons/Text.vue'
+import FilterRemove from 'vue-material-design-icons/FilterRemove.vue'
 import NcSmallButton from '../../../shared/components/ncSmallButton/NcSmallButton.vue'
 
 export default {
@@ -33,6 +39,7 @@ export default {
 	components: {
 		NcUserBubble,
 		TextIcon,
+		FilterRemove,
 		NcSmallButton,
 	},
 

--- a/src/shared/components/ncSmallButton/NcSmallButton.vue
+++ b/src/shared/components/ncSmallButton/NcSmallButton.vue
@@ -1,6 +1,9 @@
 <template>
 	<NcButton :aria-label="ariaLabel" class="button-small" @click="submit">
-		<slot />
+		<div class="button-small__label">
+			<slot name="icon" />
+			<slot />
+		</div>
 	</NcButton>
 </template>
 <script>
@@ -33,6 +36,12 @@ export default {
 		min-height: auto !important;
 		padding: 1px 2px !important;
 		margin: 0 0 0 4px !important;
+	}
+
+	.button-small__label {
+		display: flex;
+		flex-flow: row nowrap;
+		align-items: center;
 	}
 
 </style>


### PR DESCRIPTION
## Explanation
Fix/enhancement for issue #884 
Changed icon for the reset button when filtering views from a simple out of place emoji to a proper icon. In order to get the correct behavior I had to make a slight edit to the NcSmallButton, which is just a wrapper around the NcButton component with some styling changes to make the button smaller. If there's a better way to do the markup/styling, feel free to inform

## Screenshots
<details>
<summary>Previous</summary>

![grafik](https://github.com/nextcloud/tables/assets/23369449/5c115bef-a347-4860-ae9c-de0be2868a02)
</details>

<details>
<summary>Suggested</summary>

![grafik](https://github.com/nextcloud/tables/assets/23369449/861d853d-8f59-44d5-85a4-6861e65ebd5e)
</details>