### PR TITLE
fix(files): remove pagination of there is just one page

### DIFF
--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -32,7 +32,7 @@
 				<tr />
 			</tbody>
 		</table>
-		<div class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">
+		<div v-if="totalPages > 1" class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">
 			<div class="pagination-items">
 				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" @click="pageNumber = 1">
 					<template #icon>
@@ -415,11 +415,9 @@ export default {
 }
 
 .pagination-footer{
-	position: sticky;
 	box-shadow: var(--box-shadow);
-	filter: drop-shadow(0 1px 10px var(--color-box-shadow));
-	bottom: 20px;
-	left: 300px;
+	filter: drop-shadow(0 1px 6px var(--color-box-shadow));
+	padding-bottom: 20px;
 	width: calc(100vw - 316px);
 	pointer-events: none;
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/tables/issues/1211

- remove pagination of there is just one page
- set spread for the box shadow to 6px
- remove sticky position

## Screenshots

Before | After
---|---
![Peek 2024-07-18 16-041](https://github.com/user-attachments/assets/df3b015a-3ecc-4339-9294-d33728622abb) | ![Peek 2024-07-18 16-04](https://github.com/user-attachments/assets/74a1ce98-2423-4def-a043-372b3a0656de)

