### PR TITLE
fix: Navigation table entries UI issues

### DIFF
--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -20,7 +20,7 @@
 
 		<template #counter>
 			<NcCounterBubble v-if="canReadData(table)">
-				{{ n('tables', ' %n ',table.rowsCount) }}
+				{{ table.rowsCount }}
 			</NcCounterBubble>
 			<NcActionButton v-if="table.hasShares" icon="icon-share" :class="{'margin-right': !(activeTable && table.id === activeTable.id)}" @click="actionShowShare" />
 			<div v-if="table.isShared && table.ownership !== userId" class="margin-left">
@@ -279,7 +279,7 @@ export default {
 
 .app-navigation-entry.active {
 	.icon-share  {
-		background-image: var(--icon-share-white);
+		background-image: var(--icon-share-white)
 	}
 
 	.icon-collapse {

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -20,7 +20,7 @@
 
 		<template #counter>
 			<NcCounterBubble v-if="canReadData(table)">
-				{{ n('tables', '%n row', '%n rows', table.rowsCount, {}) }}
+				{{ n('tables', ' %n ',table.rowsCount) }}
 			</NcCounterBubble>
 			<NcActionButton v-if="table.hasShares" icon="icon-share" :class="{'margin-right': !(activeTable && table.id === activeTable.id)}" @click="actionShowShare" />
 			<div v-if="table.isShared && table.ownership !== userId" class="margin-left">
@@ -277,8 +277,14 @@ export default {
 </script>
 <style lang="scss">
 
-.app-navigation-entry.active .icon-share {
-	background-image: var(--icon-share-white);
+.app-navigation-entry.active {
+	.icon-share  {
+		background-image: var(--icon-share-white);
+	}
+
+	.icon-collapse {
+		color: var(--color-primary-element-text)
+	}
 }
 
 .app-navigation-entry__counter-wrapper {

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -277,6 +277,10 @@ export default {
 </script>
 <style lang="scss">
 
+.app-navigation-entry.active .icon-share {
+	background-image: var(--icon-share-white);
+}
+
 .app-navigation-entry__counter-wrapper {
 	button.action-button {
 		padding-right: 0;

--- a/src/modules/navigation/partials/NavigationViewItem.vue
+++ b/src/modules/navigation/partials/NavigationViewItem.vue
@@ -15,7 +15,7 @@
 		</template>
 		<template #counter>
 			<NcCounterBubble v-if="canReadData(view)">
-				{{ n('tables', '%n row', '%n rows', view.rowsCount, {}) }}
+				{{ n('tables', ' %n ', view.rowsCount) }}
 			</NcCounterBubble>
 			<NcActionButton v-if="view.hasShares" icon="icon-share" :class="{'margin-right': !(activeView && view.id === activeView.id)}" @click="actionShowShare" />
 			<div v-if="view.isShared && view.ownership !== userId && !canManageTable(view) && showShareSender" class="margin-left">

--- a/src/modules/navigation/partials/NavigationViewItem.vue
+++ b/src/modules/navigation/partials/NavigationViewItem.vue
@@ -15,7 +15,7 @@
 		</template>
 		<template #counter>
 			<NcCounterBubble v-if="canReadData(view)">
-				{{ n('tables', ' %n ', view.rowsCount) }}
+				{{ view.rowsCount }}
 			</NcCounterBubble>
 			<NcActionButton v-if="view.hasShares" icon="icon-share" :class="{'margin-right': !(activeView && view.id === activeView.id)}" @click="actionShowShare" />
 			<div v-if="view.isShared && view.ownership !== userId && !canManageTable(view) && showShareSender" class="margin-left">


### PR DESCRIPTION
fixes #1191 

- [x] The counter (3 rows) is cut off, we should probably just use the number as it is done in other apps without the word rows

- [x]  text and icon color is inconsistent in dark mode (should use the proper css var for text on primary)

#### Before
![image](https://github.com/user-attachments/assets/c540c10a-ccab-4cbf-8c4b-5888842a2b1e)


#### After
![Screenshot from 2024-07-15 13-38-18](https://github.com/user-attachments/assets/a264a990-dc7c-432d-b99f-bb4b67d8e48d)

