### PR TITLE
API endpoint to delete a context

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -132,6 +132,7 @@ return [
 		['name' => 'Context#show', 'url' => '/api/2/contexts/{contextId}', 'verb' => 'GET'],
 		['name' => 'Context#create', 'url' => '/api/2/contexts', 'verb' => 'POST'],
 		['name' => 'Context#update', 'url' => '/api/2/contexts/{contextId}', 'verb' => 'PUT'],
+		['name' => 'Context#destroy', 'url' => '/api/2/contexts/{contextId}', 'verb' => 'DELETE'],
 		['name' => 'Context#transfer', 'url' => '/api/2/contexts/{contextId}/transfer', 'verb' => 'PUT'],
 		['name' => 'Context#addNode', 'url' => '/api/2/contexts/{contextId}/nodes', 'verb' => 'POST'],
 		['name' => 'Context#removeNode', 'url' => '/api/2/contexts/{contextId}/nodes/{nodeRelId}', 'verb' => 'DELETE'],

--- a/lib/Controller/ContextController.php
+++ b/lib/Controller/ContextController.php
@@ -138,6 +138,29 @@ class ContextController extends AOCSController {
 	}
 
 	/**
+	 * [api v2] Delete an existing context and return it
+	 *
+	 * @param int $contextId ID of the context
+	 * @return DataResponse<Http::STATUS_OK, TablesContext, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 *
+	 * 200: returning the full context information
+	 * 403: No permissions
+	 * 404: Not found
+	 *
+	 * @NoAdminRequired
+	 * @CanManageContext
+	 */
+	public function destroy(int $contextId): DataResponse {
+		try {
+			return new DataResponse($this->contextService->delete($contextId, $this->userId)->jsonSerialize());
+		} catch (Exception $e) {
+			return $this->handleError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		}
+	}
+
+	/**
 	 * [api v2] Transfer the ownership of a context and return it
 	 *
 	 * @param int $contextId ID of the context

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -207,6 +207,15 @@ class ContextService {
 	}
 
 	/**
+	 * @throws NotFoundError
+	 * @throws Exception
+	 */
+	public function delete(int $contextId, string $userId): Context {
+		$context = $this->contextMapper->findById($contextId, $userId);
+		return $this->contextMapper->delete($context);
+	}
+
+	/**
 	 * @throws MultipleObjectsReturnedException
 	 * @throws DoesNotExistException
 	 * @throws Exception

--- a/openapi.json
+++ b/openapi.json
@@ -8475,6 +8475,151 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "operationId": "context-destroy",
+                "summary": "[api v2] Delete an existing context and return it",
+                "tags": [
+                    "context"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "contextId",
+                        "in": "path",
+                        "description": "ID of the context",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "returning the full context information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Context"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/ocs/v2.php/apps/tables/api/2/contexts/{contextId}/transfer": {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -205,6 +205,8 @@ export type paths = {
     get: operations["context-show"];
     /** [api v2] Update an existing context and return it */
     put: operations["context-update"];
+    /** [api v2] Delete an existing context and return it */
+    delete: operations["context-destroy"];
   };
   "/ocs/v2.php/apps/tables/api/2/contexts/{contextId}/transfer": {
     /** [api v2] Transfer the ownership of a context and return it */
@@ -3116,6 +3118,57 @@ export type operations = {
         /** @description provide this parameter to set a new list of nodes. */
         nodes?: string | null;
       };
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        /** @description ID of the context */
+        contextId: number;
+      };
+    };
+    responses: {
+      /** @description returning the full context information */
+      200: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: components["schemas"]["Context"];
+            };
+          };
+        };
+      };
+      /** @description Not found */
+      404: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+      500: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  /** [api v2] Delete an existing context and return it */
+  "context-destroy": {
+    parameters: {
       header: {
         /** @description Required to be true for the API request to pass */
         "OCS-APIRequest": boolean;


### PR DESCRIPTION
This could also be useful btw :sweat_smile: 

contributes to #311 

Example call: `curl --silent -X DELETE -H "OCS-APIRequest: true" -u alice:password 'https://example.com/ocs/v2.php/apps/tables/api/2/contexts/12?format=json'`