### PR TITLE
fix(App): unstuck navbar focus on internal entries

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,6 +71,15 @@ export default {
 			} else if (currentRoute.path.startsWith('/application/')) {
 				this.$store.commit('setActiveContextId', parseInt(currentRoute.params.contextId))
 				this.setPageTitle(this.$store.getters.activeContext.name)
+
+				// move the focus away from nav bar (import for app-internal switch)
+				const appContent = document.getElementById('app-content-vue')
+				const oldTabIndex = appContent.tabIndex
+				if (oldTabIndex === -1) {
+					appContent.tabIndex = 0
+				}
+				appContent.focus()
+				appContent.tabIndex = oldTabIndex
 			}
 		},
 		setPageTitle(title) {


### PR DESCRIPTION
Fixes the focus being stuck on the nav bar after switching from Tables to a Tables application. Without the fix, the labels remain to be seen, only a click fixes the state. 

Buggy behaviour:
[Screencast_20240430_112536.webm](https://github.com/nextcloud/tables/assets/2184312/8fca0601-1aed-48e2-a669-16b224a822ae)

I understand it is OK to refer to *app-content-vue* as it is already done so in a different place in the same file. Setting the tabIndex is necessary for divs to accept the focus.
