### PR TITLE
fix: insert context startpage for proper update

### DIFF
--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -127,8 +127,8 @@ class ContextService {
 			if (!empty($nodes)) {
 				$context->resetUpdatedFields();
 				$this->insertNodesFromArray($context, $nodes);
-				$this->insertPage($context);
 			}
+			$this->insertPage($context);
 		}, $this->dbc);
 
 		return $context;

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -430,17 +430,20 @@ class ContextService {
 		$addedPage = $page->jsonSerialize();
 
 		$i = 1;
-		foreach ($context->getNodes() as $node) {
-			$pageContent = new PageContent();
-			$pageContent->setPageId($page->getId());
-			$pageContent->setNodeRelId($node['id']);
-			$pageContent->setOrder(10 * $i++);
-
-			$this->pageContentMapper->insert($pageContent);
-
-			$addedPage['content'][$pageContent->getId()] = $pageContent->jsonSerialize();
-			// the content is already embedded in the page
-			unset($addedPage['content'][$pageContent->getId()]['pageId']);
+		$contextNodes = $context->getNodes();
+		if ($contextNodes) {
+			foreach ($contextNodes as $node) {
+				$pageContent = new PageContent();
+				$pageContent->setPageId($page->getId());
+				$pageContent->setNodeRelId($node['id']);
+				$pageContent->setOrder(10 * $i++);
+	
+				$this->pageContentMapper->insert($pageContent);
+	
+				$addedPage['content'][$pageContent->getId()] = $pageContent->jsonSerialize();
+				// the content is already embedded in the page
+				unset($addedPage['content'][$pageContent->getId()]['pageId']);
+			}
 		}
 
 		$context->setPages([$addedPage['id'] => $addedPage]);


### PR DESCRIPTION
There's a bug with updating context. To reproduce:
- Create a context without any tables/views
- Save context
- Edit context and add a table or view
- Try to save. There's an error. 

<details>
  <summary>Error Trace</summary>

  ```json
                  "OCA\\Tables\\Controller\\ContextController",
                  "update",
                  [
                     "OC\\AppFramework\\DependencyInjection\\DIContainer"
                  ],
                  [
                     "1",
                     "ocs.tables.context.update"
                  ]
               ]
            },
            {
               "file":"/var/www/html/ocs/v1.php",
               "line":43,
               "function":"match",
               "class":"OC\\Route\\Router",
               "type":"->",
               "args":[
                  "/ocsapp/apps/tables/api/2/contexts/1"
               ]
            },
            {
               "file":"/var/www/html/ocs/v2.php",
               "line":7,
               "args":[
                  "/var/www/html/ocs/v1.php"
               ],
               "function":"require_once"
            }
         ],
         "File":"/var/www/html/apps/tables/lib/Db/PageContentMapper.php",
         "Line":37
      },
      "message":"OCA\\Tables\\Db\\PageContentMapper::findByPageAndNodeRelation(): Argument #1 ($pageId) must be of type int, null given, called in /var/www/html/apps/tables/lib/Service/ContextService.php on line 365 in file '/var/www/html/apps/tables/lib/Db/PageContentMapper.php' line 37",
      "exception":{
         
      },
      "CustomMessage":"OCA\\Tables\\Db\\PageContentMapper::findByPageAndNodeRelation(): Argument #1 ($pageId) must be of type int, null given, called in /var/www/html/apps/tables/lib/Service/ContextService.php on line 365 in file '/var/www/html/apps/tables/lib/Db/PageContentMapper.php' line 37"
   }
}

  ```
</details>

The problem occured because there's no startpage inserted when an "empty" context without resources is created. 