### PR TITLE
fix(files): align icon to center

### DIFF
--- a/src/modules/modals/CreateContext.vue
+++ b/src/modules/modals/CreateContext.vue
@@ -10,7 +10,7 @@
 				<div class="col-4 mandatory">
 					{{ t('tables', 'Title') }}
 				</div>
-				<div class="col-4" style="display: inline-flex;">
+				<div class="col-4 content-emoji">
 					<NcIconPicker :close-on-select="true" @select="setIcon">
 						<NcButton
 							type="tertiary"
@@ -167,5 +167,10 @@ export default {
 <style lang="scss" scoped>
 .modal__content {
 	padding-right: 0 !important;
+
+	.content-emoji {
+		display: inline-flex;
+		align-items: center;
+	}
 }
 </style>

--- a/src/modules/modals/CreateTable.vue
+++ b/src/modules/modals/CreateTable.vue
@@ -7,11 +7,11 @@
 					<h2>{{ t('tables', 'Create table') }}</h2>
 				</div>
 			</div>
-			<div class="row space-T">
+			<div class="row">
 				<div class="col-4 mandatory">
 					{{ t('tables', 'Title') }}
 				</div>
-				<div class="col-4" style="display: inline-flex;">
+				<div class="col-4 content-emoji">
 					<NcEmojiPicker :close-on-select="true" @select="setIcon">
 						<NcButton type="tertiary"
 							:aria-label="t('tables', 'Select emoji for table')"
@@ -29,7 +29,7 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-4 mandatory">
+				<div class="col-4 space-T mandatory">
 					{{ t('tables', 'Description') }}
 				</div>
 				<div class="col-4">
@@ -236,6 +236,10 @@ export default {
 
 .modal__content {
 	padding-right: 0 !important;
+	.content-emoji {
+		display: inline-flex;
+		align-items: center;
+	}
 }
 
 </style>

--- a/src/modules/modals/EditTable.vue
+++ b/src/modules/modals/EditTable.vue
@@ -12,7 +12,7 @@
 				<div class="col-4 mandatory">
 					{{ t('tables', 'Title') }}
 				</div>
-				<div class="col-3 inline">
+				<div class="col-3 content-emoji">
 					<NcEmojiPicker :close-on-select="true" @select="emoji => icon = emoji">
 						<NcButton type="tertiary"
 							:aria-label="t('tables', 'Select emoji for table')"
@@ -28,7 +28,7 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-4 mandatory">
+				<div class="col-4 space-T mandatory">
 					{{ t('tables', 'Description') }}
 				</div>
 				<div class="col-4">
@@ -191,6 +191,11 @@ export default {
 :deep(.element-description) {
 	padding-inline: 0 !important;
 	max-width: 100%;
+}
+
+.content-emoji {
+	display: inline-flex;
+	align-items: center;
 }
 
 </style>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/tables/issues/1214

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2024-07-18 11-15-11](https://github.com/user-attachments/assets/b0ac0719-c2f6-48e5-974c-c84c6e5d48b4) | ![Screenshot from 2024-07-26 10-48-10](https://github.com/user-attachments/assets/a5c8b7f4-187c-42a4-834c-3704de48f725) |-------------|---------------------------------------------------------------|
| ![Screenshot from 2024-07-18 11-15-31](https://github.com/user-attachments/assets/e22bd2b8-5e57-4e56-b3a9-a32146d7fc93) | ![Screenshot from 2024-07-26 10-47-57](https://github.com/user-attachments/assets/90b9257f-e86b-4c85-85d9-7b411cf729fe) |-------------|---------------------------------------------------------------|