### PR TITLE
enh(App): navigation tweaks for Contexts

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -10,6 +10,7 @@ return [
 			'verb' => 'OPTIONS', 'requirements' => ['path' => '.+']],
 
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+		['name' => 'page#context', 'url' => '/app/{contextId}', 'verb' => 'GET'],
 
 		['name' => 'tableTemplate#list', 'url' => '/table/templates', 'verb' => 'GET'],
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -6,16 +6,21 @@ use OCA\Tables\AppInfo\Application;
 use OCA\Text\Event\LoadEditor;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\Util;
 
 class PageController extends Controller {
-	private IEventDispatcher $eventDispatcher;
 
-	public function __construct(IRequest $request, IEventDispatcher $eventDispatcher) {
+	public function __construct(
+		IRequest $request,
+		protected IEventDispatcher $eventDispatcher,
+		protected INavigationManager $navigationManager,
+		protected IInitialState $initialState,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -36,5 +41,23 @@ class PageController extends Controller {
 		}
 
 		return new TemplateResponse(Application::APP_ID, 'main');
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @IgnoreOpenAPI
+	 *
+	 * Render default template
+	 *
+	 * @psalm-param int<0, max> $appId
+	 */
+	public function context(int $contextId): TemplateResponse {
+		$navId = Application::APP_ID . '_application_' . $contextId;
+		$this->navigationManager->setActiveEntry($navId);
+
+		$this->initialState->provideInitialState('contextId', $contextId);
+
+		return $this->index();
 	}
 }

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -74,8 +74,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 					$iconUrl = $this->urlGenerator->imagePath('core', 'places/default-app-icon.svg');
 				}
 
-				$contextUrl = $this->urlGenerator->linkToRoute('tables.page.index');
-				$contextUrl .= sprintf('#/application/%d', $context->getId());
+				$contextUrl = $this->urlGenerator->linkToRoute('tables.page.context', ['contextId' => $context->getId()]);
 
 				return [
 					'id' => Application::APP_ID . '_application_' . $context->getId(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nextcloud/dialogs": "^4.2.7",
         "@nextcloud/event-bus": "^3.2.0",
         "@nextcloud/files": "^3.1.1",
+        "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.0.1",
         "@nextcloud/moment": "^1.3.1",
         "@nextcloud/router": "^3.0.1",
@@ -3679,12 +3680,12 @@
       }
     },
     "node_modules/@nextcloud/initial-state": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.1.0.tgz",
-      "integrity": "sha512-b92X/GvUPGQJpUQwauyG3D3dHsWowViVLnTtFPSMUc0rXtvYR5CvhkqJRfPC7O7W4VC7+V3q+FWeA+mQWMxN2Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
+      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/l10n": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nextcloud/dialogs": "^4.2.7",
     "@nextcloud/event-bus": "^3.2.0",
     "@nextcloud/files": "^3.1.1",
+    "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/l10n": "^3.0.1",
     "@nextcloud/moment": "^1.3.1",
     "@nextcloud/router": "^3.0.1",

--- a/src/modules/navigation/sections/Navigation.vue
+++ b/src/modules/navigation/sections/Navigation.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcAppNavigation>
+	<NcAppNavigation v-if="!isStandaloneContext">
 		<template #list>
 			<div class="filter-box">
 				<NcTextField :value.sync="filterString" :label="t('tables', 'Filter items')"
@@ -107,6 +107,7 @@ import { emit } from '@nextcloud/event-bus'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import Archive from 'vue-material-design-icons/Archive.vue'
 import { getCurrentUser } from '@nextcloud/auth'
+import { loadState } from '@nextcloud/initial-state'
 
 export default {
 	name: 'Navigation',
@@ -176,6 +177,15 @@ export default {
 		},
 		getAllContexts() {
 			return this.contexts.filter(context => context.name.toLowerCase().includes(this.filterString.toLowerCase()))
+		},
+		isStandaloneContext() {
+			try {
+				// this state is only set by the PageController.context route
+				loadState('tables', 'contextId', undefined)
+				return true
+			} catch (e) {
+				return false
+			}
 		},
 	},
 	methods: {


### PR DESCRIPTION
This is a more finegrained approach to to #933. The PR introduces an endpoint for each Context, so they can have the correct navigation item highlighted from the beginning, solving a known papercut from https://github.com/nextcloud/tables/pull/1037

It also sets an initial state, so that in Vue we can apply the actual route. Alas, the Vue Router adds the same information into the address bar, duplicating "app[lication]" and the context id. This is not nice. I reset it to the original URL (accepting #/), but it comes at the cost of flickering. In Vue the route cannot be applied without changing the address bar, which is a known drawback.

Another tweak: I disable the app navigation, when the Context is opened from its specific URL, making it more "standalone". Questionable if we want it. There are alternatives also: filtering the Tables and Views to only those included in the Context, and not showing applications; or (perhaps in future) a Context-specific app navigation (maybe relevant once we make use of pages).

What is not included in the Controller is a check whether a Context is actually having a navigation bar entry. So far we did not expose the setting, so all Contexts are shown there anyway. But even if not, I am not sure this is an issue (user has access anyways).

Please check the annotated video for a recorded quick tour.

https://github.com/nextcloud/tables/assets/2184312/f99ea308-9a30-4284-a62b-9ce9e8bc8cc6