### PR TITLE
fix(Context): do not show hidden columns

### DIFF
--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -164,7 +164,6 @@ export default {
 						const view = this.views.find(view => view.id === node.node_id)
 						await this.$store.dispatch('loadColumnsFromBE', {
 							view,
-							tableId: view.tableId,
 						})
 						await this.$store.dispatch('loadRowsFromBE', {
 							viewId: view.id,


### PR DESCRIPTION
There are two endpoints for loading the columns of a view. When using that one against a table scope, all columns will be returned, while fetching only those against the direct view endpoint, only those are returned that actually should be displayed. When opening the classic view, the later is called. In Contexts/Applications, the first one was called resulting in empty columns. This changes fixes it.

In the screenshot you see that "Last time spotted" is not shown after the change, as it is supposed to given the View configuration (hence no values are shown before either).

| Before  | After |
| --- | --- |
| ![before](https://github.com/nextcloud/tables/assets/2184312/f41bed53-28fa-42bb-a45c-5670676ec17f) |  ![after](https://github.com/nextcloud/tables/assets/2184312/31ab5471-5bed-4415-81cc-ed2359c62743) |
