### PR TITLE
enh: set nextcloud 30 as max version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ Have a good time and manage whatever you want.
 		<database>pgsql</database>
 		<database>mysql</database>
 		<database>sqlite</database>
-		<nextcloud min-version="26" max-version="29"/>
+		<nextcloud min-version="26" max-version="30"/>
 	</dependencies>
 	<repair-steps>
 		<post-migration>


### PR DESCRIPTION
The nextcloud server is now at version 30, so we need this update to make the app run on latest server code