### PR TITLE
perf: Avoid extra queries to get the view ownership

### DIFF
--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -39,8 +39,6 @@ use OCP\AppFramework\Db\Entity;
  * @method setFavorite(bool $favorite)
  * @method getRowsCount(): int
  * @method setRowsCount(int $rowCount)
- * @method getOwnership(): string
- * @method setOwnership(string $ownership)
  * @method getOwnerDisplayName(): string
  * @method setOwnerDisplayName(string $ownerDisplayName)
  */
@@ -120,6 +118,14 @@ class View extends Entity implements JsonSerializable {
 	 */
 	private function getSharePermissions(): ?array {
 		return $this->getOnSharePermissions();
+	}
+
+	public function getOwnership(): ?string {
+		return $this->ownership;
+	}
+
+	public function setOwnership(string $ownership): void {
+		$this->ownership = $ownership;
 	}
 
 	/**


### PR DESCRIPTION
Currently we were doing n+1 queries just to get the ownership for each table.

We should also add a index for the table_id column on oc_tables_views, but tracking that in #982 