### PR TITLE
fix: Open row edit modal on initial load

### DIFF
--- a/src/modules/main/sections/MainWrapper.vue
+++ b/src/modules/main/sections/MainWrapper.vue
@@ -145,7 +145,7 @@ export default {
 					isView: this.isView,
 				}
 				if (this.activeRowId) {
-					emit('tables:row:edit', { row: this.rows.find(r => r.id === this.activeRowId), columns: this.columns, isView: this.isView, elementId: this.element.id })
+					emit('tables:row:edit', { row: this.rows.find(r => r.id === this.activeRowId), columns: this.columns, isView: this.isView, elementId: this.element.id, element: this.element })
 				}
 				this.localLoading = false
 			}


### PR DESCRIPTION
When opening a link like https://nextcloud.local/index.php/apps/tables/#/table/1/row/1 we should open the modal to edit the row directly. This was broken before as the element (table or view was not passed along while the modal component requires it).

Can also be reproduced by editing a row and just reloading the browser.