### PR TITLE
Fix console warnings and errors

### DIFF
--- a/cypress/e2e/tables-favorite.cy.js
+++ b/cypress/e2e/tables-favorite.cy.js
@@ -50,7 +50,7 @@ describe('Favorite tables/views', () => {
 
     cy.get('[data-cy="navigationViewItem"]').first().as('testView')
 
-    cy.get('@testView').parent().parent().should('contain.text', 'Tutorial')
+    cy.get('@testView').parent().parent().parent().should('contain.text', 'Tutorial')
     cy.get('@testView').find('[aria-haspopup="menu"]').click({ force: true })
 
     cy.intercept({ method: 'POST', url: '**/ocs/v2.php/apps/tables/api/2/favorites/*/*' }).as('favoriteViewReq')
@@ -70,14 +70,14 @@ describe('Favorite tables/views', () => {
     cy.contains('Remove from favorites').click({ force: true })
     cy.wait('@unfavoriteViewReq').its('response.statusCode').should('equal', 200)
 
-    cy.get('@testView').parent().parent().should('contain.text', 'Tutorial')
+    cy.get('@testView').parent().parent().parent().should('contain.text', 'Tutorial')
   })
 
   it('can (un)favorite views with favorited parent tables', () => {
     cy.get('[data-cy="navigationViewItem"]').first().as('testView')
     cy.get('[data-cy="navigationTableItem"]').first().as('tutorialTable')
 
-    cy.get('@testView').parent().parent().should('contain.text', 'Tutorial')
+    cy.get('@testView').parent().parent().parent().should('contain.text', 'Tutorial')
     cy.get('@testView').find('[aria-haspopup="menu"]').click({ force: true })
     cy.contains('Add to favorites').click({ force: true })
 

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -136,10 +136,12 @@
 				{{ t('tables', 'Delete table') }}
 			</NcActionButton>
 		</template>
-		<NavigationViewItem v-for="view in getViews"
-			:key="'view'+view.id"
-			:view="view"
-			:show-share-sender="false" />
+		<div>
+			<NavigationViewItem v-for="view in getViews"
+				:key="'view'+view.id"
+				:view="view"
+				:show-share-sender="false" />
+		</div>
 	</NcAppNavigationItem>
 </template>
 

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -38,12 +38,12 @@
 		</table>
 		<div v-if="totalPages > 1" class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">
 			<div class="pagination-items">
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" @click="pageNumber = 1">
+				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to first page')" @click="pageNumber = 1">
 					<template #icon>
 						<PageFirstIcon :size="20" />
 					</template>
 				</NcButton>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" @click="pageNumber--">
+				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to previous page')" @click="pageNumber--">
 					<template #icon>
 						<ChevronLeftIcon :size="20" />
 					</template>
@@ -57,12 +57,12 @@
 						</template>
 					</NcSelect>
 				</div>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" @click="pageNumber++">
+				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to next page')" @click="pageNumber++">
 					<template #icon>
 						<ChevronRightIcon :size="20" />
 					</template>
 				</NcButton>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" @click="pageNumber = totalPages">
+				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to last page')" @click="pageNumber = totalPages">
 					<template #icon>
 						<PageLastIcon :size="20" />
 					</template>

--- a/src/shared/utils/displayError.js
+++ b/src/shared/utils/displayError.js
@@ -37,7 +37,7 @@ function statusMessage(status) {
  * @param {string} msg as message to toast out
  */
 function displaySimpleError(e = null, msg = '') {
-	console.error('Error occurred: ' + msg ?? '', e?.message)
+	console.error('Error occurred: ' + (msg ?? ''), e?.message)
 	showError(msg)
 }
 


### PR DESCRIPTION
Some small fixes I had included in another branch but are easier to get in separately, mostly found in sentry as reported through the js console:

- **fix: Add aria-label to pagination**
- **fix: Fix missing actions for empty default slot**
- **fix: Proper evaluation order when building errors strings**
