### PR TITLE
fix: reintroduce content reference provider

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,6 +9,7 @@ use OCA\Tables\Listener\AnalyticsDatasourceListener;
 use OCA\Tables\Listener\LoadAdditionalListener;
 use OCA\Tables\Listener\TablesReferenceListener;
 use OCA\Tables\Listener\UserDeletedListener;
+use OCA\Tables\Reference\ContentReferenceProvider;
 use OCA\Tables\Reference\ReferenceProvider;
 use OCA\Tables\Search\SearchTablesProvider;
 use OCP\AppFramework\App;
@@ -46,6 +47,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSearchProvider(SearchTablesProvider::class);
 
 		$context->registerReferenceProvider(ReferenceProvider::class);
+		$context->registerReferenceProvider(ContentReferenceProvider::class);
 
 		$context->registerCapability(Capabilities::class);
 	}


### PR DESCRIPTION
The ContentReferenceProvider was erroneously removed from Application.php, so this solution will re-add it so that content widgets will work again.