### PR TITLE
enh: gitignore Cypress download folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ tests/unit/.phpunit.result.cache
 /gen/
 .DS_Store
 /cypress/videos
+/cypress/downloads
 /vendor-bin/*/vendor


### PR DESCRIPTION
Any screenshots or downloads from running Cypress tests are stored in the cypress/downloads folder. I don't think anything from here should be commited. 