### PR TITLE
feat(Context): add share logic for contexts

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -33,6 +33,7 @@ return [
 		['name' => 'api1#createShare',	'url' => '/api/1/shares', 'verb' => 'POST'],
 		['name' => 'api1#deleteShare',	'url' => '/api/1/shares/{shareId}', 'verb' => 'DELETE'],
 		['name' => 'api1#updateSharePermissions',	'url' => '/api/1/shares/{shareId}', 'verb' => 'PUT'],
+		['name' => 'api1#updateShareDisplayMode',	'url' => '/api/1/shares/{shareId}/display-mode', 'verb' => 'PUT'],
 		['name' => 'api1#createTableShare',	'url' => '/api/1/tables/{tableId}/shares', 'verb' => 'POST'],
 		// -> columns
 		['name' => 'api1#indexTableColumns',	'url' => '/api/1/tables/{tableId}/columns', 'verb' => 'GET'],
@@ -97,6 +98,7 @@ return [
 		['name' => 'share#show', 'url' => '/share/{id}', 'verb' => 'GET'],
 		['name' => 'share#create', 'url' => '/share', 'verb' => 'POST'],
 		['name' => 'share#updatePermission', 'url' => '/share/{id}/permission', 'verb' => 'PUT'],
+		['name' => 'share#updateDisplayMode', 'url' => '/share/{id}/display-mode', 'verb' => 'PUT'],
 		['name' => 'share#destroy', 'url' => '/share/{id}', 'verb' => 'DELETE'],
 
 		// import

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -61,9 +61,20 @@ class ShareController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function create(int $nodeId, string $nodeType, string $receiver, string $receiverType, bool $permissionRead = false, bool $permissionCreate = false, bool $permissionUpdate = false, bool $permissionDelete = false, bool $permissionManage = false): DataResponse {
-		return $this->handleError(function () use ($nodeId, $nodeType, $receiver, $receiverType, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete, $permissionManage) {
-			return $this->service->create($nodeId, $nodeType, $receiver, $receiverType, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete, $permissionManage);
+	public function create(
+		int $nodeId,
+		string $nodeType,
+		string $receiver,
+		string $receiverType,
+		bool $permissionRead = false,
+		bool $permissionCreate = false,
+		bool $permissionUpdate = false,
+		bool $permissionDelete = false,
+		bool $permissionManage = false,
+		int $displayMode = 0,
+	): DataResponse {
+		return $this->handleError(function () use ($nodeId, $nodeType, $receiver, $receiverType, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete, $permissionManage, $displayMode) {
+			return $this->service->create($nodeId, $nodeType, $receiver, $receiverType, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete, $permissionManage, $displayMode);
 		});
 	}
 
@@ -73,6 +84,25 @@ class ShareController extends Controller {
 	public function updatePermission(int $id, string $permission, bool $value): DataResponse {
 		return $this->handleError(function () use ($id, $permission, $value) {
 			return $this->service->updatePermission($id, $permission, $value);
+		});
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @psalm-param int<0, 2> $displayMode
+	 * @psalm-param ("default"|"self") $target
+	 */
+	public function updateDisplayMode(int $id, int $displayMode, string $target = 'default') {
+		return $this->handleError(function () use ($id, $displayMode, $target) {
+			if ($target === 'default') {
+				$userId = '';
+			} elseif ($target === 'self') {
+				$userId = $this->userId;
+			} else {
+				throw new \InvalidArgumentException('target parameter must be either "default" or "self"');
+			}
+
+			return $this->service->updateDisplayMode($id, $displayMode, $userId);
 		});
 	}
 

--- a/lib/Db/ContextMapper.php
+++ b/lib/Db/ContextMapper.php
@@ -6,6 +6,7 @@ namespace OCA\Tables\Db;
 
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Errors\NotFoundError;
+use OCA\Tables\Helper\GroupHelper;
 use OCA\Tables\Helper\UserHelper;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\Exception;
@@ -15,10 +16,8 @@ use OCP\IDBConnection;
 /** @template-extends QBMapper<Context> */
 class ContextMapper extends QBMapper {
 	protected string $table = 'tables_contexts_context';
-	private UserHelper $userHelper;
 
-	public function __construct(IDBConnection $db, UserHelper $userHelper) {
-		$this->userHelper = $userHelper;
+	public function __construct(IDBConnection $db, protected UserHelper $userHelper, protected GroupHelper $groupHelper) {
 		parent::__construct($db, $this->table, Context::class);
 	}
 
@@ -86,6 +85,11 @@ class ContextMapper extends QBMapper {
 				'share_id' => (int)$item['share_id'],
 				'receiver' => $item['receiver'],
 				'receiver_type' => $item['receiver_type'],
+				'receiver_display_name' => match ($item['receiver_type']) {
+					'user' => $this->userHelper->getUserDisplayName($item['receiver']),
+					'group' => $this->groupHelper->getGroupDisplayName($item['receiver']),
+					default => $item['receiver'],
+				},
 				'display_mode_default' => (int)$item['display_mode_default'],
 			];
 			if ($userId !== null) {

--- a/lib/Db/ContextMapper.php
+++ b/lib/Db/ContextMapper.php
@@ -253,6 +253,10 @@ class ContextMapper extends QBMapper {
 	protected function applyOwnedOrSharedQuery(IQueryBuilder $qb, string $userId): void {
 		$sharedToConditions = $qb->expr()->orX();
 
+		// shared by user clause
+		$userInitiatedShare = $qb->expr()->eq('s.sender', $qb->createNamedParameter($userId));
+		$sharedToConditions->add($userInitiatedShare);
+
 		// shared to user clause
 		$userShare = $qb->expr()->andX(
 			$qb->expr()->eq('s.receiver_type', $qb->createNamedParameter('user')),

--- a/lib/Db/ContextNavigation.php
+++ b/lib/Db/ContextNavigation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method getShareId(): int
+ * @method setShareId(int $value): void
+ * @method getUserId(): string
+ * @method setUserId(string $value): void
+ * @method getDisplayMode(): int
+ * @method setDisplayMode(int $value): void
+ */
+class ContextNavigation extends Entity implements \JsonSerializable {
+	protected ?int $shareId = null;
+	protected ?string $userId = null;
+	protected ?int $displayMode = null;
+
+	public function __construct() {
+		$this->addType('shareId', 'integer');
+		$this->addType('displayMode', 'integer');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'shareId' => $this->getShareId(),
+			'displayMode' => $this->getDisplayMode(),
+			'userId' => $this->getUserId(),
+		];
+	}
+}

--- a/lib/Db/ContextNavigationMapper.php
+++ b/lib/Db/ContextNavigationMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/** @template-extends QBMapper<ContextNavigation> */
+class ContextNavigationMapper extends QBMapper {
+	protected string $table = 'tables_contexts_navigation';
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, $this->table, ContextNavigation::class);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function deleteByShareId(int $shareId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->table)
+			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($shareId, IQueryBuilder::PARAM_INT)));
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function setDisplayModeByShareId(int $shareId, int $displayMode, string $userId): ContextNavigation {
+		$entity = new ContextNavigation();
+		$entity->setShareId($shareId);
+		$entity->setDisplayMode($displayMode);
+		$entity->setUserId($userId);
+
+		return $this->insertOrUpdate($entity);
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -137,6 +137,13 @@ namespace OCA\Tables;
  *   owner: string,
  *   ownerType: int,
  * }
+ *
+ * @psalm-type TablesContextNavigation = array{
+ *     id: int,
+ *     shareId: int,
+ *     displayMode: int,
+ *     userId: string,
+ * }
  */
 class ResponseDefinitions {
 }

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -160,8 +160,15 @@ class ContextService {
 			foreach ($nodes as $node) {
 				$key = sprintf('t%di%d', $node['type'], $node['id']);
 				if (isset($oldNodeResolvableIdMapper[$key])) {
-					unset($oldNodeResolvableIdMapper[$key]);
 					$nodesBeingKept[$key] = $node;
+					if ($node['permissions'] !== $currentNodes[$oldNodeResolvableIdMapper[$key]]['permissions']) {
+						$nodeRel = $this->contextNodeRelMapper->findById($currentNodes[$oldNodeResolvableIdMapper[$key]]['id']);
+						$nodeRel->setPermissions($node['permissions']);
+						$this->contextNodeRelMapper->update($nodeRel);
+						$currentNodes[$oldNodeResolvableIdMapper[$key]]['permissions'] = $nodeRel->getPermissions();
+						$hasUpdatedNodeInformation = true;
+					}
+					unset($oldNodeResolvableIdMapper[$key]);
 					continue;
 				}
 				$nodesBeingAdded[$key] = $node;
@@ -172,7 +179,7 @@ class ContextService {
 			}
 			unset($nodesBeingKept);
 
-			$hasUpdatedNodeInformation = !empty($nodesBeingAdded) || !empty($nodesBeingRemoved);
+			$hasUpdatedNodeInformation = $hasUpdatedNodeInformation || !empty($nodesBeingAdded) || !empty($nodesBeingRemoved);
 
 			foreach ($nodesBeingRemoved as $node) {
 				/** @var ContextNodeRelation $removedNode */
@@ -203,10 +210,11 @@ class ContextService {
 		}
 
 		$context = $this->contextMapper->update($context);
-		if ($hasUpdatedNodeInformation && isset($currentNodes) && isset($currentPages)) {
+		if (isset($currentNodes, $currentPages) && $hasUpdatedNodeInformation) {
 			$context->setNodes($currentNodes);
 			$context->setPages($currentPages);
 		}
+
 		return $context;
 	}
 

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -422,7 +422,7 @@ class ContextService {
 				if (!$this->permissionsService->canManageNodeById($node['type'], $node['id'], $userId)) {
 					throw new PermissionError(sprintf('Owner cannot manage node %d (type %d)', $node['id'], $node['type']));
 				}
-				$contextNodeRel = $this->addNodeToContext($context, $node['id'], $node['type'], $node['permissions'] ?? 660);
+				$contextNodeRel = $this->addNodeToContext($context, $node['id'], $node['type'], $node['permissions'] ?? 0);
 				$addedNodes[] = $contextNodeRel->jsonSerialize();
 			} catch (Exception $e) {
 				$this->logger->warning('Could not add node {ntype}/{nid} to context {cid}, skipping.', [

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -164,6 +164,14 @@ class PermissionsService {
 		}
 	}
 
+		try {
+			$this->contextMapper->findById($contextId, $userId ?? $this->userId);
+			return true;
+		} catch (NotFoundError $e) {
+			return false;
+		}
+	}
+
 	public function canAccessView(View $view, ?string $userId = null): bool {
 		return $this->canAccessNodeById(Application::NODE_TYPE_VIEW, $view->getId(), $userId);
 	}

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -151,7 +151,6 @@ class PermissionsService {
 		}
 
 		return $context->getOwnerId() === $userId || $this->canManageContext($context, $userId);
-		;
 	}
 
 	/**

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -166,14 +166,6 @@ class PermissionsService {
 		}
 	}
 
-		try {
-			$this->contextMapper->findById($contextId, $userId ?? $this->userId);
-			return true;
-		} catch (NotFoundError $e) {
-			return false;
-		}
-	}
-
 	public function canAccessView(View $view, ?string $userId = null): bool {
 		return $this->canAccessNodeById(Application::NODE_TYPE_VIEW, $view->getId(), $userId);
 	}

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -152,6 +152,18 @@ class PermissionsService {
 		return $context->getOwnerId() === $userId;
 	}
 
+	/**
+	 * @throws Exception
+	 */
+	public function canAccessContextById(int $contextId, ?string $userId = null): bool {
+		try {
+			$this->contextMapper->findById($contextId, $userId ?? $this->userId);
+			return true;
+		} catch (NotFoundError $e) {
+			return false;
+		}
+	}
+
 	public function canAccessView(View $view, ?string $userId = null): bool {
 		return $this->canAccessNodeById(Application::NODE_TYPE_VIEW, $view->getId(), $userId);
 	}

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -523,13 +523,13 @@ class PermissionsService {
 	}
 
 	/**
-	 * @param mixed $element
-	 * @param 'table'|'view' $nodeType
+	 * @param Table|View|Context $element
+	 * @param 'table'|'view'|'context' $nodeType
 	 * @param string $permission
 	 * @param string|null $userId
 	 * @return bool
 	 */
-	private function checkPermission($element, string $nodeType, string $permission, ?string $userId = null): bool {
+	private function checkPermission(Table|View|Context $element, string $nodeType, string $permission, ?string $userId = null): bool {
 		if($this->basisCheck($element, $nodeType, $userId)) {
 			return true;
 		}
@@ -542,7 +542,9 @@ class PermissionsService {
 			return $this->getSharedPermissionsIfSharedWithMe($element->getId(), $nodeType, $userId)[$permission];
 		} catch (NotFoundError $e) {
 			try {
-				if ($this->hasPermission($this->getPermissionIfAvailableThroughContext($element->getId(), $nodeType, $userId), $permission)) {
+				if ($nodeType !== 'context'
+					&& $this->hasPermission($this->getPermissionIfAvailableThroughContext($element->getId(), $nodeType, $userId), $permission)
+				) {
 					return true;
 				}
 			} catch (NotFoundError $e) {
@@ -580,13 +582,7 @@ class PermissionsService {
 		return false;
 	}
 
-	/**
-	 * @param Table|View|Context $element
-	 * @param string $nodeType
-	 * @param string|null $userId
-	 * @return bool
-	 */
-	private function basisCheck($element, string $nodeType, ?string &$userId): bool {
+	private function basisCheck(Table|View|Context $element, string $nodeType, ?string &$userId): bool {
 		try {
 			$userId = $this->preCheckUserId($userId);
 		} catch (InternalError $e) {

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -44,6 +44,7 @@ class TableService extends SuperService {
 
 
 	protected IL10N $l;
+	private ContextService $contextService;
 
 	protected IEventDispatcher $eventDispatcher;
 
@@ -59,8 +60,9 @@ class TableService extends SuperService {
 		ShareService $shareService,
 		UserHelper $userHelper,
 		FavoritesService $favoritesService,
+		IEventDispatcher $eventDispatcher,
+		ContextService $contextService,
 		IL10N $l,
-		IEventDispatcher $eventDispatcher
 	) {
 		parent::__construct($logger, $userId, $permissionsService);
 		$this->mapper = $mapper;
@@ -73,6 +75,7 @@ class TableService extends SuperService {
 		$this->favoritesService = $favoritesService;
 		$this->l = $l;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->contextService = $contextService;
 	}
 
 	/**
@@ -91,9 +94,13 @@ class TableService extends SuperService {
 	public function findAll(?string $userId = null, bool $skipTableEnhancement = false, bool $skipSharedTables = false, bool $createTutorial = true): array {
 		/** @var string $userId */
 		$userId = $this->permissionsService->preCheckUserId($userId); // $userId can be set or ''
+		$allTables = [];
 
 		try {
-			$allTables = $this->mapper->findAll($userId); // get own tables
+			$ownedTables = $this->mapper->findAll($userId); // get own tables
+			foreach ($ownedTables as $ownedTable) {
+				$allTables[$ownedTable->getId()] = $ownedTable;
+			}
 		} catch (OcpDbException $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError($e->getMessage());
@@ -102,7 +109,8 @@ class TableService extends SuperService {
 		// if there are no own tables found, create the tutorial table
 		if (count($allTables) === 0 && $createTutorial) {
 			try {
-				$allTables = [$this->create($this->l->t('Tutorial'), 'tutorial', '🚀')];
+				$tutorialTable = $this->create($this->l->t('Tutorial'), 'tutorial', '🚀');
+				$allTables = [$tutorialTable->getId() => $tutorialTable];
 			} catch (InternalError|PermissionError|DoesNotExistException|MultipleObjectsReturnedException|OcpDbException $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
 				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
@@ -114,16 +122,22 @@ class TableService extends SuperService {
 
 			// clean duplicates
 			foreach ($sharedTables as $sharedTable) {
-				$found = false;
-				foreach ($allTables as $table) {
-					if ($sharedTable->getId() === $table->getId()) {
-						$found = true;
-						break;
-					}
+				if (isset($allTables[$sharedTable->getId()])) {
+					$allTables[$sharedTable->getId()] = $sharedTable;
 				}
-				if (!$found) {
-					$allTables[] = $sharedTable;
+			}
+		}
+
+		$contexts = $this->contextService->findAll($userId);
+		foreach ($contexts as $context) {
+			$nodes = $context->getNodes();
+			foreach ($nodes as $node) {
+				if ($node['node_type'] !== Application::NODE_TYPE_TABLE
+					|| isset($allTables[$node['node_id']])
+				) {
+					continue;
 				}
+				$allTables[$node['node_id']] = $this->find($node['node_id'], $skipTableEnhancement, $userId);
 			}
 		}
 
@@ -144,8 +158,7 @@ class TableService extends SuperService {
 			}
 		}
 
-
-		return $allTables;
+		return array_values($allTables);
 	}
 
 	/**

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -110,7 +110,7 @@ class TableService extends SuperService {
 		if (count($allTables) === 0 && $createTutorial) {
 			try {
 				$tutorialTable = $this->create($this->l->t('Tutorial'), 'tutorial', '🚀');
-				$allTables = [$tutorialTable->getId() => $tutorialTable];
+				$allTables[$tutorialTable->getId()] = $tutorialTable;
 			} catch (InternalError|PermissionError|DoesNotExistException|MultipleObjectsReturnedException|OcpDbException $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
 				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -122,7 +122,7 @@ class TableService extends SuperService {
 
 			// clean duplicates
 			foreach ($sharedTables as $sharedTable) {
-				if (isset($allTables[$sharedTable->getId()])) {
+				if (!isset($allTables[$sharedTable->getId()])) {
 					$allTables[$sharedTable->getId()] = $sharedTable;
 				}
 			}

--- a/openapi.json
+++ b/openapi.json
@@ -208,6 +208,32 @@
                     }
                 }
             },
+            "ContextNavigation": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "shareId",
+                    "displayMode",
+                    "userId"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "shareId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "displayMode": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "userId": {
+                        "type": "string"
+                    }
+                }
+            },
             "ImportState": {
                 "type": "object",
                 "required": [
@@ -2434,6 +2460,16 @@
                                 1
                             ]
                         }
+                    },
+                    {
+                        "name": "displayMode",
+                        "in": "query",
+                        "description": "context shares only, whether it should appear in nav bar. 0: no, 1: recipients, 2: all",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "default": 0
+                        }
                     }
                 ],
                 "responses": {
@@ -2485,6 +2521,141 @@
                     },
                     "404": {
                         "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/tables/api/1/shares/{shareId}/display-mode": {
+            "put": {
+                "operationId": "api1-update-share-display-mode",
+                "summary": "Updates the display mode of a context share",
+                "tags": [
+                    "api1"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "displayMode",
+                        "in": "query",
+                        "description": "The new value for the display mode of the nav bar icon. 0: hidden, 1: visible for recipients, 2: visible for all",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0,
+                            "maximum": 2
+                        }
+                    },
+                    {
+                        "name": "target",
+                        "in": "query",
+                        "description": "\"default\" to set the default, \"self\" to set an override for the authenticated user",
+                        "schema": {
+                            "type": "string",
+                            "default": "default",
+                            "enum": [
+                                "default",
+                                "self"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "shareId",
+                        "in": "path",
+                        "description": "Share ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Display mode updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ContextNavigation"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Share not found",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/modules/modals/CreateContext.vue
+++ b/src/modules/modals/CreateContext.vue
@@ -39,8 +39,8 @@
 				</div>
 				<NcContextResource :resources.sync="resources" :receivers.sync="receivers" />
 			</div>
-			<div class="row space-R">
-				<div class="fix-col-4 end space-T">
+			<div class="row space-R row space-T">
+				<div class="fix-col-4 end">
 					<NcButton type="primary" :aria-label="t('tables', 'Create application')" @click="submit">
 						{{ t('tables', 'Create application') }}
 					</NcButton>
@@ -57,7 +57,7 @@ import '@nextcloud/dialogs/dist/index.css'
 import NcContextResource from '../../shared/components/ncContextResource/NcContextResource.vue'
 import NcIconPicker from '../../shared/components/ncIconPicker/NcIconPicker.vue'
 import svgHelper from '../../shared/components/ncIconPicker/mixins/svgHelper.js'
-import { PERMISSION_READ, PERMISSION_CREATE, PERMISSION_UPDATE, PERMISSION_DELETE } from '../../shared/constants.js'
+import permissionBitmask from '../../shared/components/ncContextResource/mixins/permissionBitmask.js'
 
 export default {
 	name: 'CreateContext',
@@ -68,7 +68,7 @@ export default {
 		NcIconSvgWrapper,
 		NcContextResource,
 	},
-	mixins: [svgHelper],
+	mixins: [svgHelper, permissionBitmask],
 	props: {
 		showModal: {
 			type: Boolean,
@@ -88,10 +88,6 @@ export default {
 			description: '',
 			resources: [],
 			receivers: [],
-			PERMISSION_READ,
-			PERMISSION_CREATE,
-			PERMISSION_UPDATE,
-			PERMISSION_DELETE,
 		}
 	},
 	watch: {
@@ -140,20 +136,12 @@ export default {
 			const iconNames = ['alarm', 'apps', 'bank', 'bell', 'book', 'briefcase', 'camera', 'cellphone', 'earth', 'equalizer', 'file', 'football', 'heart', 'home', 'laptop', 'lightbulb', 'lock', 'movie', 'newspaper', 'rocket', 'star']
 			return iconNames[~~(Math.random() * iconNames.length)]
 		},
-		getPermissionBitmaskFromBools(permissionRead, permissionCreate, permissionUpdate, permissionDelete) {
-			const read = permissionRead ? PERMISSION_READ : 0
-			const create = permissionCreate ? PERMISSION_CREATE : 0
-			const update = permissionUpdate ? PERMISSION_UPDATE : 0
-			const del = permissionDelete ? PERMISSION_DELETE : 0
-			return read | create | update | del
-		},
 		async sendNewContextToBE() {
 			const dataResources = this.resources.map(resource => {
 				return {
 					id: parseInt(resource.id),
 					type: parseInt(resource.nodeType),
-					// TODO get right permissions for the node
-					permissions: this.getPermissionBitmaskFromBools(true /* ensure permission is always true */, resource.permissionCreate, resource.permissionUpdate, resource.permissionDelete),
+					permissions: this.getPermissionBitmaskFromBools(true /* ensure read permission is always true */, resource.permissionCreate, resource.permissionUpdate, resource.permissionDelete),
 				}
 			})
 			const data = {

--- a/src/modules/modals/CreateContext.vue
+++ b/src/modules/modals/CreateContext.vue
@@ -57,6 +57,7 @@ import '@nextcloud/dialogs/dist/index.css'
 import NcContextResource from '../../shared/components/ncContextResource/NcContextResource.vue'
 import NcIconPicker from '../../shared/components/ncIconPicker/NcIconPicker.vue'
 import svgHelper from '../../shared/components/ncIconPicker/mixins/svgHelper.js'
+import { PERMISSION_READ, PERMISSION_CREATE, PERMISSION_UPDATE, PERMISSION_DELETE } from '../../shared/constants.js'
 
 export default {
 	name: 'CreateContext',
@@ -87,6 +88,10 @@ export default {
 			description: '',
 			resources: [],
 			receivers: [],
+			PERMISSION_READ,
+			PERMISSION_CREATE,
+			PERMISSION_UPDATE,
+			PERMISSION_DELETE,
 		}
 	},
 	watch: {
@@ -135,13 +140,20 @@ export default {
 			const iconNames = ['alarm', 'apps', 'bank', 'bell', 'book', 'briefcase', 'camera', 'cellphone', 'earth', 'equalizer', 'file', 'football', 'heart', 'home', 'laptop', 'lightbulb', 'lock', 'movie', 'newspaper', 'rocket', 'star']
 			return iconNames[~~(Math.random() * iconNames.length)]
 		},
+		getPermissionBitmaskFromBools(permissionRead, permissionCreate, permissionUpdate, permissionDelete) {
+			const read = permissionRead ? PERMISSION_READ : 0
+			const create = permissionCreate ? PERMISSION_CREATE : 0
+			const update = permissionUpdate ? PERMISSION_UPDATE : 0
+			const del = permissionDelete ? PERMISSION_DELETE : 0
+			return read | create | update | del
+		},
 		async sendNewContextToBE() {
 			const dataResources = this.resources.map(resource => {
 				return {
 					id: parseInt(resource.id),
 					type: parseInt(resource.nodeType),
 					// TODO get right permissions for the node
-					permissions: 660,
+					permissions: this.getPermissionBitmaskFromBools(true /* ensure permission is always true */, resource.permissionCreate, resource.permissionUpdate, resource.permissionDelete),
 				}
 			})
 			const data = {

--- a/src/modules/modals/CreateContext.vue
+++ b/src/modules/modals/CreateContext.vue
@@ -37,7 +37,7 @@
 				<div class="col-4">
 					{{ t('tables', 'Resources') }}
 				</div>
-				<NcContextResource :resources.sync="resources" />
+				<NcContextResource :resources.sync="resources" :receivers.sync="receivers" />
 			</div>
 			<div class="row space-R">
 				<div class="fix-col-4 end space-T">
@@ -86,6 +86,7 @@ export default {
 			errorTitle: false,
 			description: '',
 			resources: [],
+			receivers: [],
 		}
 	},
 	watch: {
@@ -139,6 +140,7 @@ export default {
 				return {
 					id: parseInt(resource.id),
 					type: parseInt(resource.nodeType),
+					// TODO get right permissions for the node
 					permissions: 660,
 				}
 			})
@@ -148,7 +150,7 @@ export default {
 				description: this.description,
 				nodes: dataResources,
 			}
-			const res = await this.$store.dispatch('insertNewContext', { data })
+			const res = await this.$store.dispatch('insertNewContext', { data, previousReceivers: [], receivers: this.receivers })
 			if (res) {
 				return res.id
 			} else {

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -110,8 +110,8 @@ export default {
 				this.title = context.name
 				this.setIcon(this.localContext.iconName)
 				this.description = context.description
-				this.resources = context ? [...this.getContextResources(context)] : []
-				this.receivers = context && context?.sharing ? [...context.sharing] : []
+				this.resources = context ? this.getContextResources(context) : []
+				this.receivers = context ? this.getContextReceivers(context) : []
 			}
 		},
 	},
@@ -144,8 +144,9 @@ export default {
 					description: this.description,
 					nodes: dataResources,
 				}
+				const context = this.getContext(this.contextId)
 
-				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data, receivers: this.receivers })
+				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data, previousReceivers: Object.values(context.sharing), receivers: this.receivers })
 				if (res) {
 					showSuccess(t('tables', 'Updated context "{contextTitle}".', { contextTitle: this.title }))
 					this.actionCancel()
@@ -158,8 +159,21 @@ export default {
 			this.errorTitle = false
 			this.icon.name = 'equalizer'
 			this.description = ''
-			this.resources = context ? [...this.getContextResources(context)] : []
-			this.receivers = context && context?.sharing ? [...context.sharing] : []
+			this.resources = context ? this.getContextResources(context) : []
+			this.receivers = context ? this.getContextReceivers(context) : []
+		},
+		getContextReceivers(context) {
+			const sharing = Object.values(context.sharing)
+			const receivers = sharing.map((share) => {
+				return {
+					user: share.receiver,
+					displayName: share.receiver,
+					icon: 'icon-user',
+					isUser: share.receiver_type === 'user',
+					key: share.receiver_type + '-' + share.receiver,
+				}
+			})
+			return receivers
 		},
 		getContextResources(context) {
 			const resources = []

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -125,7 +125,7 @@ export default {
 			this.reset()
 			this.$emit('close')
 		},
-		// TODO show edited changes if we're currently viewing the active context
+		// TODO show edited changes without having to reload
 		async submit() {
 			if (this.title === '') {
 				showError(t('tables', 'Cannot update application. Title is missing.'))

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -12,11 +12,8 @@
 				</div>
 				<div class="col-4" style="display: inline-flex;">
 					<NcIconPicker :close-on-select="true" @select="setIcon">
-						<NcButton
-							type="tertiary"
-							:aria-label="t('tables', 'Select an icon for application')"
-							:title="t('tables', 'Select icon')"
-							@click.prevent>
+						<NcButton type="tertiary" :aria-label="t('tables', 'Select an icon for application')"
+							:title="t('tables', 'Select icon')" @click.prevent>
 							<template #icon>
 								<NcIconSvgWrapper :svg="icon.svg" />
 							</template>
@@ -36,7 +33,7 @@
 				<div class="col-4">
 					{{ t('tables', 'Resources') }}
 				</div>
-				<NcContextResource :resources.sync="resources" />
+				<NcContextResource :resources.sync="resources" :receivers.sync="receivers" />
 			</div>
 
 			<div class="row space-R">
@@ -90,6 +87,7 @@ export default {
 			description: '',
 			errorTitle: false,
 			resources: [],
+			receivers: [],
 		}
 	},
 	computed: {
@@ -113,6 +111,7 @@ export default {
 				this.setIcon(this.localContext.iconName)
 				this.description = context.description
 				this.resources = context ? [...this.getContextResources(context)] : []
+				this.receivers = context && context?.sharing ? [...context.sharing] : []
 			}
 		},
 	},
@@ -145,7 +144,14 @@ export default {
 					description: this.description,
 					nodes: dataResources,
 				}
-				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data })
+
+				const share = {
+					nodeType: 'context',
+					nodeId: this.contextId,
+					receiverType: 'user',
+					displayMode: 2,
+				}
+				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data, share, receivers: this.receivers })
 				if (res) {
 					showSuccess(t('tables', 'Updated context "{contextTitle}".', { contextTitle: this.title }))
 					this.actionCancel()
@@ -159,6 +165,7 @@ export default {
 			this.icon.name = 'equalizer'
 			this.description = ''
 			this.resources = context ? [...this.getContextResources(context)] : []
+			this.receivers = context && context?.sharing ? [...context.sharing] : []
 		},
 		getContextResources(context) {
 			const resources = []

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -173,7 +173,7 @@ export default {
 			const receivers = sharing.map((share) => {
 				return {
 					user: share.receiver,
-					displayName: share.receiver,
+					displayName: share.receiver_display_name,
 					icon: share.receiver_type === 'user' ? 'icon-user' : 'icon-group',
 					isUser: share.receiver_type === 'user',
 					key: share.receiver_type + '-' + share.receiver,

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -36,8 +36,8 @@
 				<NcContextResource :resources.sync="resources" :receivers.sync="receivers" />
 			</div>
 
-			<div class="row space-R">
-				<div class="fix-col-4 end space-T">
+			<div class="row space-R row space-T">
+				<div class="fix-col-4 end">
 					<NcButton type="primary" @click="submit">
 						{{ t('tables', 'Save') }}
 					</NcButton>
@@ -50,12 +50,14 @@
 <script>
 import { NcModal, NcButton, NcIconSvgWrapper } from '@nextcloud/vue'
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { getCurrentUser } from '@nextcloud/auth'
 import '@nextcloud/dialogs/dist/index.css'
 import { mapGetters, mapState } from 'vuex'
 import NcContextResource from '../../shared/components/ncContextResource/NcContextResource.vue'
 import NcIconPicker from '../../shared/components/ncIconPicker/NcIconPicker.vue'
 import { NODE_TYPE_TABLE, NODE_TYPE_VIEW, PERMISSION_READ, PERMISSION_CREATE, PERMISSION_UPDATE, PERMISSION_DELETE } from '../../shared/constants.js'
 import svgHelper from '../../shared/components/ncIconPicker/mixins/svgHelper.js'
+import permissionBitmask from '../../shared/components/ncContextResource/mixins/permissionBitmask.js'
 
 export default {
 	name: 'EditContext',
@@ -66,7 +68,7 @@ export default {
 		NcIconSvgWrapper,
 		NcContextResource,
 	},
-	mixins: [svgHelper],
+	mixins: [svgHelper, permissionBitmask],
 	props: {
 		showModal: {
 			type: Boolean,
@@ -92,6 +94,7 @@ export default {
 			PERMISSION_CREATE,
 			PERMISSION_UPDATE,
 			PERMISSION_DELETE,
+
 		}
 	},
 	computed: {
@@ -128,7 +131,6 @@ export default {
 			this.reset()
 			this.$emit('close')
 		},
-		// TODO show edited changes without having to reload
 		async submit() {
 			if (this.title === '') {
 				showError(t('tables', 'Cannot update application. Title is missing.'))
@@ -138,8 +140,7 @@ export default {
 					return {
 						id: parseInt(resource.id),
 						type: parseInt(resource.nodeType),
-						// TODO get right permissions for the node
-						permissions: this.getPermissionBitmaskFromBools(true /* ensure permission is always true */, resource.permissionCreate, resource.permissionUpdate, resource.permissionDelete),
+						permissions: this.getPermissionBitmaskFromBools(true /* ensure read permission is always true */, resource.permissionCreate, resource.permissionUpdate, resource.permissionDelete),
 					}
 				})
 				const data = {
@@ -167,25 +168,18 @@ export default {
 			this.receivers = context ? this.getContextReceivers(context) : []
 		},
 		getContextReceivers(context) {
-			const sharing = Object.values(context.sharing)
+			let sharing = Object.values(context.sharing)
+			sharing = sharing.filter((share) => getCurrentUser().uid !== share.receiver)
 			const receivers = sharing.map((share) => {
 				return {
 					user: share.receiver,
 					displayName: share.receiver,
-					icon: 'icon-user',
+					icon: share.receiver_type === 'user' ? 'icon-user' : 'icon-group',
 					isUser: share.receiver_type === 'user',
 					key: share.receiver_type + '-' + share.receiver,
 				}
 			})
 			return receivers
-		},
-		// TODO use mixin or similar for reusability
-		getPermissionBitmaskFromBools(permissionRead, permissionCreate, permissionUpdate, permissionDelete) {
-			const read = permissionRead ? PERMISSION_READ : 0
-			const create = permissionCreate ? PERMISSION_CREATE : 0
-			const update = permissionUpdate ? PERMISSION_UPDATE : 0
-			const del = permissionDelete ? PERMISSION_DELETE : 0
-			return read | create | update | del
 		},
 		getPermissionFromBitmask(bitmask, permission) {
 			return !!(bitmask & permission)

--- a/src/modules/modals/EditContext.vue
+++ b/src/modules/modals/EditContext.vue
@@ -145,13 +145,7 @@ export default {
 					nodes: dataResources,
 				}
 
-				const share = {
-					nodeType: 'context',
-					nodeId: this.contextId,
-					receiverType: 'user',
-					displayMode: 2,
-				}
-				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data, share, receivers: this.receivers })
+				const res = await this.$store.dispatch('updateContext', { id: this.contextId, data, receivers: this.receivers })
 				if (res) {
 					showSuccess(t('tables', 'Updated context "{contextTitle}".', { contextTitle: this.title }))
 					this.actionCancel()

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -108,7 +108,8 @@ export default {
 	},
 
 	watch: {
-		async activeContextId() {
+		// Watch for changes to active context to make page reactive
+		async activeContext() {
 			if (this.activeContextId && !this.activeContext) {
 				// context does not exists, go to startpage
 				this.$router.push('/').catch(err => err)

--- a/src/shared/components/ncContextResource/NcContextResource.vue
+++ b/src/shared/components/ncContextResource/NcContextResource.vue
@@ -1,10 +1,10 @@
 <template>
 	<div>
 		<div>
-			<ResourceForm :resources="localResource" @add="addResource" />
-			<ResourceList :resources="localResource" @remove="removeResource" />
+			<ResourceForm :resources="localResources" @add="addResource" />
+			<ResourceList :resources="localResources" @remove="removeResource" />
 			<ResourceSharees :select-users="true" :select-groups="false" :receivers="localReceivers" @update="updateReceivers" />
-			<ResourceSharePermissions :resources="localResource" />
+			<ResourceSharePermissions :resources="localResources" @update="updateResourcePermissions" />
 		</div>
 	</div>
 </template>
@@ -44,16 +44,16 @@ export default {
 	data() {
 		return {
 			loading: false,
-			contextResource: this.resources,
+			contextResources: this.resources,
 			contextReceivers: this.receivers,
 		}
 	},
 
 	computed: {
 		...mapGetters(['activeContext']),
-		localResource: {
+		localResources: {
 			get() {
-				return this.contextResource
+				return this.contextResources
 			},
 			set(v) {
 				this.$emit('update:resources', v)
@@ -71,15 +71,21 @@ export default {
 
 	methods: {
 		removeResource(resource) {
-			this.contextResource = this.contextResource.filter(r => r.key !== resource.key)
-			this.localResource = this.contextResource
+			this.contextResources = this.contextResources.filter(r => r.key !== resource.key)
+			this.localResources = this.contextResources
 		},
 		addResource(resource) {
-			this.contextResource.push(resource)
-			this.localResource = this.contextResource
+			this.contextResources.push(resource)
+			this.localResources = this.contextResources
 		},
 		updateReceivers(receivers) {
 			this.localReceivers = receivers
+		},
+		updateResourcePermissions({ resourceId, permission, value }) {
+			const resourceIndex = this.localResources.findIndex((resource) => resource.id === resourceId)
+			if (resourceIndex !== -1) {
+				this.localResources[resourceIndex][permission] = value
+			}
 		},
 
 	},

--- a/src/shared/components/ncContextResource/NcContextResource.vue
+++ b/src/shared/components/ncContextResource/NcContextResource.vue
@@ -3,6 +3,8 @@
 		<div>
 			<ResourceForm :resources="localResource" @add="addResource" />
 			<ResourceList :resources="localResource" @remove="removeResource" />
+			<ResourceSharees :select-users="true" :select-groups="false" :sharees.sync="sharees" />
+			<ResourceSharePermissions :resources="localResource" />
 		</div>
 	</div>
 </template>
@@ -11,11 +13,15 @@
 import { mapGetters } from 'vuex'
 import ResourceForm from './ResourceForm.vue'
 import ResourceList from './ResourceList.vue'
+import ResourceSharePermissions from './ResourceSharePermissions.vue'
+import ResourceSharees from './ResourceSharees.vue'
 
 export default {
 	components: {
 		ResourceForm,
 		ResourceList,
+		ResourceSharePermissions,
+		ResourceSharees,
 	},
 
 	props: {
@@ -26,6 +32,10 @@ export default {
 		},
 		// table or view
 		resources: {
+			type: Array,
+			default: () => ([]),
+		},
+		sharees: {
 			type: Array,
 			default: () => ([]),
 		},

--- a/src/shared/components/ncContextResource/NcContextResource.vue
+++ b/src/shared/components/ncContextResource/NcContextResource.vue
@@ -3,7 +3,7 @@
 		<div>
 			<ResourceForm :resources="localResource" @add="addResource" />
 			<ResourceList :resources="localResource" @remove="removeResource" />
-			<ResourceSharees :select-users="true" :select-groups="false" :sharees.sync="currentSharees" />
+			<ResourceSharees :select-users="true" :select-groups="false" :receivers="localReceivers" @update="updateReceivers" />
 			<ResourceSharePermissions :resources="localResource" />
 		</div>
 	</div>
@@ -35,7 +35,7 @@ export default {
 			type: Array,
 			default: () => ([]),
 		},
-		sharees: {
+		receivers: {
 			type: Array,
 			default: () => ([]),
 		},
@@ -45,22 +45,14 @@ export default {
 		return {
 			loading: false,
 			contextResource: this.resources,
-			// currentSharees: [...this.sharees],
-			currentSharees: [
-				{
-					user: 'user2',
-					displayName: 'user2',
-					icon: 'icon-user',
-					isUser: true,
-					key: 'users-user2',
-				},
-				{
-					user: 'user1',
-					displayName: 'user1',
-					icon: 'icon-user',
-					isUser: true,
-					key: 'users-user1',
-				},
+			contextReceivers: [
+				// {
+				// 	user: 'user2',
+				// 	displayName: 'user2',
+				// 	icon: 'icon-user',
+				// 	isUser: true,
+				// 	key: 'users-user2',
+				// },
 			],
 		}
 	},
@@ -75,6 +67,14 @@ export default {
 				this.$emit('update:resources', v)
 			},
 		},
+		localReceivers: {
+			get() {
+				return this.contextReceivers
+			},
+			set(v) {
+				this.$emit('update:receivers', v)
+			},
+		},
 	},
 
 	methods: {
@@ -85,7 +85,9 @@ export default {
 		addResource(resource) {
 			this.contextResource.push(resource)
 			this.localResource = this.contextResource
-
+		},
+		updateReceivers(receivers) {
+			this.localReceivers = receivers
 		},
 
 	},

--- a/src/shared/components/ncContextResource/NcContextResource.vue
+++ b/src/shared/components/ncContextResource/NcContextResource.vue
@@ -45,15 +45,7 @@ export default {
 		return {
 			loading: false,
 			contextResource: this.resources,
-			contextReceivers: [
-				// {
-				// 	user: 'user2',
-				// 	displayName: 'user2',
-				// 	icon: 'icon-user',
-				// 	isUser: true,
-				// 	key: 'users-user2',
-				// },
-			],
+			contextReceivers: this.receivers,
 		}
 	},
 

--- a/src/shared/components/ncContextResource/NcContextResource.vue
+++ b/src/shared/components/ncContextResource/NcContextResource.vue
@@ -3,7 +3,7 @@
 		<div>
 			<ResourceForm :resources="localResource" @add="addResource" />
 			<ResourceList :resources="localResource" @remove="removeResource" />
-			<ResourceSharees :select-users="true" :select-groups="false" :sharees.sync="sharees" />
+			<ResourceSharees :select-users="true" :select-groups="false" :sharees.sync="currentSharees" />
 			<ResourceSharePermissions :resources="localResource" />
 		</div>
 	</div>
@@ -45,6 +45,23 @@ export default {
 		return {
 			loading: false,
 			contextResource: this.resources,
+			// currentSharees: [...this.sharees],
+			currentSharees: [
+				{
+					user: 'user2',
+					displayName: 'user2',
+					icon: 'icon-user',
+					isUser: true,
+					key: 'users-user2',
+				},
+				{
+					user: 'user1',
+					displayName: 'user1',
+					icon: 'icon-user',
+					isUser: true,
+					key: 'users-user1',
+				},
+			],
 		}
 	},
 

--- a/src/shared/components/ncContextResource/ResourceForm.vue
+++ b/src/shared/components/ncContextResource/ResourceForm.vue
@@ -124,6 +124,10 @@ export default {
 				type: element.type,
 				label: element.title,
 				subline: '',
+				permissionRead: true,
+				permissionCreate: true,
+				permissionUpdate: true,
+				permissionDelete: false,
 			}
 		},
 

--- a/src/shared/components/ncContextResource/ResourceSharePermissions.vue
+++ b/src/shared/components/ncContextResource/ResourceSharePermissions.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<div class="col-4">
+		<div>
 			{{ t('tables', 'Shared resources permissions') }}
 		</div>
 		<ul v-if="resources && resources.length > 0" class="shares-list">

--- a/src/shared/components/ncContextResource/ResourceSharePermissions.vue
+++ b/src/shared/components/ncContextResource/ResourceSharePermissions.vue
@@ -1,10 +1,8 @@
 <template>
 	<div>
-		<h3>{{ t('tables', 'Sharing') }}</h3>
+		<h3>{{ t('tables', 'Shared resources permissions') }}</h3>
 		<ul v-if="resources && resources.length > 0" class="shares-list">
-			<div v-for="resource in resources"
-				:key="resource.key"
-				class="row">
+			<div v-for="resource in resources" :key="resource.key" class="row">
 				<div class="fix-col-2">
 					<div style="display:flex; align-items: center; padding: 10px;">
 						{{ resource.emoji }} &nbsp; {{ resource.title }}
@@ -12,45 +10,33 @@
 				</div>
 				<div class="fix-col-2" style="justify-content: end;">
 					<NcActions :force-menu="true">
-						<template>
-							<NcActionCaption :name="t('tables', 'Permissions')" />
-							<NcActionCheckbox
-								:disabled="true"
-								@check="updatePermission(resource, 'read', true)"
-								@uncheck="updatePermission(resource, 'read', false)">
-								{{ t('tables', 'Read data') }}
-							</NcActionCheckbox>
-							<!-- <NcActionCheckbox :checked.sync="share.permissionRead"
-								:disabled="share.permissionManage || share.permissionUpdate || share.permissionDelete"
-								@check="updatePermission(share, 'read', true)"
-								@uncheck="updatePermission(share, 'read', false)">
-								{{ t('tables', 'Read data') }}
-							</NcActionCheckbox>
-							<NcActionCheckbox :checked.sync="share.permissionCreate"
-								:disabled="share.permissionManage"
-								@check="updatePermission(share, 'create', true)"
-								@uncheck="updatePermission(share, 'create', false)">
-								{{ t('tables', 'Create data') }}
-							</NcActionCheckbox>
-							<NcActionCheckbox :checked.sync="share.permissionUpdate"
-								:disabled="share.permissionManage"
-								@check="updatePermission(share, 'update', true)"
-								@uncheck="updatePermission(share, 'update', false)">
-								{{ t('tables', 'Update data') }}
-							</NcActionCheckbox>
-							<NcActionCheckbox :checked.sync="share.permissionDelete"
-								:disabled="share.permissionManage"
-								@check="updatePermission(share, 'delete', true)"
-								@uncheck="updatePermission(share, 'delete', false)">
-								{{ t('tables', 'Delete data') }}
-							</NcActionCheckbox> -->
-						</template>
+						<NcActionCaption :name="t('tables', 'Permissions')" />
+						<NcActionCheckbox :checked.sync="resource.permissionRead" :disabled="true"
+							@check="updatePermission(resource, 'permissionRead', true)"
+							@uncheck="updatePermission(resource, 'permissionRead', false)">
+							{{ t('tables', 'Read resource') }}
+						</NcActionCheckbox>
+						<NcActionCheckbox :checked.sync="resource.permissionCreate"
+							@check="updatePermission(resource, 'create', true)"
+							@uncheck="updatePermission(resource, 'create', false)">
+							{{ t('tables', 'Create resource') }}
+						</NcActionCheckbox>
+						<NcActionCheckbox :checked.sync="resource.permissionUpdate"
+							@check="updatePermission(resource, 'update', true)"
+							@uncheck="updatePermission(resource, 'update', false)">
+							{{ t('tables', 'Update resource') }}
+						</NcActionCheckbox>
+						<NcActionCheckbox :checked.sync="resource.permissionDelete"
+							@check="updatePermission(resource, 'delete', true)"
+							@uncheck="updatePermission(resource, 'delete', false)">
+							{{ t('tables', 'Delete resource') }}
+						</NcActionCheckbox>
 					</NcActions>
 				</div>
 			</div>
 		</ul>
 		<div v-else>
-			{{ t('tables', 'No shares') }}
+			{{ t('tables', 'No shared resources') }}
 		</div>
 	</div>
 </template>
@@ -79,28 +65,18 @@ export default {
 	},
 
 	methods: {
-		updatePermission(share, permission, value) {
-			this.$emit('update', { id: share.id, permission, value })
+		updatePermission(resource, permission, value) {
+			this.$emit('update', { resourceId: resource.id, permission, value })
 		},
+
 	},
 }
 </script>
 
 <style lang="scss" scoped>
-
-	.shares-list li {
-		display: flex;
-		justify-content: space-between;
-		line-height: 44px;
-	}
-
-	.high-line-height {
-		line-height: 35px;
-	}
-
-	.manage-button {
-		display: flex;
-		justify-content: center;
-	}
-
+.shares-list li {
+	display: flex;
+	justify-content: space-between;
+	line-height: 44px;
+}
 </style>

--- a/src/shared/components/ncContextResource/ResourceSharePermissions.vue
+++ b/src/shared/components/ncContextResource/ResourceSharePermissions.vue
@@ -1,0 +1,106 @@
+<template>
+	<div>
+		<h3>{{ t('tables', 'Sharing') }}</h3>
+		<ul v-if="resources && resources.length > 0" class="shares-list">
+			<div v-for="resource in resources"
+				:key="resource.key"
+				class="row">
+				<div class="fix-col-2">
+					<div style="display:flex; align-items: center; padding: 10px;">
+						{{ resource.emoji }} &nbsp; {{ resource.title }}
+					</div>
+				</div>
+				<div class="fix-col-2" style="justify-content: end;">
+					<NcActions :force-menu="true">
+						<template>
+							<NcActionCaption :name="t('tables', 'Permissions')" />
+							<NcActionCheckbox
+								:disabled="true"
+								@check="updatePermission(resource, 'read', true)"
+								@uncheck="updatePermission(resource, 'read', false)">
+								{{ t('tables', 'Read data') }}
+							</NcActionCheckbox>
+							<!-- <NcActionCheckbox :checked.sync="share.permissionRead"
+								:disabled="share.permissionManage || share.permissionUpdate || share.permissionDelete"
+								@check="updatePermission(share, 'read', true)"
+								@uncheck="updatePermission(share, 'read', false)">
+								{{ t('tables', 'Read data') }}
+							</NcActionCheckbox>
+							<NcActionCheckbox :checked.sync="share.permissionCreate"
+								:disabled="share.permissionManage"
+								@check="updatePermission(share, 'create', true)"
+								@uncheck="updatePermission(share, 'create', false)">
+								{{ t('tables', 'Create data') }}
+							</NcActionCheckbox>
+							<NcActionCheckbox :checked.sync="share.permissionUpdate"
+								:disabled="share.permissionManage"
+								@check="updatePermission(share, 'update', true)"
+								@uncheck="updatePermission(share, 'update', false)">
+								{{ t('tables', 'Update data') }}
+							</NcActionCheckbox>
+							<NcActionCheckbox :checked.sync="share.permissionDelete"
+								:disabled="share.permissionManage"
+								@check="updatePermission(share, 'delete', true)"
+								@uncheck="updatePermission(share, 'delete', false)">
+								{{ t('tables', 'Delete data') }}
+							</NcActionCheckbox> -->
+						</template>
+					</NcActions>
+				</div>
+			</div>
+		</ul>
+		<div v-else>
+			{{ t('tables', 'No shares') }}
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcActions, NcActionCheckbox, NcActionCaption } from '@nextcloud/vue'
+
+export default {
+	components: {
+		NcActions,
+		NcActionCheckbox,
+		NcActionCaption,
+	},
+
+	props: {
+		resources: {
+			type: Array,
+			default: () => ([]),
+		},
+	},
+
+	data() {
+		return {
+			loading: false,
+		}
+	},
+
+	methods: {
+		updatePermission(share, permission, value) {
+			this.$emit('update', { id: share.id, permission, value })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+	.shares-list li {
+		display: flex;
+		justify-content: space-between;
+		line-height: 44px;
+	}
+
+	.high-line-height {
+		line-height: 35px;
+	}
+
+	.manage-button {
+		display: flex;
+		justify-content: center;
+	}
+
+</style>

--- a/src/shared/components/ncContextResource/ResourceSharePermissions.vue
+++ b/src/shared/components/ncContextResource/ResourceSharePermissions.vue
@@ -1,6 +1,8 @@
 <template>
 	<div>
-		<h3>{{ t('tables', 'Shared resources permissions') }}</h3>
+		<div class="col-4">
+			{{ t('tables', 'Shared resources permissions') }}
+		</div>
 		<ul v-if="resources && resources.length > 0" class="shares-list">
 			<div v-for="resource in resources" :key="resource.key" class="row">
 				<div class="fix-col-2">
@@ -17,18 +19,18 @@
 							{{ t('tables', 'Read resource') }}
 						</NcActionCheckbox>
 						<NcActionCheckbox :checked.sync="resource.permissionCreate"
-							@check="updatePermission(resource, 'create', true)"
-							@uncheck="updatePermission(resource, 'create', false)">
+							@check="updatePermission(resource, 'permissionCreate', true)"
+							@uncheck="updatePermission(resource, 'permissionCreate', false)">
 							{{ t('tables', 'Create resource') }}
 						</NcActionCheckbox>
 						<NcActionCheckbox :checked.sync="resource.permissionUpdate"
-							@check="updatePermission(resource, 'update', true)"
-							@uncheck="updatePermission(resource, 'update', false)">
+							@check="updatePermission(resource, 'permissionUpdate', true)"
+							@uncheck="updatePermission(resource, 'permissionUpdate', false)">
 							{{ t('tables', 'Update resource') }}
 						</NcActionCheckbox>
 						<NcActionCheckbox :checked.sync="resource.permissionDelete"
-							@check="updatePermission(resource, 'delete', true)"
-							@uncheck="updatePermission(resource, 'delete', false)">
+							@check="updatePermission(resource, 'permissionDelete', true)"
+							@uncheck="updatePermission(resource, 'permissionDelete', false)">
 							{{ t('tables', 'Delete resource') }}
 						</NcActionCheckbox>
 					</NcActions>

--- a/src/shared/components/ncContextResource/ResourceSharees.vue
+++ b/src/shared/components/ncContextResource/ResourceSharees.vue
@@ -1,8 +1,7 @@
 <template>
 	<div class="row space-B">
 		<h3>{{ t('tables', 'Share with accounts or groups') }}</h3>
-		<NcSelect v-model="value" style="width: 100%;" :loading="loading" :options="options"
-			:value="sharees"
+		<NcSelect v-model="preExistingSharees" style="width: 100%;" :loading="loading" :options="options"
 			:placeholder="getPlaceholder()"
 			:searchable="true" :get-option-key="(option) => option.key"
 			label="displayName"
@@ -59,17 +58,19 @@ export default {
 			minSearchStringLength: 1,
 			maxAutocompleteResults: 20,
 			suggestions: [],
+			preExistingSharees: [...this.sharees],
+			localSharees: this.sharees.map(userObject => userObject.user),
 		}
 	},
 
 	computed: {
 		localValue: {
 			get() {
-				return this.newOwnerUserId
+				return this.localSharees
 			},
 			set(v) {
-				console.info('newOwnerUserId set to ', v)
-				this.$emit('update:newOwnerUserId', v)
+				this.localSharees = v.map(userObject => userObject.user)
+				this.$emit('update:sharees', v)
 			},
 		},
 
@@ -99,9 +100,9 @@ export default {
 	methods: {
 		addShare(selectedItem) {
 			if (selectedItem) {
-				this.localValue = selectedItem.user
+				this.localValue = selectedItem
 			} else {
-				this.localValue = ''
+				this.localValue = []
 			}
 		},
 
@@ -160,6 +161,7 @@ export default {
 				})
 
 				this.suggestions = this.filterOutCurrentUser(rawSuggestions)
+				this.suggestions = this.filterOutSelectedUsers(this.suggestions)
 				this.loading = false
 			} catch (err) {
 				console.debug(err)
@@ -173,6 +175,9 @@ export default {
 
 		filterOutCurrentUser(list) {
 			return list.filter((item) => !(item.isUser && item.user === getCurrentUser().uid))
+		},
+		filterOutSelectedUsers(list) {
+			return list.filter((item) => !(item.isUser && this.localSharees.includes(item.user)))
 		},
 
 	},

--- a/src/shared/components/ncContextResource/ResourceSharees.vue
+++ b/src/shared/components/ncContextResource/ResourceSharees.vue
@@ -1,6 +1,8 @@
 <template>
 	<div class="row space-B">
-		<h3>{{ t('tables', 'Share with accounts or groups') }}</h3>
+		<div class="col-4">
+			{{ t('tables', 'Share with accounts') }}
+		</div>
 		<NcSelect v-model="preExistingSharees" style="width: 100%;" :loading="loading" :options="options"
 			:placeholder="getPlaceholder()"
 			:searchable="true" :get-option-key="(option) => option.key"

--- a/src/shared/components/ncContextResource/ResourceSharees.vue
+++ b/src/shared/components/ncContextResource/ResourceSharees.vue
@@ -36,7 +36,7 @@ export default {
 	mixins: [ShareTypes, formatting],
 
 	props: {
-		sharees: {
+		receivers: {
 			type: Array,
 			default: () => ([]),
 		},
@@ -58,8 +58,8 @@ export default {
 			minSearchStringLength: 1,
 			maxAutocompleteResults: 20,
 			suggestions: [],
-			preExistingSharees: [...this.sharees],
-			localSharees: this.sharees.map(userObject => userObject.user),
+			preExistingSharees: [...this.receivers],
+			localSharees: this.receivers.map(userObject => userObject.user),
 		}
 	},
 
@@ -70,7 +70,7 @@ export default {
 			},
 			set(v) {
 				this.localSharees = v.map(userObject => userObject.user)
-				this.$emit('update:sharees', v)
+				this.$emit('update', v)
 			},
 		},
 

--- a/src/shared/components/ncContextResource/ResourceSharees.vue
+++ b/src/shared/components/ncContextResource/ResourceSharees.vue
@@ -1,0 +1,187 @@
+<template>
+	<div class="row space-B">
+		<h3>{{ t('tables', 'Share with accounts or groups') }}</h3>
+		<NcSelect v-model="value" style="width: 100%;" :loading="loading" :options="options"
+			:value="sharees"
+			:placeholder="getPlaceholder()"
+			:searchable="true" :get-option-key="(option) => option.key"
+			label="displayName"
+			:aria-label-combobox="getPlaceholder()" :user-select="true"
+			:close-on-select="false"
+			:multiple="true"
+			@search="asyncFind" @input="addShare">
+			<template #noResult>
+				{{ noResultText }}
+			</template>
+		</NcSelect>
+	</div>
+</template>
+
+<script>
+import { generateOcsUrl } from '@nextcloud/router'
+import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
+import debounce from 'debounce'
+import { NcSelect } from '@nextcloud/vue'
+import formatting from '../../../shared/mixins/formatting.js'
+import ShareTypes from '../../mixins/shareTypesMixin.js'
+import { showError } from '@nextcloud/dialogs'
+import '@nextcloud/dialogs/style.css'
+
+export default {
+
+	components: {
+		NcSelect,
+	},
+
+	mixins: [ShareTypes, formatting],
+
+	props: {
+		sharees: {
+			type: Array,
+			default: () => ([]),
+		},
+		selectUsers: {
+			type: Boolean,
+			default: true,
+		},
+		selectGroups: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	data() {
+		return {
+			query: '',
+			value: '',
+			loading: false,
+			minSearchStringLength: 1,
+			maxAutocompleteResults: 20,
+			suggestions: [],
+		}
+	},
+
+	computed: {
+		localValue: {
+			get() {
+				return this.newOwnerUserId
+			},
+			set(v) {
+				console.info('newOwnerUserId set to ', v)
+				this.$emit('update:newOwnerUserId', v)
+			},
+		},
+
+		isValidQuery() {
+			return this.query?.trim() && this.query.length >= this.minSearchStringLength
+		},
+
+		options() {
+			if (this.isValidQuery) {
+				return this.suggestions
+			}
+			return []
+		},
+
+		noResultText() {
+			if (this.loading) {
+				return t('tables', 'Searching …')
+			}
+			return t('tables', 'No elements found.')
+		},
+
+		userId() {
+			return getCurrentUser().uid
+		},
+	},
+
+	methods: {
+		addShare(selectedItem) {
+			if (selectedItem) {
+				this.localValue = selectedItem.user
+			} else {
+				this.localValue = ''
+			}
+		},
+
+		getShareTypes() {
+			const types = []
+			if (this.selectUsers) {
+				types.push(this.SHARE_TYPES.SHARE_TYPE_USER)
+			}
+			if (this.selectGroups) {
+				types.push(this.SHARE_TYPES.SHARE_TYPE_GROUP)
+			}
+			return types
+		},
+
+		getShareTypeString() {
+			if (this.selectUsers && !this.selectGroups) {
+				return 'User'
+			} else if (!this.selectUsers && this.selectGroups) {
+				return 'Group'
+			} else {
+				return 'User or group'
+			}
+		},
+
+		getPlaceholder() {
+			return t('tables', '{shareTypeString}...', { shareTypeString: this.getShareTypeString() })
+		},
+
+		async asyncFind(query) {
+			this.query = query.trim()
+			if (this.isValidQuery) {
+				this.loading = true
+				await this.debounceGetSuggestions(query)
+			}
+		},
+
+		async getSuggestions(search) {
+			this.loading = true
+			const shareTypes = this.getShareTypes()
+			let shareTypeQueryString = ''
+			shareTypes.forEach(shareType => {
+				shareTypeQueryString += `&shareTypes[]=${shareType}`
+			})
+			const url = generateOcsUrl(`core/autocomplete/get?search=${search}${shareTypeQueryString}&limit=${this.maxAutocompleteResults}`)
+
+			try {
+				const res = await axios.get(url)
+				const rawSuggestions = res.data.ocs.data.map(autocompleteResult => {
+					return {
+						user: autocompleteResult.id,
+						displayName: autocompleteResult.label,
+						icon: autocompleteResult.icon,
+						isUser: autocompleteResult.source.startsWith('users'),
+						key: autocompleteResult.source + '-' + autocompleteResult.id,
+					}
+				})
+
+				this.suggestions = this.filterOutCurrentUser(rawSuggestions)
+				this.loading = false
+			} catch (err) {
+				console.debug(err)
+				showError(t('tables', 'Failed to fetch {shareTypeString}', { shareTypeString: this.getShareTypeString().toLowerCase() }))
+			}
+		},
+
+		debounceGetSuggestions: debounce(function(...args) {
+			this.getSuggestions(...args)
+		}, 300),
+
+		filterOutCurrentUser(list) {
+			return list.filter((item) => !(item.isUser && item.user === getCurrentUser().uid))
+		},
+
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.multiselect {
+	width: 100% !important;
+	max-width: 100% !important;
+}
+</style>

--- a/src/shared/components/ncContextResource/mixins/permissionBitmask.js
+++ b/src/shared/components/ncContextResource/mixins/permissionBitmask.js
@@ -1,0 +1,21 @@
+import { PERMISSION_READ, PERMISSION_CREATE, PERMISSION_UPDATE, PERMISSION_DELETE } from '../../../constants.js'
+
+export default {
+	data() {
+		return {
+			PERMISSION_READ,
+			PERMISSION_CREATE,
+			PERMISSION_UPDATE,
+			PERMISSION_DELETE,
+		}
+	},
+	methods: {
+		getPermissionBitmaskFromBools(permissionRead, permissionCreate, permissionUpdate, permissionDelete) {
+			const read = permissionRead ? PERMISSION_READ : 0
+			const create = permissionCreate ? PERMISSION_CREATE : 0
+			const update = permissionUpdate ? PERMISSION_UPDATE : 0
+			const del = permissionDelete ? PERMISSION_DELETE : 0
+			return read | create | update | del
+		},
+	},
+}

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -21,3 +21,11 @@
 
 export const NODE_TYPE_TABLE = 0
 export const NODE_TYPE_VIEW = 1
+
+// from Application.php
+export const PERMISSION_READ = 1
+export const PERMISSION_CREATE = 2
+export const PERMISSION_UPDATE = 4
+export const PERMISSION_DELETE = 8
+export const PERMISSION_MANAGE = 16
+export const PERMISSION_ALL = 31

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -339,7 +339,7 @@ export default new Vuex.Store({
 					}
 				}
 			} catch (e) {
-				displayError(e, t('tables', 'Could not add context share.'))
+				displayError(e, t('tables', 'Could not add application share.'))
 			}
 			try {
 				// If there's a previous share that wasn't maintained, delete it
@@ -353,7 +353,7 @@ export default new Vuex.Store({
 					}
 				}
 			} catch (e) {
-				displayError(e, t('tables', 'Could not remove context share.'))
+				displayError(e, t('tables', 'Could not remove application share.'))
 			}
 		},
 		async insertNewContext({ commit, state, dispatch }, { data, receivers }) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -339,8 +339,13 @@ export default new Vuex.Store({
 
 			return true
 		},
-		async updateContext({ state, commit, dispatch }, { id, data, share, receivers }) {
+		async updateContext({ state, commit, dispatch }, { id, data, receivers }) {
 			let res = null
+			let share = {
+				nodeType: 'context',
+				nodeId: id,
+				displayMode: 2,
+			}
 
 			try {
 				res = await axios.put(generateOcsUrl('/apps/tables/api/2/contexts/' + id), data)

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -339,11 +339,16 @@ export default new Vuex.Store({
 
 			return true
 		},
-		async updateContext({ state, commit, dispatch }, { id, data }) {
+		async updateContext({ state, commit, dispatch }, { id, data, share, receivers }) {
 			let res = null
 
 			try {
 				res = await axios.put(generateOcsUrl('/apps/tables/api/2/contexts/' + id), data)
+				for (const receiver of receivers) {
+					share.receiverType = receiver.isUser ? 'user' : 'group'
+					share.receiver = receiver.user
+					await axios.post(generateUrl('/apps/tables/share'), share)
+				}
 			} catch (e) {
 				displayError(e, t('tables', 'Could not update application.'))
 				return false

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -60,6 +60,10 @@ export type paths = {
     /** Create a new share */
     post: operations["api1-create-share"];
   };
+  "/index.php/apps/tables/api/1/shares/{shareId}/display-mode": {
+    /** Updates the display mode of a context share */
+    put: operations["api1-update-share-display-mode"];
+  };
   "/index.php/apps/tables/api/1/tables/{tableId}/columns": {
     /** Get all columns for a table or a underlying view Return an empty array if no columns were found */
     get: operations["api1-list-table-columns"];
@@ -282,6 +286,15 @@ export type components = {
       owner: string;
       /** Format: int64 */
       ownerType: number;
+    };
+    ContextNavigation: {
+      /** Format: int64 */
+      id: number;
+      /** Format: int64 */
+      shareId: number;
+      /** Format: int64 */
+      displayMode: number;
+      userId: string;
     };
     ImportState: {
       /** Format: int64 */
@@ -1079,6 +1092,8 @@ export type operations = {
         permissionDelete?: 0 | 1;
         /** @description Permission if receiver can manage node */
         permissionManage?: 0 | 1;
+        /** @description context shares only, whether it should appear in nav bar. 0: no, 1: recipients, 2: all */
+        displayMode?: number;
       };
     };
     responses: {
@@ -1097,6 +1112,60 @@ export type operations = {
         };
       };
       /** @description Not found */
+      404: {
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      500: {
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+    };
+  };
+  /** Updates the display mode of a context share */
+  "api1-update-share-display-mode": {
+    parameters: {
+      query: {
+        /** @description The new value for the display mode of the nav bar icon. 0: hidden, 1: visible for recipients, 2: visible for all */
+        displayMode: number;
+        /** @description "default" to set the default, "self" to set an override for the authenticated user */
+        target?: "default" | "self";
+      };
+      path: {
+        /** @description Share ID */
+        shareId: number;
+      };
+    };
+    responses: {
+      /** @description Display mode updated */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ContextNavigation"];
+        };
+      };
+      /** @description Invalid parameter */
+      400: {
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      /** @description No permissions */
+      403: {
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      /** @description Share not found */
       404: {
         content: {
           "application/json": {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -611,7 +611,8 @@ class FeatureContext implements Context {
 			$titles[] = $d['title'];
 		}
 		foreach ($body->getRows()[0] as $tableTitle) {
-			Assert::assertTrue(in_array($tableTitle, $titles, true));
+			$message = sprintf('"%s" not in the list: %s', $tableTitle, implode(', ', $titles));
+			Assert::assertTrue(in_array($tableTitle, $titles, true), $message);
 		}
 	}
 


### PR DESCRIPTION
contributes to #311 and #897

* `createShare` endpoints where extended with the optional parameter `displayMode`, which is only effective for contexts. The permissions flags on the other hand are not effective for contexts at the moment.
* `updateShareDisplayMode` (Routes: `api1#updateShareDisplayMode` and `share#updateDisplayMode`) endpoint was added, as the only updatable endpoint was against purely against permissions.
* business logic was adjusted to supply contexts specific needs.