### PR TITLE
fix(DB): update tables_row_sleeves' sequence after migration

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,6 +48,7 @@ Have a good time and manage whatever you want.
 	<repair-steps>
 		<post-migration>
 			<step>OCA\Tables\Migration\NewDbStructureRepairStep</step>
+			<step>OCA\Tables\Migration\DbRowSleeveSequence</step>
 		</post-migration>
 	</repair-steps>
 	<commands>

--- a/lib/Migration/DbRowSleeveSequence.php
+++ b/lib/Migration/DbRowSleeveSequence.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace OCA\Tables\Migration;
+
+use Doctrine\DBAL\Schema\Sequence;
+use OCA\Tables\AppInfo\Application;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+class DbRowSleeveSequence implements IRepairStep {
+	public function __construct(
+		protected IDBConnection $db,
+		protected IConfig $config,
+		protected LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName() {
+		return 'Fixing the sequence of the row-sleeves table';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function run(IOutput $output) {
+		$legacyRowTransferRunComplete = $this->config->getAppValue('tables', 'legacyRowTransferRunComplete', 'false') === 'true';
+		$sequenceRepairComplete = $this->config->getAppValue('tables', 'sequenceRepairComplete', 'false') === 'true';
+		if (!$legacyRowTransferRunComplete || $sequenceRepairComplete) {
+			return;
+		}
+
+		$platform = $this->db->getDatabasePlatform();
+		if (!$platform->supportsSequences()) {
+			$this->config->setAppValue('tables', 'sequenceRepairComplete', 'true');
+			return;
+		}
+
+		$newSequenceOffset = $this->getNewOffset();
+		if ($newSequenceOffset === null) {
+			// no data, no op
+			$this->config->setAppValue('tables', 'sequenceRepairComplete', 'true');
+			return;
+		}
+
+		$schema = $this->db->createSchema();
+		$sequences = $schema->getSequences();
+
+		$candidates = array_filter($sequences, function (string $sequenceName): bool {
+			return str_contains($sequenceName, 'tables_row_sleeves');
+		}, ARRAY_FILTER_USE_KEY);
+
+		if (count($candidates) > 1) {
+			$this->logger->error('Unexpected number of sequences, aborting.', [
+				'app' => Application::APP_ID,
+				'sequences' => $candidates,
+			]);
+			throw new \LogicException('Failed to find the correct sequence.');
+		} elseif (count($candidates) === 0) {
+			// 🤷
+			$this->config->setAppValue('tables', 'sequenceRepairComplete', 'true');
+			return;
+		}
+		/** @var Sequence $sequence */
+		$sequence = $candidates[array_key_first($candidates)];
+
+		$this->db->executeStatement(sprintf('ALTER SEQUENCE %s RESTART START WITH %d', $sequence->getName(), $newSequenceOffset));
+		$this->config->setAppValue('tables', 'sequenceRepairComplete', 'true');
+	}
+
+	protected function getNewOffset(): ?int {
+		$maxIdFromSleeves = $this->getMaxIdFromTable('tables_row_sleeves');
+		$maxIdFromLegacy = $this->getMaxIdFromTable('tables_rows');
+
+		if ($maxIdFromSleeves === null && $maxIdFromLegacy === null) {
+			return null;
+		}
+
+		return 1 + max($maxIdFromSleeves ?? -1, $maxIdFromLegacy ?? -1);
+	}
+
+	protected function getMaxIdFromTable(string $tableName): ?int {
+		$maxQuerySleeves = $this->db->getQueryBuilder();
+		$result = $maxQuerySleeves->select($maxQuerySleeves->createFunction('MAX(' . $maxQuerySleeves->getColumnName('id') . ')'))
+			->from($tableName)
+			->executeQuery();
+
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return $row ? (int)$row[array_key_first($row)] : null;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -34,6 +34,7 @@
 				<referencedClass name="Doctrine\DBAL\Exception\TableNotFoundException" />
 				<referencedClass name="Doctrine\DBAL\Exception\UniqueConstraintViolationException" />
 				<referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform" />
+				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="Doctrine\DBAL\Types\Types" />
 				<referencedClass name="OC\Core\Command\Base" />
@@ -47,6 +48,7 @@
 				<referencedClass name="Doctrine\DBAL\Platforms\AbstractPlatform" />
 				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
 				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
+				<referencedClass name="Doctrine\DBAL\Schema\Sequence" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 			</errorLevel>
 		</UndefinedDocblockClass>


### PR DESCRIPTION
fixes #1029 

On (at least) Postgres the migration logic from 0.6.6 to 0.7 inserts rows into oc_tables_row_sleeves with the id parameter set. It is an autoincrement column, but when the ids are specified manually, the backing sequence is not updated automatically. It then leads to constraint violation when adding new rows.

Doctrine does not offer much to interact with sequences, so here is a fall back a manual query that follows SQL standard. 