### PR TITLE
fix: unhide part of single selection NcSelect value

### DIFF
--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -242,5 +242,10 @@ export default {
 	:where(.slot.fix-col-4 input, .slot.fix-col-4 .row) {
 		min-width: 100% !important;
 	}
+
+	:where(.name-parts) {
+		display: block !important;
+		max-width: fit-content !important;
+	}
 }
 </style>


### PR DESCRIPTION
When editing a row with a single selection, part of it is hidden. This unhides it. 

Before:
![Screenshot from 2024-08-14 15-21-20](https://github.com/user-attachments/assets/e6e7310a-b9f6-4f64-9fed-106b4b1d4cbe)


After:
![Screenshot from 2024-08-14 15-22-52](https://github.com/user-attachments/assets/f5df3c38-8f91-476e-a818-c6e545f72b86)
