### PR TITLE
test(Integration): add contexts related tests

### DIFF
--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -418,7 +418,7 @@ class ContextService {
 			unset($addedPage['content'][$pageContent->getId()]['pageId']);
 		}
 
-		$context->setPages($addedPage);
+		$context->setPages([$addedPage['id'] => $addedPage]);
 	}
 
 	protected function insertNodesFromArray(Context $context, array $nodes): void {

--- a/openapi.json
+++ b/openapi.json
@@ -8333,6 +8333,82 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "invalid parameters were supplied",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "lacking permissions on a resource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -3113,6 +3113,32 @@ export type operations = {
           };
         };
       };
+      /** @description invalid parameters were supplied */
+      400: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+      /** @description lacking permissions on a resource */
+      403: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
       500: {
         content: {
           "application/json": {

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -99,3 +99,42 @@ Feature: APIv2
     Then table "t4" is owned by "participant1-v2"
     Then change owner for table "t4" from user "participant1-v2" to user "participant2-v2"
     Then table "t4" is owned by "participant2-v2"
+
+  @api2 @contexts
+  Scenario: Create a simple context containing one table and one view
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "👋" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    When user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | v1    | view  | read                |
+    Then user "participant1-v2" has access to Context "c1"
+    And the fetched Context "c1" has following data:
+      | field | value                        |
+      | name  | Enchanting Guitar            |
+      | icon  | tennis                       |
+      | node  | table:t1:read,create,update  |
+      | node  | view:v1:read                 |
+      | page  | startpage:2                  |
+
+  @api2 @contexts
+  Scenario: Fetch the overview over existing Contexts as owner
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And table "Table X via api v2" with emoji "📋" exists for user "participant2-v2" as "t3" via v2
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" create view "v2" with emoji "🦉" for "t2" as "v2"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+      | v1    | view  | read                |
+    And user "participant1-v2" creates the Context "c2" with name "Placid Ring" with icon "headphones" and description "Lacus suspendisse faucibus etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t2    | table | read,create,update  |
+      | v2    | view  | read                |
+    And user "participant2-v2" creates the Context "c3" with name "Chilly Lumber" with icon "monitor" and description "Sed blandit libero etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t3    | table | all                 |
+    When user "participant1-v2" fetches all Contexts
+    Then they will find Contexts "c1, c2" and no other

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -130,6 +130,18 @@ Feature: APIv2
     Then they will find Contexts "" and no other
 
   @api2 @contexts
+  Scenario: Attempt to create a context containing an inaccessible view
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "👋" exists for user "participant2-v2" as "t2" via v2
+    And user "participant2-v2" create view "v2" with emoji "⚡️" for "t2" as "v2"
+    When user "participant1-v2" attempts to create the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | v2    | view | read,create,update  |
+    Then the reported status is "403"
+    And user "participant1-v2" fetches all Contexts
+    Then they will find Contexts "" and no other
+
+  @api2 @contexts
   Scenario: Fetch the overview over existing Contexts as owner
     Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
     And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -119,6 +119,17 @@ Feature: APIv2
       | page  | startpage:2                  |
 
   @api2 @contexts
+  Scenario: Attempt to create a context containing an inaccessible table
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "👋" exists for user "participant2-v2" as "t2" via v2
+    When user "participant1-v2" attempts to create the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t2    | table | read,create,update  |
+    Then the reported status is "403"
+    And user "participant1-v2" fetches all Contexts
+    Then they will find Contexts "" and no other
+
+  @api2 @contexts
   Scenario: Fetch the overview over existing Contexts as owner
     Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
     And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -138,3 +138,28 @@ Feature: APIv2
       | t3    | table | all                 |
     When user "participant1-v2" fetches all Contexts
     Then they will find Contexts "c1, c2" and no other
+
+  @api2 @contexts
+  Scenario: Fetch the a specific Context as owner
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And table "Table X via api v2" with emoji "📋" exists for user "participant2-v2" as "t3" via v2
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" create view "v2" with emoji "🦉" for "t2" as "v2"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+      | v1    | view  | read                |
+    And user "participant1-v2" creates the Context "c2" with name "Placid Ring" with icon "headphones" and description "Lacus suspendisse faucibus etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t2    | table | read,create,update  |
+      | v2    | view  | read                |
+    And user "participant2-v2" creates the Context "c3" with name "Chilly Lumber" with icon "monitor" and description "Sed blandit libero etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t3    | table | all                 |
+    When user "participant1-v2" fetches Context "c2"
+    Then known Context "c2" has "name" set to "Placid Ring"
+    And known Context "c2" has "icon" set to "headphones"
+    And known Context "c2" has "description" set to "Lacus suspendisse faucibus etc pp"
+    And known Context "c2" contains "table" "t2" with permissions "read,create,update"
+    And known Context "c2" contains "view" "v2" with permissions "read"

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -186,3 +186,23 @@ Feature: APIv2
     And known Context "c2" has "description" set to "Lacus suspendisse faucibus etc pp"
     And known Context "c2" contains "table" "t2" with permissions "read,create,update"
     And known Context "c2" contains "view" "v2" with permissions "read"
+
+  @api2 @contexts
+  Scenario: Fetch a specific, but inaccessible Context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant2-v2" attempts to fetch Context "c1"
+    Then the reported status is "404"
+
+  @api2 @contexts
+  Scenario: Fetch a specific, but non-existing Context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant1-v2" attempts to fetch Context "NON-EXISTENT"
+    Then the reported status is "404"

--- a/tests/integration/features/bootstrap/CollectionManager.php
+++ b/tests/integration/features/bootstrap/CollectionManager.php
@@ -24,6 +24,7 @@ class CollectionManager {
 
 	public function update(mixed $item, string $type, int $id, ?callable $cleanUpFunc = null): void {
 		$idMapKey = $this->makeKey($type, $id);
+		$this->itemsById[$idMapKey] = $item;
 		$aliasMapKey = array_search($idMapKey, $this->mapByAlias, true) ?: null;
 
 		if ($cleanUpFunc) {

--- a/tests/integration/features/bootstrap/CollectionManager.php
+++ b/tests/integration/features/bootstrap/CollectionManager.php
@@ -1,0 +1,67 @@
+<?php
+
+class CollectionManager {
+	protected array $itemsById = [];
+	protected array $mapByAlias = [];
+	protected array $cleanUp = [];
+
+	public function register(mixed $item, string $type, int $id, ?string $alias = null, ?callable $cleanUpFunc = null): void {
+		$idMapKey = $this->makeKey($type, $id);
+		$this->itemsById[$idMapKey] = $item;
+
+		if ($alias) {
+			$aliasMapKey = $this->makeKey($type, $alias);
+			$this->mapByAlias[$aliasMapKey] = $idMapKey;
+		}
+
+		if ($cleanUpFunc) {
+			$this->cleanUp[$idMapKey] = [
+				'aliasMapKey' => $aliasMapKey ?? null,
+				'func' => $cleanUpFunc,
+			];
+		}
+	}
+
+	public function update(mixed $item, string $type, int $id, ?callable $cleanUpFunc = null): void {
+		$idMapKey = $this->makeKey($type, $id);
+		$aliasMapKey = array_search($idMapKey, $this->mapByAlias, true) ?: null;
+
+		if ($cleanUpFunc) {
+			$this->cleanUp[$idMapKey] = [
+				'aliasMapKey' => $aliasMapKey ?? null,
+				'func' => $cleanUpFunc
+			];
+		}
+	}
+
+	public function forget(string $type, int $id, ?string $alias = null): void {
+		if ($alias) {
+			unset($this->mapByAlias[$this->makeKey($type, $alias)]);
+		}
+		unset($this->itemsById[$this->makeKey($type, $id)]);
+	}
+
+	public function cleanUp(): void {
+		foreach ($this->cleanUp as $idMapKey => $cleanUpData) {
+			$cleanUpData['func']();
+			if ($cleanUpData['aliasMapKey']) {
+				unset($this->mapByAlias['aliasMapKey']);
+			}
+			unset($this->itemsById[$idMapKey]);
+		}
+		$this->cleanUp = [];
+	}
+
+	public function getById(string $type, int $id): mixed {
+		return $this->itemsById[$this->makeKey($type, $id)] ?? null;
+	}
+
+	public function getByAlias(string $type, string $alias): mixed {
+		$idMapKey = $this->mapByAlias[$this->makeKey($type, $alias)];
+		return $this->itemsById[$idMapKey] ?? null;
+	}
+
+	protected function makeKey(string $type, int|string $id): string {
+		return $type . '//' . $id;
+	}
+}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -28,6 +28,7 @@ use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -1759,6 +1760,21 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When user :user attempts to create the Context :alias with name :name with icon :icon and description :description and nodes:
+	 */
+	public function attemptCreateContext(string $user, string $alias, string $name, string $icon, string $description, TableNode $table) {
+		$exceptionCaught = false;
+		try {
+			$this->createContext($user, $alias, $name, $icon, $description, $table);
+		} catch (ExpectationFailedException $e) {
+			$exceptionCaught = true;
+
+		}
+
+		Assert::assertTrue($exceptionCaught);
+	}
+
+	/**
 	 * @When user :user creates the Context :alias with name :name with icon :icon and description :description and nodes:
 	 */
 	public function createContext(string $user, string $alias, string $name, string $icon, string $description, TableNode $table) {
@@ -1908,7 +1924,7 @@ class FeatureContext implements Context {
 	public function theyWillFindContextsAndNoOther(string $contextAliasList): void {
 		$receivedContexts = $this->getDataFromResponse($this->response)['ocs']['data'];
 
-		$aliases = explode(',', $contextAliasList);
+		$aliases = $contextAliasList === '' ? [] : explode(',', $contextAliasList);
 		$expectedContextIds = array_map(function (string $alias) {
 			return $this->collectionManager->getByAlias('context', trim($alias))['id'];
 		}, $aliases);
@@ -1984,4 +2000,12 @@ class FeatureContext implements Context {
 		$expectedPermissions = $this->humanReadablePermissionToInt($permissionList);
 		Assert::assertSame($expectedPermissions, $actualPermissions);
 	}
+
+	/**
+	 * @Then the reported status is :statusCode
+	 */
+	public function theReportedStatusIs(int $statusCode): void {
+		Assert::assertEquals($statusCode, $this->response->getStatusCode());
+	}
+
 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -36,6 +36,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class FeatureContext implements Context {
 	public const TEST_PASSWORD = '123456';
+	public const NON_EXISTING_CONTEXT_ALIAS = 'NON-EXISTENT';
+	public const NON_EXISTING_CONTEXT_ID = 99404;
 
 	/** @var string */
 	protected $currentUser;
@@ -1887,12 +1889,30 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When user :user attempts to fetch Context :contextAlias
+	 */
+	public function userAttemptsToFetchContext(string $user, string $contextAlias): void {
+		$caughtException = false;
+		try {
+			$this->userFetchesContext($user, $contextAlias);
+		} catch (ExpectationFailedException $e) {
+			$caughtException = true;
+		}
+
+		Assert::assertTrue($caughtException);
+	}
+
+	/**
 	 * @When user :user fetches Context :contextAlias
 	 */
 	public function userFetchesContext(string $user, string $contextAlias): void {
 		$this->setCurrentUser($user);
 
-		$context = $this->collectionManager->getByAlias('context', $contextAlias);
+		if ($contextAlias === self::NON_EXISTING_CONTEXT_ALIAS) {
+			$context = ['id' => self::NON_EXISTING_CONTEXT_ID];
+		} else {
+			$context = $this->collectionManager->getByAlias('context', $contextAlias);
+		}
 
 		$this->sendOcsRequest(
 			'GET',


### PR DESCRIPTION
This PR includes some foundations for Context integration tests and a couple of create and read scenarios, plus some smaller fixes.

Let's got with this and add more scenarios in follow-ups. I'll open an overview issue.

## Scenarios covered

Creation

- [x] Create context with views and tables
- [x] Create context with inaccessible table
- [x] Create context with inaccessible view

Reading

- [x] Read all contexts
- [x] Read specific owned context
- [x] Read inaccessible context
- [x] Read a non-existing context

## Small bug fixes included

- ensure that node parameters are treated as integer values
- report node permissions on creation
- normalization of page result format 
- atomic handling of DB inserts on create + error handling + openapi update