### PR TITLE
feat: Semi-persistent local filtering on table through URL parameters

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -79,6 +79,7 @@ return [
 		['name' => 'view#create', 'url' => '/view', 'verb' => 'POST'],
 		['name' => 'view#update', 'url' => '/view/{id}', 'verb' => 'PUT'],
 		['name' => 'view#destroy', 'url' => '/view/{id}', 'verb' => 'DELETE'],
+		['name' => 'view#createTemporaryView', 'url' => '/view/{tableId}/temporary-view', 'verb' => 'POST'],
 
 		// columns
 		['name' => 'column#indexTableByView', 'url' => '/column/table/{tableId}/view/{viewId}', 'verb' => 'GET'],

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -98,6 +98,15 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	public function createTemporaryView(int $tableId, array $data): DataResponse {
+		return $this->handleError(function () use ($tableId, $data) {
+			return $this->service->createTemporaryView($tableId, $data, $this->userId);
+		});
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id);

--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -53,6 +53,10 @@ use OCP\AppFramework\Db\Entity;
  * @method setSort(string $sort)
  * @method getOwnerDisplayName(): string
  * @method setOwnerDisplayName(string $ownerDisplayName)
+ * @method getRows(): string
+ * @method setRows(string $rows)
+ * @method getColumnValues(): string
+ * @method setColumnValues(string $columnValues)
  */
 class View extends Entity implements JsonSerializable {
 	protected ?string $title = null;
@@ -73,6 +77,8 @@ class View extends Entity implements JsonSerializable {
 	protected ?int $rowsCount = 0;
 	protected ?string $ownership = null;
 	protected ?string $ownerDisplayName = null;
+	protected ?string $rows = null;
+	protected ?string $columnValues = null;
 
 	public function __construct() {
 		$this->addType('id', 'integer');
@@ -86,6 +92,16 @@ class View extends Entity implements JsonSerializable {
 	public function getColumnsArray(): array {
 		return $this->getArray($this->getColumns());
 	}
+
+
+	public function getRowsArray(): array {
+		return $this->getArray($this->getRows());
+	}
+
+	public function getColumnValuesArray(): array {
+		return $this->getArray($this->getColumnValues());
+	}
+
 
 	/**
 	 * @psalm-suppress MismatchingDocblockReturnType
@@ -123,6 +139,14 @@ class View extends Entity implements JsonSerializable {
 
 	public function setColumnsArray(array $array):void {
 		$this->setColumns(\json_encode($array));
+	}
+
+	public function setRowsArray(array $array):void {
+		$this->setRows(\json_encode($array));
+	}
+
+	public function setColumnValuesArray(array $array):void {
+		$this->setColumnValues(\json_encode($array));
 	}
 
 	public function setSortArray(array $array):void {
@@ -168,6 +192,8 @@ class View extends Entity implements JsonSerializable {
 			'hasShares' => !!$this->hasShares,
 			'rowsCount' => $this->rowsCount ?: 0,
 			'ownerDisplayName' => $this->ownerDisplayName,
+			'rows' => $this->getRowsArray(),
+			'columnValues' => $this->getColumnValuesArray(),
 		];
 		$serialisedJson['filter'] = $this->getFilterArray();
 

--- a/src/modules/main/sections/Temp.vue
+++ b/src/modules/main/sections/Temp.vue
@@ -1,0 +1,69 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<!-- <div v-if="!view" class="icon-loading" />
+    <div v-else class="main-view-view"> -->
+	<div>
+		<ElementTitle :active-element="view" :is-table="false" :view-setting.sync="localViewSetting" />
+		<div class="table-wrapper">
+			<EmptyView v-if="columns.length === 0" :view="view" />
+			<TableView v-else
+				:rows="rows"
+				:columns="columns"
+				:element="view"
+				:view-setting.sync="localViewSetting"
+				:is-view="true"
+				:can-read-rows="true"
+				:can-create-rows="true"
+				:can-edit-rows="true"
+				:can-delete-rows="false"
+				:can-create-columns="false"
+				:can-edit-columns="false"
+				:can-delete-columns="false"
+				:can-delete-table="false" />
+		</div>
+	</div>
+</template>
+
+<script>
+import TableView from '../partials/TableView.vue'
+
+import EmptyView from './EmptyView.vue'
+import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
+import ElementTitle from './ElementTitle.vue'
+
+export default {
+	components: {
+		EmptyView,
+		TableView,
+		ElementTitle,
+	},
+
+	mixins: [permissionsMixin],
+
+	props: {
+		view: {
+			type: Object,
+			default: null,
+		},
+		columns: {
+			type: Array,
+			default: null,
+		},
+		rows: {
+			type: Array,
+			default: null,
+		},
+	},
+
+	data() {
+		return {
+			localLoading: false,
+			lastActiveViewId: null,
+			localViewSetting: {},
+		}
+	},
+}
+</script>

--- a/src/pages/TemporaryView.vue
+++ b/src/pages/TemporaryView.vue
@@ -1,0 +1,124 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div v-if="!view" class="icon-loading" />
+	<div v-else class="main-view-view">
+		<Temp :view="view" :rows="view?.rows || []" :columns="view?.columnValues || []" />
+		<MainModals />
+	</div>
+</template>
+
+<script>
+
+import MainModals from '../modules/modals/Modals.vue'
+import Temp from '../modules/main/sections/Temp.vue'
+
+export default {
+
+	components: {
+		Temp,
+		MainModals,
+	},
+
+	data() {
+		return {
+			view: null,
+			columns: [],
+			rows: [],
+			queryParams: {},
+			parsedData: {
+				tableId: null,
+				data: {
+					title: 'Temporary View',
+					emoji: '\ud83d\ude09',
+					columns: [],
+					sort: [],
+					filter: [],
+				},
+			},
+		}
+	},
+
+	created() {
+		this.extractQueryParams()
+		this.parseQueryParams()
+	},
+
+	// async mounted() {
+	//     const res = await this.$store.dispatch('createTemporaryView', {
+	//         tableId: 1,
+	//         data: {
+	//             title: 'Temporary View',
+	//             emoji: '\ud83d\ude09',
+	//             columns: [1, 2, 3, 4],
+	//             sort: [{ columnId: 1, mode: 'ASC' }],
+	//             filter: [[{ columnId: 1, operator: 'contains', value: 'row' }], [{ columnId: 2, operator: 'contains', value: 'row' }]],
+	//         },
+	//     })
+	//     this.view = res
+	// },
+
+	methods: {
+		extractQueryParams() {
+			// Access query parameters from the $route object
+			this.queryParams = { ...this.$route.query }
+			console.log('Query parameters:', this.queryParams)
+		},
+
+		// Example: http://nextcloud.local/index.php/apps/tables/#/tempview?tableId=1&columns=[1,2,3,4]&filter=1:contains:row&sort=1:asc
+		parseQueryParams() {
+			const query = this.$route.query
+
+			// Parse tableId
+			this.parsedData.tableId = parseInt(query.tableId) || null
+
+			// Parse columns
+			if (query.columns) {
+				try {
+					this.parsedData.data.columns = JSON.parse(query.columns)
+				} catch (e) {
+					console.error('Error parsing columns:', e)
+				}
+			}
+
+			// Parse sort
+			if (query.sort) {
+				const sortParts = query.sort.split(':')
+				if (sortParts.length === 2) {
+					this.parsedData.data.sort = [{
+						columnId: parseInt(sortParts[0]),
+						mode: sortParts[1].toUpperCase(),
+					}]
+				}
+			}
+
+			// Parse filter
+            // Should be an array of arrarys
+			if (query.filter) {
+				const [columnId, operator, value] = query.filter.split(':')
+				this.parsedData.data.filter = [[{ columnId: parseInt(columnId), operator, value }]]
+			}
+
+			this.loadTempView()
+		},
+
+		async loadTempView() {
+			const res = await this.$store.dispatch('createTemporaryView', {
+				tableId: this.parsedData.tableId,
+				data: this.parsedData.data,
+			})
+			this.view = res
+			this.localLoading = false
+			console.log('temporary view', this.view)
+		},
+	},
+}
+</script>
+<style lang="scss">
+.main-view-view {
+    width: max-content;
+    min-width: var(--app-content-width, 100%);
+}
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ import MainViewWrapper from './pages/View.vue'
 import MainDashboardWrapper from './pages/Table.vue'
 import Startpage from './pages/Startpage.vue'
 import Context from './pages/Context.vue'
+import TemporaryView from './pages/TemporaryView.vue'
 
 Vue.use(Router)
 
@@ -49,6 +50,11 @@ export default new Router({
 			path: '/view/:viewId',
 			component: MainViewWrapper,
 			name: 'view',
+		},
+		{
+			path: '/tempview',
+			component: TemporaryView,
+			name: 'temporaryView',
 		},
 		{
 			path: '/view/:viewId/content',

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -221,6 +221,18 @@ export default new Vuex.Store({
 
 			return res.data.id
 		},
+
+		async createTemporaryView({ commit, state }, { tableId, data }) {
+			let res = null
+			try {
+				res = await axios.post(generateUrl('/apps/tables/view/' + tableId + '/temporary-view'), { data })
+			} catch (e) {
+				displayError(e, t('tables', 'Could not create temporary view.'))
+				return false
+			}
+			return res.data
+		},
+
 		async updateView({ state, commit, dispatch }, { id, data }) {
 			let res = null
 


### PR DESCRIPTION
Fixes #662 


At the moment, you can try it out with the URL `http://local-nc-domain.com/index.php/apps/tables/#/tempview?tableId=1&columns=[1,2,3,4]&filter=1:contains:row&sort=1:asc`.

It requires specifying the tableId, columns id and then the various filters and sort. 

Still a lot a work to be done here:
- [ ]  Decide how URLs would be created. You could manually modify the URL parameters, but this gets long and complicated. We should use the 'ViewSettings' modal to specify what the view should look like and apply these to a URL that can be copies
- [ ] Maybe create a new entity for these semi-persistent view. Currently, `View.php` is modified to store the columns and filtered/sorted rows that would be sent to the frontend. It will be better to create a separate file for this and avoid modifying the existing `View.php`. 
- [ ] Properly parse the query params, especially in cases where multiple filters are specifiec
- [ ] Think about how to handle searching. We would like to have a search param (e.g `?search=test`). Right now, I believe Tables searching is being done in the frontend using the search bar, not in the backend. So the easiest way to do this would be to just add whatever search term to the search bar. 