### PR TITLE
fix(api): ContextMapper now coerces the row ID to an int for proper comparison

### DIFF
--- a/lib/Db/ContextMapper.php
+++ b/lib/Db/ContextMapper.php
@@ -152,7 +152,7 @@ class ContextMapper extends QBMapper {
 		foreach ($contextIds as $contextId) {
 			$workArray = [];
 			foreach ($r as $row) {
-				if ($row['id'] === $contextId) {
+				if ((int) $row['id'] === $contextId) {
 					$workArray[] = $row;
 				}
 			}
@@ -188,7 +188,7 @@ class ContextMapper extends QBMapper {
 		foreach ($contextIds as $contextId) {
 			$workArray = [];
 			foreach ($r as $row) {
-				if ($row['id'] === $contextId) {
+				if ((int) $row['id'] === $contextId) {
 					$workArray[] = $row;
 				}
 			}


### PR DESCRIPTION
### Overview
I've been having an issue where, after I add a Context and try to re-fetch all Contexts from `/ocs/v2.php/apps/tables/api/2/contexts/`, the response returned by the API is a `Context[]` as expected, but the values are all `null`.

<details>
<summary>Example from before fix</summary>

```json
{
    "data": [
        {
            "id": null,
            "name": null,
            "iconName": null,
	    "description": null,
	    "owner": null,
	    "ownerType": null,
	    "sharing": [],
	    "nodes": [],
	    "pages": []
        }
    ]
}
```
</details>

This issue was preventing me from properly reviewing pull requests, so I decided to look into it. The problem was found in `ContextMapper.php`, where the row IDs were of type `string`, and the context ID variable held `int`s. They were being compared using `===` operator which, in addition to value, checks for type equivalence. `string` and `int` are not of the same type, so the comparison was failing, resulting in `null` values.

Upon further investigation and with help from @juliushaertl, it is thought that it is due to sqlite storing the id as a `string` by default. The solution here would be to cast the row ID to an `int` so that the strict comparison succeeds and to maintain compatibility with sqlite.