### PR TITLE
fix: properly indent child views of archived tables

### DIFF
--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -49,6 +49,7 @@
 
 				<!-- ARCHIVED -->
 				<NcAppNavigationItem v-if="getArchivedTables.length > 0"
+					class="archived-items"
 					:name="t('tables', 'Archived tables')"
 					:allow-collapse="true"
 					:open="false">
@@ -182,7 +183,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
 :deep(.filter-box) {
 	.input-field {
 		padding: 8px;
@@ -201,5 +201,14 @@ export default {
 		margin-top: 3vh;
 	}
 }
+</style>
 
+<style>
+.archived-items .app-navigation-entry__children {
+	& .app-navigation-entry-wrapper .app-navigation-entry__children {
+		& .app-navigation-entry {
+			padding-left: calc(16px * 2);
+		}
+	}
+}
 </style>

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -207,7 +207,7 @@ export default {
 .archived-items .app-navigation-entry__children {
 	& .app-navigation-entry-wrapper .app-navigation-entry__children {
 		& .app-navigation-entry {
-			padding-left: calc(16px * 2);
+			padding-left: 32px;
 		}
 	}
 }


### PR DESCRIPTION
Fix for issue #892 

Added some CSS which will further indent views which are nested in an archived table to make the hierarchy more visible. If there's a better way, definitely let me know :)

### Screenshots
<details>
<summary>Previous</summary>

![grafik](https://github.com/nextcloud/tables/assets/23369449/f902e459-33bf-4afa-a3c0-5d36de6aa0f3)
</details>

<details>
<summary>Suggested</summary>

![grafik](https://github.com/nextcloud/tables/assets/23369449/dc7afb4d-c847-4075-9d3b-56acd781b096)
</details>