### PR TITLE
fix(filter): pass datetime object for PARAM_DATE

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -407,18 +407,20 @@ class Row2Mapper {
 
 		switch ($columnId) {
 			case -1: // row ID
-				$qb2->where($this->getSqlOperator($operator, $qb, 'id', $value, IQueryBuilder::PARAM_INT));
+				$qb2->where($this->getSqlOperator($operator, $qb, 'id', (int)$value, IQueryBuilder::PARAM_INT));
 				break;
 			case -2: // created by
 				$qb2->where($this->getSqlOperator($operator, $qb, 'created_by', $value, IQueryBuilder::PARAM_STR));
 				break;
 			case -3: // created at
+				$value = new \DateTimeImmutable($value);
 				$qb2->where($this->getSqlOperator($operator, $qb, 'created_at', $value, IQueryBuilder::PARAM_DATE));
 				break;
 			case -4: // last edit by
 				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_by', $value, IQueryBuilder::PARAM_STR));
 				break;
 			case -5: // last edit at
+				$value = new \DateTimeImmutable($value);
 				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_at', $value, IQueryBuilder::PARAM_DATE));
 				break;
 		}


### PR DESCRIPTION
When you have a view with a filter on last edited (cf. screenshot), loading the view would end in an "Unknown error", actually `OCA\Tables\Db\Row2Mapper - getWantedRowIds: Could not convert PHP value '2024-01-01 00:01' to type datetime. Expected one of the following types: null, DateTime, DateTimeImmutable`.

![Screenshot_20240429_095635](https://github.com/nextcloud/tables/assets/2184312/b807182f-248b-4e5a-9eac-cb6cc31ce7f5)

