### PR TITLE
fix: add aria-label to NcSelect

### DIFF
--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -45,7 +45,7 @@
 					</template>
 				</NcButton>
 				<div class="page-number">
-					<NcSelect v-model="pageNumber" :options="allPageNumbersArray">
+					<NcSelect v-model="pageNumber" :options="allPageNumbersArray" :aria-label-combobox="t('tables', 'Page number')">
 						<template #selected-option-container="{ option }">
 							<span class="selected-page">
 								{{ option.label }} of {{ totalPages }}


### PR DESCRIPTION
It's good for accessibility if the `NcSelect` component has an aria-label. 
Plus, this fixes the error in the console:
<details>
<summary> Console Error </summary>
vue.runtime.esm.js:4625 [Vue warn]: [NcSelect] An `inputLabel` or `ariaLabelCombobox` should be set. If an external label is used, `labelOutside` should be set to `true`.
found in
---> <NcSelect>
       <CustomTable> at src/shared/components/ncTable/sections/CustomTable.vue
         <NcTable> at src/shared/components/ncTable/NcTable.vue
           <TableView> at src/modules/main/partials/TableView.vue
             <DataTable> at src/modules/main/sections/DataTable.vue
               <TableWrapper> at src/modules/main/sections/TableWrapper.vue
                 <Context> at src/pages/Context.vue
                   <NcAppContent>
                     <NcContent>
                       <App> at src/App.vue
                         <Root>
</details>