### PR TITLE
fix(Import): expect selectionOptions as array from json

### DIFF
--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -158,7 +158,7 @@ class ApiTablesController extends AOCSController {
 						numberDecimals: $column['numberDecimals'],
 						numberPrefix: $column['numberPrefix'],
 						numberSuffix: $column['numberSuffix'],
-						selectionOptions: $column['selectionOptions'] == [] ? '' : $column['selectionOptions'],
+						selectionOptions: $column['selectionOptions'] === [] ? '' : \json_encode($column['selectionOptions'], JSON_THROW_ON_ERROR),
 						selectionDefault: $column['selectionDefault'],
 						datetimeDefault: $column['datetimeDefault'],
 						usergroupDefault: $column['usergroupDefault'][0] ?? '',


### PR DESCRIPTION
currently an import fails silently (no web UI feedback) with `Argument #15 ($selectionOptions) must be of type ?string, array given` in the logs. This fixes handlig of the selectionOptions.