### PR TITLE
fix: use actions/upload-artifact v4 for cypress workflow

### DIFF
--- a/.github/workflows/cypress-custom.yml
+++ b/.github/workflows/cypress-custom.yml
@@ -156,7 +156,7 @@ jobs:
           cat data/nextcloud.log
 
       - name: Upload test failure screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload screenshots
@@ -164,7 +164,7 @@ jobs:
           retention-days: 5
 
       - name: Upload nextcloud logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload nextcloud log


### PR DESCRIPTION
 actions/upload-artifact v2 is deprecated and causes failures: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/