### PR TITLE
fix: shared views can be favorited

### DIFF
--- a/cypress/e2e/tables-favorite.cy.js
+++ b/cypress/e2e/tables-favorite.cy.js
@@ -67,5 +67,23 @@ describe('Favorite tables/views', () => {
 
     cy.get('@testView').parent().parent().should('contain.text', 'Tutorial')
   })
-  
+
+  it('can (un)favorite views with favorited parent tables', () => {
+    cy.get('[data-cy="navigationViewItem"]').first().as('testView')
+    cy.get('[data-cy="navigationTableItem"]').first().as('tutorialTable')
+
+    cy.get('@testView').parent().parent().should('contain.text', 'Tutorial')
+    cy.get('@testView').find('[aria-haspopup="menu"]').click({ force: true })
+    cy.contains('Add to favorites').click({ force: true })
+
+    cy.get('@testView').parent().should('contain.text', 'Favorites')
+
+    cy.get('@tutorialTable').should('contain.text', 'Tutorial')
+    cy.get('@tutorialTable').find('[aria-haspopup="menu"]').first().click({ force: true })
+    cy.contains('Add to favorites').click({ force: true })
+
+    cy.get('@tutorialTable').parent().should('contain.text', 'Tables')
+    cy.get('@testView').parent().should('not.contain.text', 'Favorites')
+  })
+
 })

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -141,14 +141,22 @@ export default {
 			}).filter(view => view.title.toLowerCase().includes(this.filterString.toLowerCase()))
 		},
 		getSharedViews() {
-			const sharedTableIds = this.getFilteredTables.map(table => table.id)
-
 			return this.views.filter(view => {
-				return view.isShared && view.ownership !== getCurrentUser().uid && !sharedTableIds.includes(view.tableId)
+				return view.isShared && view.ownership !== getCurrentUser().uid
 			}).filter(view => view.title.toLowerCase().includes(this.filterString.toLowerCase()))
 		},
+		getFavoriteTables() {
+			return this.getAllNodes.filter(node => !node.tableId && node.favorite)
+		},
+		getFavoriteViews() {
+			return this.getAllNodes.filter(node => node.tableId && node.favorite)
+		},
 		getFavoriteNodes() {
-			return this.getAllNodes.filter(node => node.favorite)
+			const favoriteViews = this.getFavoriteViews.filter(view => {
+				return !this.getFavoriteTables.map(t => t.id).includes(view.tableId)
+			})
+
+			return [...this.getFavoriteTables, ...favoriteViews]
 		},
 		getArchivedTables() {
 			return this.getFilteredTables.filter(node => node.archived)


### PR DESCRIPTION
## Current behavior
If a view is shared (the user is not the owner of the view), the user will have the option to favorite/unfavorite it, but this will not be reflected in the UI (it will not be added/removed from the favorites list).

## Suggested behavior
Fix the behavior defined above. Additionally, if a table that contains views is favorited, its views will then not display a favorite/unfavorite button until the table is unfavorited. Any views which are already favorited but are also a part of the table will disappear from the favorite list as an individual view, and instead appear normally under the favorited table. This is done to prevent the view from showing in the favorites list twice.

## Recording

https://github.com/nextcloud/tables/assets/23369449/02a5f820-f888-44d7-8ff9-87d1a33a0b9d

## TODO
- [x] Determine if this behavior is appropriate
- [x] Address any design concerns
- [x] Implement testing