### PR TITLE
Match default values when querying views

### DIFF
--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -62,6 +62,11 @@ use OCP\AppFramework\Db\Entity;
  * @method setDatetimeDefault(?string $datetimeDefault)
  */
 class Column extends Entity implements JsonSerializable {
+	public const TYPE_SELECTION = 'selection';
+	public const TYPE_TEXT = 'text';
+	public const TYPE_NUMBER = 'number';
+	public const TYPE_DATETIME = 'datetime';
+
 	protected ?string $title = null;
 	protected ?int $tableId = null;
 	protected ?string $createdBy = null;


### PR DESCRIPTION
When gathering rows that are visible in views we need to take rows into
account that have no corresponding entry in the columns_TYPE tables. For
those we can match the filter in PHP and include row ids from a left
join where there is no entry.

Taking an example of a yes/no selection:

If the default value of a column doesn't match we end up using the same
query as before for collecting row ids

```
...
	`id` IN (SELECT `row_id` FROM `oc_tables_row_cells_selection` WHERE (`column_id` = 7) AND (`value` LIKE '"false"'))
...
```

If the default value matches, we need to include those that do not have
an entry

```
...
	`id` IN (SELECT `row_id` FROM `oc_tables_row_cells_selection` WHERE (`column_id` = 7) AND (`value` LIKE '"false"'))
OR
	`id` IN (select sl.id from oc_tables_row_sleeves sl LEFT JOIN oc_tables_row_cells_selection se ON sl.id = se.row_id AND se.column_id = 7 WHERE se.id IS NULL)
...
```

## Steps to reproduce

- Create a table with one text field
- Add a row
- Add a new column to it with some default value
- Create a filter that filters for the default value