### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6599,10 +6599,11 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -7545,9 +7546,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.2.tgz",
-      "integrity": "sha512-hLGGBI1tw5N8qTELr3blKjAML/LY4ANxksbS612UiJyDfyf/2D092Pvm+S7pmeTGJRqvlJkFzBoHBQKgQlOQVg=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
       "version": "3.1.0",
@@ -8780,9 +8782,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8792,7 +8794,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 14 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [cookie](#user-content-cookie)
* [dompurify](#user-content-dompurify)
* [express](#user-content-express)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`
  * `node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### cookie <a href="#user-content-cookie" id="cookie">#</a>
* cookie accepts cookie name, path, and domain with out of bounds characters
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-pxg6-pf52-xh8x](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)
* Affected versions: <0.7.0
* Package usage:
  * `node_modules/cookie`

### dompurify <a href="#user-content-dompurify" id="dompurify">#</a>
* DOMPurify allows tampering by prototype pollution
* Severity: **high** (CVSS 7)
* Reference: [https://github.com/advisories/GHSA-mmhx-hmjr-r674](https://github.com/advisories/GHSA-mmhx-hmjr-r674)
* Affected versions: 3.0.0 - 3.1.2
* Package usage:
  * `node_modules/dompurify`

### express <a href="#user-content-express" id="express">#</a>
* Caused by vulnerable dependency:
  * [cookie](#user-content-cookie)
* Affected versions: 3.0.0-alpha1 - 4.21.0 || 5.0.0-alpha.1 - 5.0.0
* Package usage:
  * `node_modules/express`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`