### PR TITLE
fix(occ): Fix occ tables:update by defining the `description` option and making `title` optional

### DIFF
--- a/lib/Command/RenameTable.php
+++ b/lib/Command/RenameTable.php
@@ -54,7 +54,7 @@ class RenameTable extends Command {
 			)
 			->addArgument(
 				'title',
-				InputArgument::REQUIRED,
+				InputArgument::OPTIONAL,
 				'New title for the table.'
 			)
 			->addOption(

--- a/lib/Command/RenameTable.php
+++ b/lib/Command/RenameTable.php
@@ -58,6 +58,12 @@ class RenameTable extends Command {
 				'New title for the table.'
 			)
 			->addOption(
+				'description',
+				'd',
+				InputOption::VALUE_REQUIRED,
+				'New description for the table.'
+			)
+			->addOption(
 				'emoji',
 				'e',
 				InputOption::VALUE_OPTIONAL,


### PR DESCRIPTION
Fix #894 
Fix #1044 