### PR TITLE
fix: Avoid variable access on unhandled exception and lower log level for expected permission check failures

### DIFF
--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -553,7 +553,7 @@ class PermissionsService {
 				}
 			} catch (NotFoundError $e) {
 			}
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			$this->logger->info($e->getMessage(), ['exception' => $e]);
 		}
 
 		return false;
@@ -580,7 +580,7 @@ class PermissionsService {
 					}
 				} catch (NotFoundError $e) {
 				}
-				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				$this->logger->info($e->getMessage(), ['exception' => $e]);
 			}
 		}
 		return false;

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -374,10 +374,9 @@ class ViewService extends SuperService {
 							$manageTableShare = $this->shareService->getSharedPermissionsIfSharedWithMe($view->getTableId(), 'table', $userId);
 						} catch (NotFoundError) {
 							$manageTableShare = $this->permissionsService->getPermissionArrayForNodeFromContexts($view->getTableId(), 'table', $userId);
-						} finally {
-							if ($manageTableShare->manage) {
-								$permissions->manageTable = true;
-							}
+						}
+						if ($manageTableShare->manage) {
+							$permissions->manageTable = true;
 						}
 					} catch (NotFoundError $e) {
 					} catch (\Exception $e) {


### PR DESCRIPTION
Fixes a couple of log findings:

https://nextcloud-gmbh.sentry.io/share/issue/541ed23a30da423b81b8ec43d52a9d8b/
https://nextcloud-gmbh.sentry.io/share/issue/e8250bd9c66e4cf89d77665744ae96d9/
https://nextcloud-gmbh.sentry.io/share/issue/855f1af7127d422d923a6bdd2ea4872f/