### PR TITLE
enh(Contexts): set active navigation entry

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -65,12 +65,15 @@ export default {
 			if (currentRoute.path.startsWith('/table/')) {
 				this.$store.commit('setActiveTableId', parseInt(currentRoute.params.tableId))
 				this.setPageTitle(this.$store.getters.activeTable.title)
+				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables"]'))
 			} else if (currentRoute.path.startsWith('/view/')) {
 				this.$store.commit('setActiveViewId', parseInt(currentRoute.params.viewId))
 				this.setPageTitle(this.$store.getters.activeView.title)
+				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables"]'))
 			} else if (currentRoute.path.startsWith('/application/')) {
 				this.$store.commit('setActiveContextId', parseInt(currentRoute.params.contextId))
 				this.setPageTitle(this.$store.getters.activeContext.name)
+				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables_application_' + currentRoute.params.contextId + '"]'))
 
 				// move the focus away from nav bar (import for app-internal switch)
 				const appContent = document.getElementById('app-content-vue')
@@ -81,6 +84,11 @@ export default {
 				appContent.focus()
 				appContent.tabIndex = oldTabIndex
 			}
+		},
+		switchActiveMenuEntry(targetElement) {
+			const currentlyActive = document.querySelector('header .header-left .app-menu li.app-menu-entry__active')
+			currentlyActive.classList.remove('app-menu-entry__active')
+			targetElement.classList.add('app-menu-entry__active')
 		},
 		setPageTitle(title) {
 			if (this.defaultPageTitle === false) {


### PR DESCRIPTION
This is sort of a PoC actually. Addresses #933 

I looked at the backend options first. The problem is that we are currently working with a set anchor, i.e. *example.com/index.php/apps/tables/**#/application/28***, so that is no information that we have on the backend. We'd either have to change this behaviour, or to avoid completely reloading the Tables app, having a mechanism that works with both, an URL that can be understood by the server, and the inside-app URL with the anchor.

Nevertheless, I looked at the frontend bits for a quick win. And there is the quick win:

[Screencast_20240430_113348.webm](https://github.com/nextcloud/tables/assets/2184312/3e1bb2b4-1108-4098-8074-e048ce5216eb)

It is not ideal though, because

- the active entry is visible flicking from Tables to the Tables Application when opening the Application directly, as it is initially set by the backend, and later adjusted by the app
- there is no exposed API to manipulated the navigation bar, so I am directly manipulating the JS class. This will easily break. It might be an approach to serve NC 29, but for 30 some API by the server would be necessary. Even if the backend scenario is solved, as laid out up front, this will be needed for inside-app Application switches.

What do you think?