### PR TITLE
feat(Contexts): add Contexts to navigation when applicable

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,6 +6,7 @@ use Exception;
 use OCA\Analytics\Datasource\DatasourceEvent;
 use OCA\Tables\Capabilities;
 use OCA\Tables\Listener\AnalyticsDatasourceListener;
+use OCA\Tables\Listener\BeforeTemplateRenderedListener;
 use OCA\Tables\Listener\LoadAdditionalListener;
 use OCA\Tables\Listener\TablesReferenceListener;
 use OCA\Tables\Listener\UserDeletedListener;
@@ -16,6 +17,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\User\Events\BeforeUserDeletedEvent;
@@ -27,6 +29,10 @@ class Application extends App implements IBootstrap {
 	public const NODE_TYPE_VIEW = 1;
 
 	public const OWNER_TYPE_USER = 0;
+
+	public const NAV_ENTRY_MODE_HIDDEN = 0;
+	public const NAV_ENTRY_MODE_RECIPIENTS = 1;
+	public const NAV_ENTRY_MODE_ALL = 2;
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);
@@ -43,7 +49,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeUserDeletedEvent::class, UserDeletedListener::class);
 		$context->registerEventListener(DatasourceEvent::class, AnalyticsDatasourceListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, TablesReferenceListener::class);
-
+		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
 
 		$context->registerSearchProvider(SearchTablesProvider::class);

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace OCA\Tables\Listener;
+
+use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Service\ContextService;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\INavigationManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+
+/**
+ * @template-implements IEventListener<Event|BeforeTemplateRenderedEvent>
+ */
+class BeforeTemplateRenderedListener implements IEventListener {
+	public function __construct(
+		protected INavigationManager $navigationManager,
+		protected IURLGenerator $urlGenerator,
+		protected IUserSession $userSession,
+		protected ContextService $contextService,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforeTemplateRenderedEvent) {
+			return;
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return;
+		}
+
+		// temporarily show all
+		//$contexts = $this->contextService->findForNavigation($user->getUID());
+		$contexts = $this->contextService->findAll($user->getUID());
+		foreach ($contexts as $context) {
+			/* temporarily, show all
+			if ($context->getOwnerType() === Application::OWNER_TYPE_USER
+				&& $context->getOwnerId() === $user->getUID()) {
+
+
+				// filter out entries for owners unless it is set to be visible
+				$skipEntry = true;
+				foreach ($context->getSharing() as $shareInfo) {
+					// TODO: integrate into DB query in Mapper
+
+					if (isset($shareInfo['display_mode']) && $shareInfo['display_mode'] === Application::NAV_ENTRY_MODE_ALL) {
+						// a custom override makes it visible
+						$skipEntry = false;
+						break;
+					} elseif (!isset($shareInfo['display_mode']) && $shareInfo['display_mode_default'] === Application::NAV_ENTRY_MODE_ALL) {
+						// no custom override, and visible also for owner by default
+						$skipEntry = false;
+						break;
+					}
+				}
+				if ($skipEntry) {
+					continue;
+				}
+			}
+			*/
+
+			$this->navigationManager->add(function () use ($context) {
+				$iconRelPath = 'material/' . $context->getIcon() . '.svg';
+				if (file_exists(__DIR__ . '/../../img/' . $iconRelPath)) {
+					$iconUrl = $this->urlGenerator->imagePath(Application::APP_ID, $iconRelPath);
+				} else {
+					$iconUrl = $this->urlGenerator->imagePath('core', 'places/default-app-icon.svg');
+				}
+
+				$contextUrl = $this->urlGenerator->linkToRoute('tables.page.index');
+				$contextUrl .= sprintf('#/application/%d', $context->getId());
+
+				return [
+					'id' => Application::APP_ID . '_application_' . $context->getId(),
+					'name' => $context->getName(),
+					'href' => $contextUrl,
+					'icon' => $iconUrl,
+					'order' => 500,
+					'type' => 'link',
+				];
+			});
+		}
+	}
+}

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -77,6 +77,10 @@ class ContextService {
 		return $this->contextMapper->findAll($userId);
 	}
 
+	public function findForNavigation(string $userId): array {
+		return $this->contextMapper->findForNavBar($userId);
+	}
+
 	/**
 	 * @throws Exception
 	 * @throws InternalError


### PR DESCRIPTION
solves #863 

needs #903 (soft)

~~wants https://github.com/nextcloud/server/pull/44178~~

* [x] generate correct link
* [x] does not appear yet for the owner even if there is a share where display is enabled for all
* [ ] move logic from application to db query (see TODO remark in code)

Screenshot made with frontend from https://github.com/nextcloud/tables/pull/844. On the content area in the UI we don't render the material icons yet, but the icon is in the nav bar. The icon over the mouse pointer is material design, while the two icons on the very right have fallback icons (default app icon). 
 
![Screenshot_20240313_161237](https://github.com/nextcloud/tables/assets/2184312/c1bf4948-f4f0-4984-91e5-7aad21d1908f)
