### PR TITLE
fix: pass view as prop to EmptyView

### DIFF
--- a/src/modules/main/sections/EmptyView.vue
+++ b/src/modules/main/sections/EmptyView.vue
@@ -2,7 +2,7 @@
 	<NcEmptyContent :name="t('tables', 'No columns selected')"
 		:description="t('tables', 'The view is empty. Edit which columns should be displayed.')">
 		<template #icon>
-			{{ activeView.emoji }}
+			{{ view.emoji }}
 		</template>
 		<template #action>
 			<NcButton :aria-label="t('table', 'Edit view')" type="primary" @click="editView()">
@@ -13,7 +13,6 @@
 </template>
 <script>
 import { NcEmptyContent, NcButton } from '@nextcloud/vue'
-import { mapGetters } from 'vuex'
 import { emit } from '@nextcloud/event-bus'
 
 export default {
@@ -22,12 +21,15 @@ export default {
 		NcEmptyContent,
 		NcButton,
 	},
-	computed: {
-		...mapGetters(['activeView']),
+	props: {
+		view: {
+			type: Object,
+			default: null,
+		},
 	},
 	methods: {
 		editView() {
-			emit('tables:view:edit', { view: this.activeView, viewSetting: {} })
+			emit('tables:view:edit', { view: this.view, viewSetting: {} })
 		},
 	},
 }

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -2,7 +2,7 @@
 	<div>
 		<ElementTitle :active-element="view" :is-table="false" :view-setting.sync="localViewSetting" />
 		<div class="table-wrapper">
-			<EmptyView v-if="columns.length === 0" />
+			<EmptyView v-if="columns.length === 0"  :view="view"/>
 			<TableView v-else
 				:rows="rows"
 				:columns="columns"

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -2,7 +2,7 @@
 	<div>
 		<ElementTitle :active-element="view" :is-table="false" :view-setting.sync="localViewSetting" />
 		<div class="table-wrapper">
-			<EmptyView v-if="columns.length === 0"  :view="view"/>
+			<EmptyView v-if="columns.length === 0" :view="view" />
 			<TableView v-else
 				:rows="rows"
 				:columns="columns"


### PR DESCRIPTION
When an empty view is in a context, sometimes, the `activeView` is null which breaks the component. It's better if we just pass in the view as a prop, just like we do for `EmptyTable`. 