### PR TITLE
fix: use different app menu selectors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,16 +81,21 @@ export default {
 			if (currentRoute.path.startsWith('/table/')) {
 				this.$store.commit('setActiveTableId', parseInt(currentRoute.params.tableId))
 				this.setPageTitle(this.$store.getters.activeTable.title)
-				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables"]'))
+				if (!currentRoute.path.includes('/row/')) {
+					this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu a[title="Tables"]'))
+				}
 			} else if (currentRoute.path.startsWith('/view/')) {
 				this.$store.commit('setActiveViewId', parseInt(currentRoute.params.viewId))
 				this.setPageTitle(this.$store.getters.activeView.title)
-				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables"]'))
+				if (!currentRoute.path.includes('/row/')) {
+					this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu a[title="Tables"]'))
+				}
 			} else if (currentRoute.path.startsWith('/application/')) {
 				const contextId = parseInt(currentRoute.params.contextId)
 				this.$store.commit('setActiveContextId', contextId)
 				this.setPageTitle(this.$store.getters.activeContext.name)
-				this.switchActiveMenuEntry(document.querySelector('header .header-left .app-menu li[data-app-id="tables_application_' + contextId + '"]'))
+				// This breaks if there are multiple contexts with the same name or another app has the same name. We need a better way to identify the correct element.
+				this.switchActiveMenuEntry(document.querySelector(`header .header-left .app-menu [title="${this.$store.getters.activeContext.name}"]`))
 
 				// move the focus away from nav bar (import for app-internal switch)
 				const appContent = document.getElementById('app-content-vue')
@@ -103,6 +108,7 @@ export default {
 			}
 		},
 		switchActiveMenuEntry(targetElement) {
+			targetElement = targetElement?.tagName?.toLowerCase() === 'a' ? targetElement.parentElement : targetElement
 			const currentlyActive = document.querySelector('header .header-left .app-menu li.app-menu-entry--active')
 			currentlyActive.classList.remove('app-menu-entry--active')
 			targetElement.classList.add('app-menu-entry--active')


### PR DESCRIPTION
The app menu selector changed, so we need these updates to when the table or application is active

Also added a check to avoid unnecessary  work when editing rows

Right now, all this is very hacky. Not sure if there's a better solution. Having `data-app-id` made this more robust, but that isn't available anymore

This gets rid of the console errors
```
NavigationTableItem.vue:134 [Vue warn]: Error in callback for watcher "$route": "TypeError: Cannot read properties of null (reading 'classList')"
```
