### PR TITLE
fix(Cypress): remove unneeded visibility check

### DIFF
--- a/cypress/e2e/tables-table.cy.js
+++ b/cypress/e2e/tables-table.cy.js
@@ -25,7 +25,6 @@ describe('Manage a table', () => {
 		cy.get('.icon-loading').should('not.exist')
 		cy.get('[data-cy="navigationCreateTableIcon"]').click({ force: true })
 		cy.get('.tile').contains('ToDo').click({ force: true })
-		cy.get('.modal__content').should('be.visible')
 		cy.get('.modal__content input[type="text"]').clear().type('to do list')
 		cy.get('.modal__content #description-editor .tiptap.ProseMirror').type('to Do List description')
 		cy.contains('button', 'Create table').scrollIntoView().click()
@@ -41,7 +40,6 @@ describe('Manage a table', () => {
 		cy.get('.icon-loading').should('not.exist')
 		cy.get('[data-cy="navigationCreateTableIcon"]').click({ force: true })
 		cy.get('.tile').contains('Import').click({ force: true })
-		cy.get('.modal__content').should('be.visible')
 		cy.get('.modal__content input[type="text"]').clear().type('import list')
 		cy.contains('button', 'Create table').scrollIntoView().click()
 		cy.contains('h2', 'Import').should('be.visible')
@@ -67,7 +65,6 @@ describe('Manage a table', () => {
 		cy.get('[data-cy="customTableAction"] button').click()
 		cy.get('.action-button__text').contains('Edit table').click()
 
-		cy.get('.modal__content').should('be.visible')
 		cy.get('.modal-container input').last().clear().type('ToDo list')
 		cy.get('.modal__content #description-editor .tiptap.ProseMirror').type('Updated ToDo List description')
 		cy.get('.modal-container button').contains('Save').click()
@@ -82,7 +79,6 @@ describe('Manage a table', () => {
 		cy.get('[data-cy="customTableAction"] button').click()
 		cy.get('.action-button__text').contains('Edit table').click()
 
-		cy.get('.modal__content').should('be.visible')
 		cy.get('.modal-container button').contains('Delete').click()
 		cy.get('.modal-container button').contains('I really want to delete this table!').click()
 
@@ -94,7 +90,6 @@ describe('Manage a table', () => {
 		cy.get('.icon-loading').should('not.exist')
 		cy.get('[data-cy="navigationCreateTableIcon"]').click({ force: true })
 		cy.get('.tile').contains('ToDo').click({ force: true })
-		cy.get('.modal__content').should('be.visible')
 		cy.get('.modal__content input[type="text"]').clear().type('test table')
 		cy.contains('button', 'Create table').click()
 


### PR DESCRIPTION
We do not need to check if the modal content is visible. When we have this, we sometimes get the following error:

```
AssertionError: Timed out retrying after 4000ms: expected '<div.modal__content>' to be 'visible'

This element `<div.modal__content>` is not visible because it has CSS property: `position: fixed` and it's being covered by another element:

`<div data-v-1d602fb0="" class="modal-wrapper modal-wrapper--normal">...</div>`
``` 