### PR TITLE
enh(API): add OCS API to create rows

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -131,6 +131,7 @@ return [
 
 		['name' => 'ApiFavorite#create', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'POST', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],
 		['name' => 'ApiFavorite#destroy', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'DELETE', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],
+
 		['name' => 'Context#index', 'url' => '/api/2/contexts', 'verb' => 'GET'],
 		['name' => 'Context#show', 'url' => '/api/2/contexts/{contextId}', 'verb' => 'GET'],
 		['name' => 'Context#create', 'url' => '/api/2/contexts', 'verb' => 'POST'],
@@ -138,5 +139,7 @@ return [
 		['name' => 'Context#destroy', 'url' => '/api/2/contexts/{contextId}', 'verb' => 'DELETE'],
 		['name' => 'Context#transfer', 'url' => '/api/2/contexts/{contextId}/transfer', 'verb' => 'PUT'],
 		['name' => 'Context#updateContentOrder', 'url' => '/api/2/contexts/{contextId}/pages/{pageId}', 'verb' => 'PUT'],
+
+		['name' => 'RowOCS#createRow',	'url' => '/api/2/{nodeCollection}/{nodeId}/rows', 'verb' => 'POST', 'requirements' => ['nodeCollection' => '(tables|views)', 'nodeId' => '(\d+)']],
 	]
 ];

--- a/lib/Controller/RowOCSController.php
+++ b/lib/Controller/RowOCSController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace OCA\Tables\Controller;
+
+use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Errors\BadRequestError;
+use OCA\Tables\Errors\InternalError;
+use OCA\Tables\Errors\NotFoundError;
+use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Helper\ConversionHelper;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
+use OCA\Tables\Model\RowDataInput;
+use OCA\Tables\ResponseDefinitions;
+use OCA\Tables\Service\RowService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @psalm-import-type TablesRow from ResponseDefinitions
+ */
+class RowOCSController extends AOCSController {
+
+	public function __construct(
+		IRequest $request,
+		LoggerInterface $logger,
+		IL10N $n,
+		string $userId,
+		protected RowService $rowService,
+	) {
+		parent::__construct($request, $logger, $n, $userId);
+	}
+
+	/**
+	 * [api v2] Create a new row in a table or a view
+	 *
+	 * @param 'tables'|'views' $nodeCollection Indicates whether to create a row on a table or view
+	 * @param int $nodeId The identifier of the targeted table or view
+	 * @param string|array{columnId: int, value: mixed} $data An array containing the column identifiers and their values
+	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row returned
+	 * 400: Invalid request parameters
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 *
+	 * @NoAdminRequired (26 compatibility)
+	 */
+	#[NoAdminRequired]
+	#[RequirePermission(permission: Application::PERMISSION_CREATE, typeParam: 'nodeCollection')]
+	public function createRow(string $nodeCollection, int $nodeId, mixed $data): DataResponse {
+		if (is_string($data)) {
+			$data = json_decode($data, true);
+		}
+		if (!is_array($data)) {
+			return $this->handleBadRequestError(new BadRequestError('Cannot create row: data input is invalid.'));
+		}
+
+		$iNodeType = ConversionHelper::stringNodeType2Const($nodeCollection);
+		$tableId = $viewId = null;
+		if ($iNodeType === Application::NODE_TYPE_TABLE) {
+			$tableId = $nodeId;
+		} elseif ($iNodeType === Application::NODE_TYPE_VIEW) {
+			$viewId = $nodeId;
+		}
+
+		$newRowData = new RowDataInput();
+		foreach ($data as $key => $value) {
+			$newRowData->add((int)$key, $value);
+		}
+
+		try {
+			return new DataResponse($this->rowService->create($tableId, $viewId, $newRowData)->jsonSerialize());
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+}

--- a/lib/Helper/ConversionHelper.php
+++ b/lib/Helper/ConversionHelper.php
@@ -23,8 +23,8 @@ class ConversionHelper {
 	 */
 	public static function stringNodeType2Const(string $nodeType): int {
 		return match ($nodeType) {
-			'table' => Application::NODE_TYPE_TABLE,
-			'view' => Application::NODE_TYPE_VIEW,
+			'table', 'tables' => Application::NODE_TYPE_TABLE,
+			'view', 'views' => Application::NODE_TYPE_VIEW,
 			default => throw new InvalidArgumentException('Invalid node type'),
 		};
 	}

--- a/lib/Helper/ConversionHelper.php
+++ b/lib/Helper/ConversionHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OCA\Tables\Helper;
+
+use InvalidArgumentException;
+use OCA\Tables\AppInfo\Application;
+
+class ConversionHelper {
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	public static function constNodeType2String(int $nodeType): string {
+		return match ($nodeType) {
+			Application::NODE_TYPE_TABLE => 'table',
+			Application::NODE_TYPE_VIEW => 'view',
+			default => throw new InvalidArgumentException('Invalid node type'),
+		};
+	}
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	public static function stringNodeType2Const(string $nodeType): int {
+		return match ($nodeType) {
+			'table' => Application::NODE_TYPE_TABLE,
+			'view' => Application::NODE_TYPE_VIEW,
+			default => throw new InvalidArgumentException('Invalid node type'),
+		};
+	}
+}

--- a/lib/Middleware/PermissionMiddleware.php
+++ b/lib/Middleware/PermissionMiddleware.php
@@ -2,10 +2,12 @@
 
 namespace OCA\Tables\Middleware;
 
+use InvalidArgumentException;
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Helper\ConversionHelper;
 use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\PermissionsService;
 use OCP\AppFramework\Http;
@@ -76,11 +78,11 @@ class PermissionMiddleware extends Middleware {
 				// currently they are only passed as string as well
 				$isContext = true;
 			} else {
-				$nodeType = match ($nodeType) {
-					'table' => Application::NODE_TYPE_TABLE,
-					'view' => Application::NODE_TYPE_VIEW,
-					default => throw new InternalError('Invalid node type'),
-				};
+				try {
+					$nodeType = ConversionHelper::stringNodeType2Const((string)$nodeType);
+				} catch (InvalidArgumentException) {
+					throw new InternalError('Invalid node type');
+				}
 			}
 		} elseif (!in_array((int)$nodeType, [Application::NODE_TYPE_TABLE, Application::NODE_TYPE_VIEW], true)) {
 			throw new InternalError('Invalid node type');
@@ -88,6 +90,7 @@ class PermissionMiddleware extends Middleware {
 		$nodeType = (int)$nodeType;
 
 		// pre-test: if the node is not accessible in first place, we do not have to reveal it
+		// this is also an assertion for READ permissions.
 		if ($isContext) {
 			if (!$this->permissionsService->canAccessContextById($nodeId, $this->userId)) {
 				throw new NotFoundError();
@@ -98,21 +101,78 @@ class PermissionMiddleware extends Middleware {
 			}
 		}
 
-		if ($attribute->getPermission() === Application::PERMISSION_MANAGE) {
-			if (!$isContext) {
-				if (!$this->permissionsService->canManageNodeById($nodeType, $nodeId, $this->userId)) {
-					throw new PermissionError(sprintf('User %s cannot manage node %d (type %d)',
-						$this->userId, $nodeId, $nodeType
-					));
-				}
-			} else {
-				if (!$this->permissionsService->canManageContextById($nodeId, $this->userId)) {
-					throw new PermissionError(sprintf('User %s cannot manage context %d',
-						$this->userId, $nodeId
-					));
-				}
+		match ($attribute->getPermission()) {
+			Application::PERMISSION_MANAGE => $this->assertManagePermission($isContext, $nodeType, $nodeId),
+			Application::PERMISSION_CREATE => $this->assertCreatePermissions($nodeType, $nodeId),
+			Application::PERMISSION_UPDATE => $this->assertUpdatePermissions($nodeType, $nodeId),
+			Application::PERMISSION_DELETE => $this->assertDeletePermissions($nodeType, $nodeId),
+			Application::PERMISSION_ALL => $this->assertManagePermission($isContext, $nodeType, $nodeId)
+				&& $this->assertCreatePermissions($nodeType, $nodeId)
+				&& $this->assertUpdatePermissions($nodeType, $nodeId)
+				&& $this->assertDeletePermissions($nodeType, $nodeId),
+		};
+	}
+
+	/**
+	 * @throws PermissionError
+	 */
+	private function assertCreatePermissions(int $nodeType, int $nodeId): bool {
+		if (!$this->permissionsService->canCreateRowsById($nodeType, $nodeId, $this->userId)) {
+			throw new PermissionError(sprintf('User %s cannot create rows on node %d (type %d)',
+				$this->userId, $nodeId, $nodeType
+			));
+		}
+		return true;
+	}
+
+	/**
+	 * @throws PermissionError
+	 */
+	private function assertUpdatePermissions(int $nodeType, int $nodeId): bool {
+		if (
+			($nodeType === Application::NODE_TYPE_TABLE && !$this->permissionsService->canUpdateRowsByTableId($nodeId, $this->userId))
+			|| ($nodeType === Application::NODE_TYPE_VIEW && !$this->permissionsService->canUpdateRowsByViewId($nodeId, $this->userId))
+		) {
+			throw new PermissionError(sprintf('User %s cannot update rows on node %d (type %d)',
+				$this->userId, $nodeId, $nodeType
+			));
+		}
+		return true;
+	}
+
+	/**
+	 * @throws PermissionError
+	 */
+	private function assertDeletePermissions(int $nodeType, int $nodeId): bool {
+		if (
+			($nodeType === Application::NODE_TYPE_TABLE && !$this->permissionsService->canDeleteRowsByTableId($nodeId, $this->userId))
+			|| ($nodeType === Application::NODE_TYPE_VIEW && !$this->permissionsService->canDeleteRowsByViewId($nodeId, $this->userId))
+		) {
+			throw new PermissionError(sprintf('User %s cannot delete rows on node %d (type %d)',
+				$this->userId, $nodeId, $nodeType
+			));
+		}
+		return true;
+	}
+
+	/**
+	 * @throws PermissionError
+	 */
+	private function assertManagePermission(bool $isContext, int $nodeType, int $nodeId): bool {
+		if (!$isContext) {
+			if (!$this->permissionsService->canManageNodeById($nodeType, $nodeId, $this->userId)) {
+				throw new PermissionError(sprintf('User %s cannot manage node %d (type %d)',
+					$this->userId, $nodeId, $nodeType
+				));
+			}
+		} else {
+			if (!$this->permissionsService->canManageContextById($nodeId, $this->userId)) {
+				throw new PermissionError(sprintf('User %s cannot manage context %d',
+					$this->userId, $nodeId
+				));
 			}
 		}
+		return true;
 	}
 
 	/**

--- a/lib/Model/Permissions.php
+++ b/lib/Model/Permissions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OCA\Tables\Model;
+
+class Permissions {
+	public function __construct(
+		public bool $read = false,
+		public bool $create = false,
+		public bool $update = false,
+		public bool $delete = false,
+		public bool $manage = false,
+		public bool $manageTable = false,
+	) {
+	}
+}

--- a/lib/Model/RowDataInput.php
+++ b/lib/Model/RowDataInput.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OCA\Tables\Model;
+
+use ArrayAccess;
+
+/**
+ * @template-implements ArrayAccess<mixed, array{'columnId': int, 'value': mixed}>
+ */
+class RowDataInput implements ArrayAccess {
+	protected const DATA_KEY = 'columnId';
+	protected const DATA_VAL = 'value';
+	/** @psalm-var array<array{'columnId': int, 'value': mixed}> */
+	protected array $data = [];
+
+	public function add(int $columnId, string $value): self {
+		$this->data[] = [self::DATA_KEY => $columnId, self::DATA_VAL => $value];
+		return $this;
+	}
+
+	public function offsetExists(mixed $offset): bool {
+		foreach ($this->data as $data) {
+			if ($data[self::DATA_KEY] === $offset[self::DATA_KEY]) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function offsetGet(mixed $offset): mixed {
+		return $this->data[$offset];
+	}
+
+	public function offsetSet(mixed $offset, mixed $value): void {
+		$this->data[$offset] = $value;
+	}
+
+	public function offsetUnset(mixed $offset): void {
+		if (isset($this->data[$offset])) {
+			unset($this->data[$offset]);
+		}
+	}
+}

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -13,6 +13,7 @@ use OCA\Tables\Db\View;
 use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
+use OCA\Tables\Helper\ConversionHelper;
 use OCA\Tables\Helper\UserHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -315,6 +316,11 @@ class PermissionsService {
 		return $this->checkPermission($element, 'view', 'create', $userId);
 	}
 
+	public function canCreateRowsById(int $nodeType, int $nodeId, ?string $userId = null): bool {
+		$sNodeType = ConversionHelper::constNodeType2String($nodeType);
+		return $this->checkPermissionById($nodeId, $sNodeType, 'create', $userId);
+	}
+
 	/**
 	 * @param int $viewId
 	 * @param string|null $userId
@@ -332,7 +338,6 @@ class PermissionsService {
 	public function canUpdateRowsByTableId(int $tableId, ?string $userId = null): bool {
 		return $this->checkPermissionById($tableId, 'table', 'update', $userId);
 	}
-
 
 	/**
 	 * @param int $viewId
@@ -470,10 +475,7 @@ class PermissionsService {
 	public function getPermissionIfAvailableThroughContext(int $nodeId, string $nodeType, string $userId): int {
 		$permissions = 0;
 		$found = false;
-		$iNodeType = match ($nodeType) {
-			'table' => Application::NODE_TYPE_TABLE,
-			'view' => Application::NODE_TYPE_VIEW,
-		};
+		$iNodeType = ConversionHelper::stringNodeType2Const($nodeType);
 		$contexts = $this->contextMapper->findAllContainingNode($iNodeType, $nodeId, $userId);
 		foreach ($contexts as $context) {
 			$found = true;

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -14,6 +14,7 @@ use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
 use OCA\Tables\Event\RowDeletedEvent;
+use OCA\Tables\Model\RowDataInput;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\ColumnTypes\IColumnTypeBusiness;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -152,7 +153,7 @@ class RowService extends SuperService {
 	/**
 	 * @param int|null $tableId
 	 * @param int|null $viewId
-	 * @param list<array{columnId: int, value: mixed}> $data
+	 * @param RowDataInput|list<array{columnId: int, value: mixed}> $data
 	 * @return Row2
 	 *
 	 * @throws NotFoundError
@@ -160,7 +161,7 @@ class RowService extends SuperService {
 	 * @throws Exception
 	 * @throws InternalError
 	 */
-	public function create(?int $tableId, ?int $viewId, array $data): Row2 {
+	public function create(?int $tableId, ?int $viewId, RowDataInput|array $data): Row2 {
 		if ($this->userId === null || $this->userId === '') {
 			$e = new \Exception('No user id in context, but needed.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
@@ -221,7 +222,7 @@ class RowService extends SuperService {
 	}
 
 	/**
-	 * @param list<array{columnId: string|int, value: mixed}> $data
+	 * @param RowDataInput|list<array{columnId: string|int, value: mixed}> $data
 	 * @param Column[] $columns
 	 * @param int|null $tableId
 	 * @param int|null $viewId
@@ -229,7 +230,7 @@ class RowService extends SuperService {
 	 *
 	 * @throws InternalError
 	 */
-	private function cleanupData(array $data, array $columns, ?int $tableId, ?int $viewId): array {
+	private function cleanupData(RowDataInput|array $data, array $columns, ?int $tableId, ?int $viewId): array {
 		$out = [];
 		foreach ($data as $entry) {
 			$column = $this->getColumnFromColumnsArray((int) $entry['columnId'], $columns);

--- a/openapi.json
+++ b/openapi.json
@@ -9018,6 +9018,282 @@
                     }
                 }
             }
+        },
+        "/ocs/v2.php/apps/tables/api/2/{nodeCollection}/{nodeId}/rows": {
+            "post": {
+                "operationId": "rowocs-create-row",
+                "summary": "[api v2] Create a new row in a table or a view",
+                "tags": [
+                    "rowocs"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "data"
+                                ],
+                                "properties": {
+                                    "data": {
+                                        "description": "An array containing the column identifiers and their values",
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "object",
+                                                "required": [
+                                                    "columnId",
+                                                    "value"
+                                                ],
+                                                "properties": {
+                                                    "columnId": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "value": {
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "nodeCollection",
+                        "in": "path",
+                        "description": "Indicates whether to create a row on a table or view",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "tables",
+                                "views"
+                            ],
+                            "pattern": "^(tables|views)$"
+                        }
+                    },
+                    {
+                        "name": "nodeId",
+                        "in": "path",
+                        "description": "The identifier of the targeted table or view",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Row returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/Row"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -220,6 +220,10 @@ export type paths = {
     /** [api v2] Update the order on a page of a context */
     put: operations["context-update-content-order"];
   };
+  "/ocs/v2.php/apps/tables/api/2/{nodeCollection}/{nodeId}/rows": {
+    /** [api v2] Create a new row in a table or a view */
+    post: operations["rowocs-create-row"];
+  };
 };
 
 export type webhooks = Record<string, never>;
@@ -3816,6 +3820,98 @@ export type operations = {
           };
         };
       };
+      500: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  /** [api v2] Create a new row in a table or a view */
+  "rowocs-create-row": {
+    parameters: {
+      header: {
+        /** @description Required to be true for the API request to pass */
+        "OCS-APIRequest": boolean;
+      };
+      path: {
+        /** @description Indicates whether to create a row on a table or view */
+        nodeCollection: "tables" | "views";
+        /** @description The identifier of the targeted table or view */
+        nodeId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description An array containing the column identifiers and their values */
+          data: OneOf<[string, {
+            /** Format: int64 */
+            columnId: number;
+            value: Record<string, never>;
+          }]>;
+        };
+      };
+    };
+    responses: {
+      /** @description Row returned */
+      200: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: components["schemas"]["Row"];
+            };
+          };
+        };
+      };
+      /** @description Invalid request parameters */
+      400: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+      /** @description No permissions */
+      403: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+      /** @description Not found */
+      404: {
+        content: {
+          "application/json": {
+            ocs: {
+              meta: components["schemas"]["OCSMeta"];
+              data: {
+                message: string;
+              };
+            };
+          };
+        };
+      };
+      /** @description Internal error */
       500: {
         content: {
           "application/json": {

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -542,3 +542,265 @@ Feature: APIv2
     Then the reported status is "404"
     When user "participant3-v2" attempts to fetch Context "c1"
     Then the reported status is "404"
+
+  @api2 @rows
+  Scenario: Create rows via v2 and check them
+    Given table "Rows check" with emoji "👨🏻‍💻" exists for user "participant1-v2" as "base1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    When row exists using v2 with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 200
+
+  @api2 @rows
+  Scenario: Try to create rows via v2 with permissions
+    Given table "Rows check" with emoji "👨🏻‍💻" exists for user "participant1-v2" as "base1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" shares table with user "participant2-v2"
+    And user "participant2-v2" has the following permissions
+      | read    | 1 |
+      | create  | 1 |
+      | update  | 1 |
+      | delete  | 0 |
+      | manage  | 0 |
+    When user "participant2-v2" tries to create a row using v2 with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 200
+
+  @api2 @rows
+  Scenario: Try to create rows via v2 without permissions
+    Given table "Rows check" with emoji "👨🏻‍💻" exists for user "participant1-v2" as "base1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" shares table with user "participant2-v2"
+    And user "participant1-v2" sets permission "create" to 0
+    And user "participant2-v2" has the following permissions
+      | read    | 1 |
+      | create  | 0 |
+      | update  | 1 |
+      | delete  | 0 |
+      | manage  | 0 |
+    When user "participant2-v2" tries to create a row using v2 with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 403
+
+  @api2 @rows
+  Scenario: Try to create rows via v2 without access
+    Given table "Rows check" with emoji "👨🏻‍💻" exists for user "participant1-v2" as "base3" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    When user "participant2-v2" tries to create a row using v2 with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 404
+
+  @api2 @rows @views
+  Scenario: Create rows on a view via v2
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    When user "participant1-v2" tries to create a row using v2 on "view" "v1" with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 200
+
+  @api2 @rows @views
+  Scenario: Create rows on a view via v2 with permissions
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" shares view "v1" with "participant2-v2"
+    When user "participant2-v2" tries to create a row using v2 on "view" "v1" with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 200
+
+  @api2 @rows @views
+  Scenario: Create rows on a view via v2 without permissions
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" shares view "v1" with "participant2-v2"
+    And user "participant1-v2" sets permission "create" to 0
+    When user "participant2-v2" tries to create a row using v2 on "view" "v1" with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 403
+
+  @api2 @rows @views
+  Scenario: Create rows on a view via v2 without access
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "one" exists with following properties
+      | type          | text                    |
+      | subtype       | line                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And column "two" exists with following properties
+      | type          | number                  |
+      | mandatory     | 1                       |
+      | numberDefault | 10                      |
+      | description   | This is a description!  |
+    And column "three" exists with following properties
+      | type          | selection               |
+      | subtype       | check                   |
+      | mandatory     | 1                       |
+      | description   | This is a description!  |
+    And column "four" exists with following properties
+      | type          | datetime                |
+      | subtype       | date                    |
+      | mandatory     | 0                       |
+      | description   | This is a description!  |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    When user "participant2-v2" tries to create a row using v2 on "view" "v1" with following values
+      | one           | AHA                     |
+      | two           | 161                     |
+      | three         | true                    |
+      | four          | 2023-12-24              |
+    Then the reported status is 404

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -81,10 +81,19 @@ echo ''
 echo '#'
 echo '# Stopping PHP webserver and disabling spreedcheats'
 echo '#'
-kill $PHPPID1
-kill $PHPPID2
 
-wait $PHPPID1
-wait $PHPPID2
+if ps --pid ${PHPPID1} > /dev/null; then
+	kill ${PHPPID1}
+fi
+if ps --pid ${PHPPID2} > /dev/null; then
+	kill ${PHPPID2}
+fi
+
+if ps --pid ${PHPPID1} > /dev/null; then
+	wait ${PHPPID1}
+fi
+if ps --pid ${PHPPID2} > /dev/null; then
+	wait ${PHPPID2} || true
+fi
 
 exit $RESULT


### PR DESCRIPTION
solves #1105 

also features
:sparkles: completed and flexible PermissionMiddleware
:sparkles: integration tests of new endpoint against both tables and views, owners and sharees, negative tests
:sparkles: the advertised new OCS endpoint for creating rows
:sparkles: helper model to avoid a loose array with set or not set keys flying around
:sparkles: simple conversion helper to translate stringy node types to ints and other way around

Open question: should I create endpoints for all other row-related methods as well? Would make sense, this feels incomplete. Can do a follow up as well of course.