### PR TITLE
fix: use unique names for actions upload-artifact

### DIFF
--- a/.github/workflows/cypress-custom.yml
+++ b/.github/workflows/cypress-custom.yml
@@ -149,24 +149,24 @@ jobs:
           CYPRESS_ncVersion: ${{ matrix.server-versions }}
           npm_package_name: ${{ env.APP_NAME }}
 
-      - name: Print logs
+      - name: Print logs ${{ matrix.node-version }}-${{ matrix.php-versions }}-${{ matrix.server-versions }}-${{ matrix.databases }}
         if: always()
         run: |
           cat /tmp/requestlog
           cat data/nextcloud.log
 
-      - name: Upload test failure screenshots
+      - name: Upload test failure screenshots ${{ matrix.node-version }}-${{ matrix.php-versions }}-${{ matrix.server-versions }}-${{ matrix.databases }}
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Upload screenshots
+          name: Upload screenshots ${{ matrix.node-version }}-${{ matrix.php-versions }}-${{ matrix.server-versions }}-${{ matrix.databases }}
           path: apps/${{ env.APP_NAME }}/cypress/screenshots/
           retention-days: 5
 
-      - name: Upload nextcloud logs
+      - name: Upload nextcloud logs ${{ matrix.node-version }}-${{ matrix.php-versions }}-${{ matrix.server-versions }}-${{ matrix.databases }}
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Upload nextcloud log
+          name: Upload nextcloud log ${{ matrix.node-version }}-${{ matrix.php-versions }}-${{ matrix.server-versions }}-${{ matrix.databases }}
           path: data/nextcloud.log
           retention-days: 5

--- a/cypress/e2e/tables-table.cy.js
+++ b/cypress/e2e/tables-table.cy.js
@@ -32,7 +32,7 @@ describe('Manage a table', () => {
 		cy.contains('button', 'Create row').should('be.visible')
 		cy.contains('h1', 'to do list').should('be.visible')
 		cy.contains('table th', 'Task').should('exist')
-		cy.contains('.paragraph-content', 'to Do List description').should('be.visible')
+		cy.contains('.text-editor__content p', 'to Do List description').should('be.visible')
 	})
 
 	it('Create with import', () => {
@@ -71,7 +71,7 @@ describe('Manage a table', () => {
 
 		cy.wait(10).get('.toastify.toast-success').should('be.visible')
 		cy.get('.app-navigation__list').contains('ToDo list').should('exist')
-		cy.contains('.paragraph-content', 'Updated ToDo List description').should('be.visible')
+		cy.contains('.text-editor__content p', 'Updated ToDo List description').should('be.visible')
 	})
 
 	it('Delete', () => {


### PR DESCRIPTION
At https://github.com/nextcloud/tables/actions/runs/11089354255?pr=1396, we have the error `Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`. This is an attempt to fix it. 