### PR TITLE
ci(integration): tests against context updates

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8219,39 +8219,33 @@
                         }
                     },
                     {
-                        "name": "nodes",
+                        "name": "nodes[]",
                         "in": "query",
                         "description": "optional nodes to be connected to this context",
                         "schema": {
+                            "type": "array",
                             "default": [],
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "required": [
-                                        "id",
-                                        "type",
-                                        "permissions"
-                                    ],
-                                    "properties": {
-                                        "id": {
-                                            "type": "integer",
-                                            "format": "int64"
-                                        },
-                                        "type": {
-                                            "type": "integer",
-                                            "format": "int64"
-                                        },
-                                        "permissions": {
-                                            "type": "integer",
-                                            "format": "int64"
-                                        }
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "id",
+                                    "type"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "type": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64"
                                     }
-                                },
-                                {
-                                    "type": "array",
-                                    "maxLength": 0
                                 }
-                            ]
+                            }
                         }
                     },
                     {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -3087,14 +3087,14 @@ export type operations = {
         /** @description Descriptive text of the context */
         description?: string;
         /** @description optional nodes to be connected to this context */
-        nodes?: OneOf<[{
-          /** Format: int64 */
-          id: number;
-          /** Format: int64 */
-          type: number;
-          /** Format: int64 */
-          permissions: number;
-        }, unknown[]]>;
+        "nodes[]"?: {
+            /** Format: int64 */
+            id: number;
+            /** Format: int64 */
+            type: number;
+            /** Format: int64 */
+            permissions?: number;
+          }[];
       };
       header: {
         /** @description Required to be true for the API request to pass */

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -244,3 +244,94 @@ Feature: APIv2
     Then the reported status is "404"
     When user "participant1-v2" attempts to fetch Context "NON-EXISTENT"
     Then the reported status is "404"
+
+  @api2 @contexts @contexts-update
+  Scenario: Update an owned context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant1-v2" updates Context "c1" by setting
+      | property    | value                 |
+      | name        | Psychedelic Drawer    |
+      | iconName    | thermostat            |
+      | description | Roll With the Punches |
+    Then the reported status is "200"
+    When user "participant1-v2" fetches Context "c1"
+    Then known Context "c1" has "name" set to "Psychedelic Drawer"
+    And known Context "c1" has "icon" set to "thermostat"
+    And known Context "c1" has "description" set to "Roll With the Punches"
+
+  @api2 @contexts @contexts-update
+  Scenario: Update an inaccessible context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant2-v2" updates Context "c1" by setting
+      | property    | value                 |
+      | name        | Psychedelic Drawer    |
+      | iconName    | thermostat            |
+      | description | Roll With the Punches |
+    Then the reported status is "404"
+    When user "participant1-v2" fetches Context "c1"
+    Then known Context "c1" has "name" set to "Enchanting Guitar"
+    And known Context "c1" has "icon" set to "tennis"
+    And known Context "c1" has "description" set to "Lorem ipsum dolor etc pp"
+
+  @api2 @contexts @contexts-update
+  Scenario: Add a table to an owned context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+    When user "participant1-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | t2    | table | read                |
+    Then the reported status is "200"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+      | node  | table:t2:read                |
+
+  @api2 @contexts @contexts-update
+  Scenario: Add a table to an inaccessible context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant2-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+    When user "participant2-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create         |
+      | t2    | table | read                |
+    Then the reported status is "404"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+
+  @api2 @contexts @contexts-update
+  Scenario: Add an inaccessible table to an owned context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant2-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant1-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | t2    | table | read                |
+    Then the reported status is "200"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+    And the fetched Context "c1" does not contain following data:
+      | field | value                        |
+      | node  | table:t2:read                |

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -335,3 +335,61 @@ Feature: APIv2
     And the fetched Context "c1" does not contain following data:
       | field | value                        |
       | node  | table:t2:read                |
+
+  @api2 @contexts @contexts-update
+  Scenario: Add an inaccessible table to an inaccessible context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant2-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,created,update |
+    When user "participant2-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | t2    | table | read                |
+    Then the reported status is "404"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+    And the fetched Context "c1" does not contain following data:
+      | field | value                        |
+      | node  | table:t2:read                |
+
+  @api2 @contexts @contexts-update
+  Scenario: Remove a table from an owned context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | t2    | table | read                |
+    When user "participant1-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+    Then the reported status is "200"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+    And the fetched Context "c1" does not contain following data:
+      | field | value                        |
+      | node  | table:t2:read                |
+
+  @api2 @contexts @contexts-update
+  Scenario: Remove a non-existing table from an inaccessible context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And table "Table 2 via api v2" with emoji "📸" exists for user "participant1-v2" as "t2" via v2
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+      | t2    | table | read                |
+    When user "participant2-v2" updates the nodes of the Context "c1" to
+      | alias | type  | permissions         |
+      | t1    | table | read,create,update  |
+    Then the reported status is "404"
+    When user "participant1-v2" fetches Context "c1"
+    Then the fetched Context "c1" has following data:
+      | field | value                        |
+      | node  | table:t1:read,create,update  |
+      | node  | table:t2:read                |


### PR DESCRIPTION
contributes to #1006 ("Updating Context")

- includes a fix that ensures the data types and presence of required data in `$nodes` parameters on Controller level instead. This includes an compatible open API update ("permissions" not required anymore, defaults to READ).