### PR TITLE
Add SPDX header - Part 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml.license
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/.github/ISSUE_TEMPLATE/feature-request.yml.license
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-
+#
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 cd ..
 
 echo

--- a/LICENSES/CC-BY-SA-2.0.txt
+++ b/LICENSES/CC-BY-SA-2.0.txt
@@ -1,0 +1,85 @@
+Creative Commons Attribution-ShareAlike 2.0
+
+ CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM ITS USE.
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+
+1. Definitions
+
+     a. "Collective Work" means a work, such as a periodical issue, anthology or encyclopedia, in which the Work in its entirety in unmodified form, along with a number of other contributions, constituting separate and independent works in themselves, are assembled into a collective whole. A work that constitutes a Collective Work will not be considered a Derivative Work (as defined below) for the purposes of this License.
+
+     b. "Derivative Work" means a work based upon the Work or upon the Work and other pre-existing works, such as a translation, musical arrangement, dramatization, fictionalization, motion picture version, sound recording, art reproduction, abridgment, condensation, or any other form in which the Work may be recast, transformed, or adapted, except that a work that constitutes a Collective Work will not be considered a Derivative Work for the purpose of this License. For the avoidance of doubt, where the Work is a musical composition or sound recording, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered a Derivative Work for the purpose of this License.
+
+     c. "Licensor" means the individual or entity that offers the Work under the terms of this License.
+
+     d. "Original Author" means the individual or entity who created the Work.
+
+     e. "Work" means the copyrightable work of authorship offered under the terms of this License.
+
+     f. "You" means an individual or entity exercising rights under this License who has not previously violated the terms of this License with respect to the Work, or who has received express permission from the Licensor to exercise rights under this License despite a previous violation.
+
+     g. "License Elements" means the following high-level license attributes as selected by Licensor and indicated in the title of this License: Attribution, ShareAlike.
+
+2. Fair Use Rights. Nothing in this license is intended to reduce, limit, or restrict any rights arising from fair use, first sale or other limitations on the exclusive rights of the copyright owner under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) license to exercise the rights in the Work as stated below:
+
+     a. to reproduce the Work, to incorporate the Work into one or more Collective Works, and to reproduce the Work as incorporated in the Collective Works;
+
+     b. to create and reproduce Derivative Works;
+
+     c. to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission the Work including as incorporated in Collective Works;
+
+     d. to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission Derivative Works.
+
+     e. For the avoidance of doubt, where the work is a musical composition:
+
+          i. Performance Royalties Under Blanket Licenses. Licensor waives the exclusive right to collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC), royalties for the public performance or public digital performance (e.g. webcast) of the Work.
+
+          ii. Mechanical Rights and Statutory Royalties. Licensor waives the exclusive right to collect, whether individually or via a music rights society or designated agent (e.g. Harry Fox Agency), royalties for any phonorecord You create from the Work ("cover version") and distribute, subject to the compulsory license created by 17 USC Section 115 of the US Copyright Act (or the equivalent in other jurisdictions).
+
+     f. Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where the Work is a sound recording, Licensor waives the exclusive right to collect, whether individually or via a performance-rights society (e.g. SoundExchange), royalties for the public digital performance (e.g. webcast) of the Work, subject to the compulsory license created by 17 USC Section 114 of the US Copyright Act (or the equivalent in other jurisdictions).
+
+The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats. All rights not expressly granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made subject to and limited by the following restrictions:
+
+     a. You may distribute, publicly display, publicly perform, or publicly digitally perform the Work only under the terms of this License, and You must include a copy of, or the Uniform Resource Identifier for, this License with every copy or phonorecord of the Work You distribute, publicly display, publicly perform, or publicly digitally perform. You may not offer or impose any terms on the Work that alter or restrict the terms of this License or the recipients' exercise of the rights granted hereunder. You may not sublicense the Work. You must keep intact all notices that refer to this License and to the disclaimer of warranties. You may not distribute, publicly display, publicly perform, or publicly digitally perform the Work with any technological measures that control access or use of the Work in a manner inconsistent with the terms of this License Agreement. The above applies to the Work as incorporated in a Collective Work, but this does not require the Collective Work apart from the Work itself to be made subject to the terms of this License. If You create a Collective Work, upon notice from any Licensor You must, to the extent practicable, remove from the Collective Work any reference to such Licensor or the Original Author, as requested. If You create a Derivative Work, upon notice from any Licensor You must, to the extent practicable, remove from the Derivative Work any reference to such Licensor or the Original Author, as requested.
+
+     b. You may distribute, publicly display, publicly perform, or publicly digitally perform a Derivative Work only under the terms of this License, a later version of this License with the same License Elements as this License, or a Creative Commons iCommons license that contains the same License Elements as this License (e.g. Attribution-ShareAlike 2.0 Japan). You must include a copy of, or the Uniform Resource Identifier for, this License or other license specified in the previous sentence with every copy or phonorecord of each Derivative Work You distribute, publicly display, publicly perform, or publicly digitally perform. You may not offer or impose any terms on the Derivative Works that alter or restrict the terms of this License or the recipients' exercise of the rights granted hereunder, and You must keep intact all notices that refer to this License and to the disclaimer of warranties. You may not distribute, publicly display, publicly perform, or publicly digitally perform the Derivative Work with any technological measures that control access or use of the Work in a manner inconsistent with the terms of this License Agreement. The above applies to the Derivative Work as incorporated in a Collective Work, but this does not require the Collective Work apart from the Derivative Work itself to be made subject to the terms of this License.
+
+     c. If you distribute, publicly display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works, You must keep intact all copyright notices for the Work and give the Original Author credit reasonable to the medium or means You are utilizing by conveying the name (or pseudonym if applicable) of the Original Author if supplied; the title of the Work if supplied; to the extent reasonably practicable, the Uniform Resource Identifier, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work; and in the case of a Derivative Work, a credit identifying the use of the Work in the Derivative Work (e.g., "French translation of the Work by Original Author," or "Screenplay based on original Work by Original Author"). Such credit may be implemented in any reasonable manner; provided, however, that in the case of a Derivative Work or Collective Work, at a minimum such credit will appear where any other comparable authorship credit appears and in a manner at least as prominent as such other comparable authorship credit.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE MATERIALS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+     a. This License and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this License. Individuals or entities who have received Derivative Works or Collective Works from You under this License, however, will not have their licenses terminated provided such individuals or entities remain in full compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
+
+     b. Subject to the above terms and conditions, the license granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different license terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this License (or any other license that has been, or is required to be, granted under the terms of this License), and this License will continue in full force and effect unless terminated as stated above.
+
+8. Miscellaneous
+
+     a. Each time You distribute or publicly digitally perform the Work or a Collective Work, the Licensor offers to the recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
+
+     b. Each time You distribute or publicly digitally perform a Derivative Work, Licensor offers to the recipient a license to the original Work on the same terms and conditions as the license granted to You under this License.
+
+     c. If any provision of this License is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this License, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+     d. No term or provision of this License shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent.
+
+     e. This License constitutes the entire agreement between the parties with respect to the Work licensed here. There are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You. This License may not be modified without the mutual written agreement of the Licensor and You.
+
+Creative Commons is not a party to this License, and makes no warranty whatsoever in connection with the Work. Creative Commons will not be liable to You or any party on any legal theory for any damages whatsoever, including without limitation any general, special, incidental or consequential damages arising in connection to this license. Notwithstanding the foregoing two (2) sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it shall have all rights and obligations of Licensor.
+
+Except for the limited purpose of indicating to the public that the Work is licensed under the CCPL, neither party will use the trademark "Creative Commons" or any related trademark or logo of Creative Commons without the prior written consent of Creative Commons. Any permitted use will be in compliance with Creative Commons' then-current trademark usage guidelines, as may be published on its website or otherwise made available upon request from time to time.
+
+Creative Commons may be contacted at http://creativecommons.org/.

--- a/LICENSES/LicenseRef-AppleAppStoreBadge.txt
+++ b/LICENSES/LicenseRef-AppleAppStoreBadge.txt
@@ -1,0 +1,46 @@
+App Store Badges
+
+Include App Store badges in all digital and printed marketing materials as a clear call to action to get your app. App Store badges are available in 40 localizations to help you reach a broader audience. Versions are available for the App Store for iPhone and iPad, the Mac App Store, and Apple TV.
+
+
+Preferred Badges
+
+Use the preferred black badge in all marketing communications promoting your app. The gray border surrounding the black badge is part of the badge artwork and should not be modified. Whenever one or more badges for other app platforms appear in the layout, use the preferred black badge. Place the App Store badge first in the lineup of badges.
+
+
+Legal Requirements
+Trademark Symbols
+
+In communications distributed only in the United States, the appropriate symbol (™, ℠, or ®) must follow each Apple trademark the first time it is mentioned in body copy. Do not use trademark symbols on products, product documentation, or other product communications that will be distributed outside the United States.
+
+For example, use Apple Watch®, iPhone®, iPad®, iPod touch®, Apple TV®, App Store®, Mac App Store℠, Mac®, MacBook Pro®, MacBook Air®, and iMac®.
+
+Don’t add symbols to headline copy or to the App Store badge artwork provided by Apple.
+
+For the correct trademark symbols, refer to the Apple Trademark List.
+Credit Lines
+
+Use the appropriate credit lines in all communications worldwide, listing all the Apple trademarks and products included in your communication and advertising. Include the credit lines only once in your communication or website, and place the credit lines wherever you provide legal notification. Follow standard practices for the placement of legal copy, such as creating additional screens or providing interactive links. When the App Store badge is used, credit both Apple and the Apple Logo.
+
+Refer to the Apple Trademark List for the correct trademark symbol, spelling of the trademark, and generic term to use with the trademark. Generally, the symbol appears at the right shoulder of the trademark (except the Apple Logo, where the logo appears at the right foot).
+
+Use the following formats for distribution within the United States only:
+
+______ and ______ are registered trademarks of Apple Inc.
+
+______ and ______ are trademarks of Apple Inc.
+
+For distribution outside the United States, use one of the following international credit notices:
+
+______ and______ are trademarks of Apple Inc., registered in the U.S. and other countries.
+
+______ and______ are trademarks of Apple Inc.
+
+A translation of the legal notice and credit lines (but not the trademarks) can be used in materials distributed outside the U.S.
+
+For more information on using Apple trademarks, see Using Apple Trademarks and Copyrights.
+Association with Apple
+
+Your app screen images, Mac, Apple Watch, iPhone, iPad, iPod touch, and Apple TV product images, or photographs thereof cannot be used in any manner that falsely suggests an association with Apple or is likely to reduce, diminish, or damage the goodwill, value, or reputation associated with the App Store, the Mac App Store, iPhone, iPad, iPod touch, Apple Watch, Apple TV, or Apple itself.
+
+see https://developer.apple.com/app-store/marketing/guidelines/

--- a/LICENSES/LicenseRef-FacebookTrademarks.txt
+++ b/LICENSES/LicenseRef-FacebookTrademarks.txt
@@ -1,0 +1,17 @@
+Facebook brand resources and guidelines
+
+The logo is our most important brand asset. We use it with consistency and intention to represent the world of social discovery to billions of people around the world.
+
+Our Logo Evolution
+
+Our logo has evolved over time, building on our past heritage, using an 'f' within a blue circle. The current logo has been refined in shape and color to make it more accessible and legible. Always ensure you are using the current version of our logo in any new designs or communications.
+
+Legal
+
+Meta dedicates substantial resources to the development and protection of its intellectual property. In addition to seeking registration of its trademarks and logos around the world, Meta enforces its rights against people who misuse its trademarks.
+
+Meta's trademarks are owned by Meta and may only be used as provided in these guidelines or with Meta’s permission. A list of some of Meta’s trademarks can be found here (https://about.meta.com/brand/resources/meta/our-trademarks/). You may not use or register, or otherwise claim rights in any Meta trademark, including as or as part of any trademark, service mark, company name, trade name, username or domain registration. You should not use or claim rights in any trademark in a way that is confusingly similar to or dilutive of Meta’s trademarks, including as, or as any part of, a trademark. Do not use Meta's trademarks for anything that would be inconsistent with Meta’s Terms of Service (https://www.facebook.com/terms.php) or Community Standards (https://transparency.meta.com/policies/community-standards/).
+
+We may revoke permission to use Meta’s trademarks at any time. Meta reserves the right to withhold approval of content that it considers inconsistent with the Meta brand.
+
+A copy can be found at https://about.meta.com/brand/resources/facebook/logo/

--- a/LICENSES/LicenseRef-GooglePlayBadge.txt
+++ b/LICENSES/LicenseRef-GooglePlayBadge.txt
@@ -1,0 +1,23 @@
+badge guidelines
+Dos & Don'ts
+
+Follow these guidelines whenever you are using a Google Play badge.
+
+* Use the badges as provided. Never alter the badges.
+* There must be clear space surrounding the badge equal to one-quarter the height of the badge.
+* The badge must be large enough that all of the text is legible.
+* The Google Play badge should be the same size or larger than other application store badges.
+* Badges must be shown on a solid colored background or a simple background image that does not obscure the badge.
+* Match the badge language to the language of your marketing campaign whenever possible.
+* Any online use of the badge must link to the Google Play store. Use the generator below to get the HTML to include in your digital marketing.
+* The badge can only be used to promote content available on Google Play.
+* Include the appropriate Google Play legal attribution when there is space in the creative. See the badge generator for localized legal attributions.
+* Use of the Google Play badge must be reviewed and approved by the Google Play Partner Brand team if the badge will be in:
+  * a TV commercial
+  * an out-of-home marketing campaign
+  * a marketing campaign that will receive over 1 million impressions
+* Use this form (https://partnermarketinghub.withgoogle.com/login/?next=/submit-assets/) to submit your marketing for approval.
+
+see https://play.google.com/intl/en_us/badges/
+
+Google Play and the Google Play logo are trademarks of Google LLC.

--- a/LICENSES/LicenseRef-MastodonTrademarks.txt
+++ b/LICENSES/LicenseRef-MastodonTrademarks.txt
@@ -1,0 +1,46 @@
+Trademark Policy
+
+Last updated December 21, 2022
+
+The Mastodon name and logos are trademarks of Mastodon gGmbH. As such, their use is restricted and protected by intellectual property law. While the software we create is available under a free and open source software license, the copyright license does not include an implied right or license to use our trademarks.
+
+The role of trademarks is to prevent the exploitation of the good name and reputation of Mastodon by other people and organizations, and to provide assurance about the quality of the products and services associated with it.
+
+To use our trademarks beyond what is considered "fair" or "nominative" use, you must follow these guidelines. By making use of our trademarks, you agree to abide by the following terms and conditions. You further agree that any dispute arising in connection with your use of our trademarks or under these terms and conditions shall be under the exclusive jurisdiction of the state and federal courts of New York in the United States of America and that the state and federal courts of New York shall have personal jurisdiction over you for the purposes of adjudicating any dispute concerning the use of our trademarks or these terms and conditions.
+
+You agree to defend and indemnify Mastodon gGmbH from and against any and all claims and losses brought by a third party in connection with your use of the Mastodon trademarks.
+
+To request the use of the Mastodon name and logos in a way not covered in these guidelines, or to report violations, please contact us at trademark@joinmastodon.org. In the event that we do not approve such use of the Mastodon name and logos within ten (10) business days, your request shall be deemed denied.
+General guidelines
+
+In general:
+
+* Only use the Mastodon marks to accurately identify those goods or services that are built using the Mastodon software.
+* Do not use the Mastodon marks in any way that could mistakenly imply that Mastodon GmbH has reviewed, approved, or guaranteed your goods or services.
+* Do not use or register, in whole or in part, the Mastodon marks as part of your own or any other trademark, service mark, domain name, company name, trade name, product name, or service name.
+* Do not use the Mastodon marks in a manner that disparages or defames the marks, Mastodon gGmbH, or Mastodon’s products.
+* Do not use the Mastodon marks in connection with any illegal activity.
+* You may use the Mastodon word mark in referential phrases such as "for", "for use with", or "compatible with".
+* You may use the Mastodon marks when embedding or otherwise displaying user generated content published using the Mastodon software.
+* Do not change or modify the Mastodon marks.
+* Any all use of the Mastodon marks, and any goodwill accrued as a result of that use, belongs entirely to, and shall inure for the benefit of, Mastodon gGmbH.
+
+Server guidelines
+
+If you run your own Mastodon server using the Mastodon software, including modified Mastodon software on the condition that the modifications are limited to switching on or off features already included in the software, minor tweaks in visual appearance, translations into other languages, and bug fixes:
+
+* You may not use the Mastodon word mark, or any similar mark, in your domain name, unless you have written permission from Mastodon gGmbH.
+* As long as you abide by the terms and conditions of this agreement, you may use the Mastodon marks included in the Mastodon server software for the purposes of running the server.
+
+Open source project guidelines
+
+If you choose to build on or modify Mastodon's open-source code, beyond modifications limited to switching on or off features already included in the software, minor tweaks in visual appearance, translations into other languages, and bug fixes:
+
+* You must choose your own branding, logos, and trademarks that denote your unique identity so as to clearly signal to users that there is no affiliation with or endorsement by Mastodon gGmbH.
+* You may use word marks, but not our logos, in truthful statements that describe the relationship between your software and ours, for example "this software is derived from the source code of the Mastodon software".
+
+Social media guidelines
+
+The name and handle of your social media account and any and all pages cannot begin with a Mastodon word mark, or a similar mark (e.g. "mastodoon", "mast0don", "mstdn"). In addition, Mastodon logos cannot be used in a way that might suggest affiliation with or endorsement by Mastodon.
+
+A copy can be found at https://joinmastodon.org/de/trademark

--- a/LICENSES/LicenseRef-NextcloudTrademarks.txt
+++ b/LICENSES/LicenseRef-NextcloudTrademarks.txt
@@ -1,0 +1,9 @@
+The Nextcloud marks
+Nextcloud and the Nextcloud logo is a registered trademark of Nextcloud GmbH in Germany and/or other countries.
+These guidelines cover the following marks pertaining both to the product names and the logo: “Nextcloud”
+and the blue/white cloud logo with or without the word Nextcloud; the service “Nextcloud Enterprise”;
+and our products: “Nextcloud Files”; “Nextcloud Groupware” and “Nextcloud Talk”.
+This set of marks is collectively referred to as the “Nextcloud marks.”
+
+Use of Nextcloud logos and other marks is only permitted under the guidelines provided by the Nextcloud GmbH.
+A copy can be found at https://discord.com/branding

--- a/LICENSES/LicenseRef-XTrademarks.txt
+++ b/LICENSES/LicenseRef-XTrademarks.txt
@@ -1,0 +1,49 @@
+Trademark policy
+April 2023
+
+
+You may not violate others’ intellectual property rights, including copyright and trademark.
+
+A trademark is a word, logo, phrase, or device that distinguishes a trademark holder’s good or service in the marketplace. Trademark law may prevent others from using a trademark in an unauthorized or confusing manner.  
+
+
+What is in violation of this policy?
+
+Using another’s trademark in a way that may mislead or confuse people about your affiliation may be a violation of our trademark policy.
+ 
+
+What is not a violation of this policy?
+
+Referencing another’s trademark is not automatically a violation of X's trademark policy. Examples of non-violations include:
+
+* using a trademark in a way that is outside the scope of the trademark registration e.g., in a different territory, or a different class of goods or services than that identified in the registration; and
+* using a trademark in a nominative or other fair use manner. For more information, see our Misleading and deceptive identities policy (https://help.twitter.com/en/rules-and-policies/twitter-impersonation-and-deceptive-identities-policy.html).
+ 
+
+Who can report violations of this policy?
+
+X only investigates requests that are submitted by the trademark holder or their authorized representative e.g., a legal representative or other representative for a brand. 
+ 
+
+How can I report violations of this policy?
+
+You can submit a trademark report through our trademark report form (https://help.twitter.com/forms/trademark). Please provide all the information requested in the form. If you submit an incomplete report, we’ll need to follow up about the missing information. Please note that this will result in a delay in processing your report.
+
+Note: We may provide the account holder with your name and other information included in the copy of the report.
+
+
+What happens if you violate this policy?
+
+If we determine that you violated our trademark policy, we may suspend your account. Depending on the type of violation, we may give you an opportunity to comply with our policies. In other instances, an account may be permanently suspended upon first review. If you believe that your account was suspended in error, you can submit an appeal (https://help.twitter.com/forms/general?subtopic=suspended).
+ 
+
+Additional resources
+
+Learn more about our range of enforcement options (https://help.twitter.com/rules-and-policies/enforcement-options) and our approach to policy development and enforcement (https://help.twitter.com/rules-and-policies/enforcement-philosophy).
+
+
+Legal disclaimer
+
+By using the X trademarks and resources on this site, you agree to follow the X Trademark Guidelines in our Brand Guidelines — as well as our Terms of Service and all other X rules and policies. If you have any questions, contact us at trademarks@x.com.
+
+A copy can be found at https://about.x.com/en/who-we-are/brand-toolkit and https://help.twitter.com/en/rules-and-policies/x-trademark-policy

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,3 +28,81 @@ path = ["img/app-dark.svg", "img/app.svg", "img/view.svg", "img/view-dark.svg", 
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2018-2024 Google LLC"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/loading-dark.gif", "cypress/styleguide/assets/img/loading-small-dark.gif", "cypress/styleguide/assets/img/loading-small.gif", "cypress/styleguide/assets/img/loading.gif"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016 ownCloud, Inc., 2016 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/favicon*.*", "cypress/styleguide/assets/img/logo/logo*.*", "cypress/styleguide/assets/img/apps/spreed.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016-2024 Nextcloud GmbH"
+SPDX-License-Identifier = "LicenseRef-NextcloudTrademarks"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/desktopapp.svg", "cypress/styleguide/assets/img/background.png", "cypress/styleguide/assets/img/background.svg", "cypress/styleguide/assets/img/categories/dashboard.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016-2024 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/filetypes/package-x-generic.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/actions/checkbox-mixed.svg", "cypress/styleguide/assets/img/actions/checkmark-white.svg", "cypress/styleguide/assets/img/actions/checkbox-mark-dark.svg", "cypress/styleguide/assets/img/actions/checkbox-mark-white.svg", "cypress/styleguide/assets/img/actions/checkbox-mark.svg", "cypress/styleguide/assets/img/actions/checkbox-mixed-dark.svg", "cypress/styleguide/assets/img/actions/checkbox-mixed-white.svg", "cypress/styleguide/assets/img/actions/checkbox-mixed.svg", "cypress/styleguide/assets/img/actions/checkmark-white.svg", "cypress/styleguide/assets/img/actions/checkmark.png", "cypress/styleguide/assets/img/actions/checkmark.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2017 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/filetypes/font.svg", "cypress/styleguide/assets/img/actions/star-rounded.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/filetypes/application-pdf.svg", "cypress/styleguide/assets/img/breadcrumb.svg", "cypress/styleguide/assets/img/filetypes/application.svg", "cypress/styleguide/assets/img/filetypes/audio.svg", "cypress/styleguide/assets/img/filetypes/file.svg", "cypress/styleguide/assets/img/filetypes/folder-drag-accept.svg", "cypress/styleguide/assets/img/filetypes/folder-encrypted.svg", "cypress/styleguide/assets/img/filetypes/folder-external.svg", "cypress/styleguide/assets/img/filetypes/folder-public.svg", "cypress/styleguide/assets/img/filetypes/folder-shared.svg", "cypress/styleguide/assets/img/filetypes/folder-starred.svg", "cypress/styleguide/assets/img/filetypes/folder.svg", "cypress/styleguide/assets/img/filetypes/image.svg", "cypress/styleguide/assets/img/filetypes/link.svg", "cypress/styleguide/assets/img/filetypes/location.svg", "cypress/styleguide/assets/img/filetypes/mindmap.svg", "cypress/styleguide/assets/img/filetypes/text-calendar.svg", "cypress/styleguide/assets/img/filetypes/text-code.svg", "cypress/styleguide/assets/img/filetypes/text-vcard.svg", "cypress/styleguide/assets/img/filetypes/text.svg", "cypress/styleguide/assets/img/filetypes/video.svg", "cypress/styleguide/assets/img/filetypes/x-office-document.svg", "cypress/styleguide/assets/img/filetypes/x-office-drawing.svg", "cypress/styleguide/assets/img/filetypes/x-office-form-template.svg", "cypress/styleguide/assets/img/filetypes/x-office-form.svg", "cypress/styleguide/assets/img/filetypes/x-office-presentation.svg", "cypress/styleguide/assets/img/filetypes/x-office-spreadsheet.svg", "cypress/styleguide/assets/img/places/calendar-dark.png", "cypress/styleguide/assets/img/places/calendar.png", "cypress/styleguide/assets/img/places/calendar.svg", "cypress/styleguide/assets/img/places/contacts-dark.png", "cypress/styleguide/assets/img/places/contacts.svg", "cypress/styleguide/assets/img/places/default-app-icon.svg", "cypress/styleguide/assets/img/places/files.svg", "cypress/styleguide/assets/img/places/home.svg", "cypress/styleguide/assets/img/places/link.svg", "cypress/styleguide/assets/img/places/music.svg", "cypress/styleguide/assets/img/places/picture.svg", "cypress/styleguide/assets/img/rating/s0.svg", "cypress/styleguide/assets/img/rating/s1.svg", "cypress/styleguide/assets/img/rating/s10.svg", "cypress/styleguide/assets/img/rating/s2.svg", "cypress/styleguide/assets/img/rating/s3.svg", "cypress/styleguide/assets/img/rating/s4.svg", "cypress/styleguide/assets/img/rating/s5.svg", "cypress/styleguide/assets/img/rating/s6.svg", "cypress/styleguide/assets/img/rating/s7.svg", "cypress/styleguide/assets/img/rating/s8.svg", "cypress/styleguide/assets/img/rating/s9.svg", "cypress/styleguide/assets/img/mail.svg", "cypress/styleguide/assets/img/rss.svg", "cypress/styleguide/assets/img/clients/desktop.svg", "cypress/styleguide/assets/img/clients/phone.svg", "cypress/styleguide/assets/img/clients/tablet.svg", "cypress/styleguide/assets/img/categories/auth.svg", "cypress/styleguide/assets/img/categories/bundles.svg", "cypress/styleguide/assets/img/categories/customization.svg", "cypress/styleguide/assets/img/categories/files.svg", "cypress/styleguide/assets/img/categories/games.svg", "cypress/styleguide/assets/img/categories/integration.svg", "cypress/styleguide/assets/img/categories/monitoring.svg", "cypress/styleguide/assets/img/categories/multimedia.svg", "cypress/styleguide/assets/img/categories/office.svg", "cypress/styleguide/assets/img/categories/organization.svg", "cypress/styleguide/assets/img/categories/social.svg", "cypress/styleguide/assets/img/categories/workflow.svg", "cypress/styleguide/assets/img/apps/circles.svg", "cypress/styleguide/assets/img/apps/notes.svg", "cypress/styleguide/assets/img/apps/richdocuments.svg", "cypress/styleguide/assets/img/caldav/attendees.png", "cypress/styleguide/assets/img/caldav/attendees.svg", "cypress/styleguide/assets/img/caldav/description.png", "cypress/styleguide/assets/img/caldav/description.svg", "cypress/styleguide/assets/img/caldav/link.png", "cypress/styleguide/assets/img/caldav/link.svg", "cypress/styleguide/assets/img/caldav/location.png", "cypress/styleguide/assets/img/caldav/location.svg", "cypress/styleguide/assets/img/caldav/organizer.png", "cypress/styleguide/assets/img/caldav/organizer.svg", "cypress/styleguide/assets/img/caldav/time.png", "cypress/styleguide/assets/img/caldav/time.svg", "cypress/styleguide/assets/img/caldav/title.png", "cypress/styleguide/assets/img/caldav/title.svg", "cypress/styleguide/assets/img/actions/add-folder-description.svg", "cypress/styleguide/assets/img/actions/add.svg", "cypress/styleguide/assets/img/actions/address.png", "cypress/styleguide/assets/img/actions/address.svg", "cypress/styleguide/assets/img/actions/alert-outline.svg", "cypress/styleguide/assets/img/actions/arrow-left.svg", "cypress/styleguide/assets/img/actions/arrow-right.svg", "cypress/styleguide/assets/img/actions/audio-off.svg", "cypress/styleguide/assets/img/actions/audio.svg", "cypress/styleguide/assets/img/actions/caret-white.svg", "cypress/styleguide/assets/img/actions/caret.svg", "cypress/styleguide/assets/img/actions/change.svg", "cypress/styleguide/assets/img/actions/clippy.svg", "cypress/styleguide/assets/img/actions/close.svg", "cypress/styleguide/assets/img/actions/comment.png", "cypress/styleguide/assets/img/actions/comment.svg", "cypress/styleguide/assets/img/actions/confirm-fade.svg", "cypress/styleguide/assets/img/actions/confirm-white.svg", "cypress/styleguide/assets/img/actions/confirm.svg", "cypress/styleguide/assets/img/actions/delete.png", "cypress/styleguide/assets/img/actions/delete.svg", "cypress/styleguide/assets/img/actions/details.svg", "cypress/styleguide/assets/img/actions/disabled-user.svg", "cypress/styleguide/assets/img/actions/disabled-users.svg", "cypress/styleguide/assets/img/actions/download.png", "cypress/styleguide/assets/img/actions/download.svg", "cypress/styleguide/assets/img/actions/edit.svg", "cypress/styleguide/assets/img/actions/error-white.svg", "cypress/styleguide/assets/img/actions/error.svg", "cypress/styleguide/assets/img/actions/external.svg", "cypress/styleguide/assets/img/actions/filter.svg", "cypress/styleguide/assets/img/actions/fullscreen.svg", "cypress/styleguide/assets/img/actions/group.svg", "cypress/styleguide/assets/img/actions/history.png", "cypress/styleguide/assets/img/actions/history.svg", "cypress/styleguide/assets/img/actions/info-white.svg", "cypress/styleguide/assets/img/actions/info.png", "cypress/styleguide/assets/img/actions/info.svg", "cypress/styleguide/assets/img/actions/logout.svg", "cypress/styleguide/assets/img/actions/mail.svg", "cypress/styleguide/assets/img/actions/menu-sidebar.svg", "cypress/styleguide/assets/img/actions/menu.svg", "cypress/styleguide/assets/img/actions/more-white.svg", "cypress/styleguide/assets/img/actions/more.png", "cypress/styleguide/assets/img/actions/more.svg", "cypress/styleguide/assets/img/actions/password-white.svg", "cypress/styleguide/assets/img/actions/password.png", "cypress/styleguide/assets/img/actions/password.svg", "cypress/styleguide/assets/img/actions/pause.svg", "cypress/styleguide/assets/img/actions/phone.svg", "cypress/styleguide/assets/img/actions/play-add.svg", "cypress/styleguide/assets/img/actions/play-next.svg", "cypress/styleguide/assets/img/actions/play-previous.svg", "cypress/styleguide/assets/img/actions/play.svg", "cypress/styleguide/assets/img/actions/profile.svg", "cypress/styleguide/assets/img/actions/projects.svg", "cypress/styleguide/assets/img/actions/public-white.svg", "cypress/styleguide/assets/img/actions/public.svg", "cypress/styleguide/assets/img/actions/quota.svg", "cypress/styleguide/assets/img/actions/recent.svg", "cypress/styleguide/assets/img/actions/rename.svg", "cypress/styleguide/assets/img/actions/screen-off.svg", "cypress/styleguide/assets/img/actions/screen.svg", "cypress/styleguide/assets/img/actions/search.svg", "cypress/styleguide/assets/img/actions/settings-dark.svg", "cypress/styleguide/assets/img/actions/settings.svg", "cypress/styleguide/assets/img/actions/share.png", "cypress/styleguide/assets/img/actions/share.svg", "cypress/styleguide/assets/img/actions/shared.svg", "cypress/styleguide/assets/img/actions/sound-off.svg", "cypress/styleguide/assets/img/actions/sound.svg", "cypress/styleguide/assets/img/actions/star-dark.svg", "cypress/styleguide/assets/img/actions/star.png", "cypress/styleguide/assets/img/actions/star.svg", "cypress/styleguide/assets/img/actions/starred.png", "cypress/styleguide/assets/img/actions/starred.svg", "cypress/styleguide/assets/img/actions/tag.png", "cypress/styleguide/assets/img/actions/tag.svg", "cypress/styleguide/assets/img/actions/template-add.svg", "cypress/styleguide/assets/img/actions/timezone.svg", "cypress/styleguide/assets/img/actions/toggle-background.svg", "cypress/styleguide/assets/img/actions/toggle-filelist.svg", "cypress/styleguide/assets/img/actions/toggle-pictures.svg", "cypress/styleguide/assets/img/actions/toggle.svg", "cypress/styleguide/assets/img/actions/triangle-e.svg", "cypress/styleguide/assets/img/actions/triangle-n.svg", "cypress/styleguide/assets/img/actions/triangle-s.svg", "cypress/styleguide/assets/img/actions/unshare.svg", "cypress/styleguide/assets/img/actions/upload.svg", "cypress/styleguide/assets/img/actions/user-admin.svg", "cypress/styleguide/assets/img/actions/user.svg", "cypress/styleguide/assets/img/actions/verified.svg", "cypress/styleguide/assets/img/actions/verify.svg", "cypress/styleguide/assets/img/actions/verifying.svg", "cypress/styleguide/assets/img/actions/video-off.svg", "cypress/styleguide/assets/img/actions/video-switch.svg", "cypress/styleguide/assets/img/actions/video.svg", "cypress/styleguide/assets/img/actions/view-close.svg", "cypress/styleguide/assets/img/actions/view-download.svg", "cypress/styleguide/assets/img/actions/view-next.svg", "cypress/styleguide/assets/img/actions/view-pause.svg", "cypress/styleguide/assets/img/actions/view-play.svg", "cypress/styleguide/assets/img/actions/view-previous.svg", "cypress/styleguide/assets/img/places/contacts-dark.png", "cypress/styleguide/assets/img/places/contacts.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2018-2024 Google LLC"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/background/kamil-porembinski-clouds.jpg", "cypress/styleguide/assets/img/app-background.jpg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2013 Kamil Porembiński <https://www.flickr.com/photos/paszczak000>"
+SPDX-License-Identifier = "CC-BY-SA-2.0"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/twitter.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "X Corp."
+SPDX-License-Identifier = "LicenseRef-XTrademarks"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/facebook.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Meta"
+SPDX-License-Identifier = "LicenseRef-FacebookTrademarks"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/mastodon.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Mastodon gGmbH"
+SPDX-License-Identifier = "LicenseRef-MastodonTrademarks"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/googleplay.png"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Google LLC."
+SPDX-License-Identifier = "LicenseRef-GooglePlayBadge"
+
+[[annotations]]
+path = ["cypress/styleguide/assets/img/appstore.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Apple Inc."
+SPDX-License-Identifier = "LicenseRef-AppleAppStoreBadge"

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 return [
 	'routes' => [
 

--- a/build/fetch-material-icons.sh
+++ b/build/fetch-material-icons.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-
+#
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 set -x
 set -e
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-
+#
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 APP_NAME=tables
 SCENARIO=$1
 


### PR DESCRIPTION
mostly covering `cypress/.../img` assets 

# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: LicenseRef-MastodonTrademarks, LicenseRef-GooglePlayBadge, LicenseRef-XTrademarks, LicenseRef-AppleAppStoreBadge, CC-BY-SA-2.0, LicenseRef-NextcloudTrademarks, MIT, AGPL-3.0-or-later, LicenseRef-FacebookTrademarks, Apache-2.0
* Read errors: 0
* Files with copyright information: 806 / 1180
* Files with license information: 782 / 1180