### PR TITLE
refactor: Extend Permission Middleware usage and replace deprecated annotations with attributes

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -153,6 +153,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function showScheme(int $tableId): DataResponse {
 		try {
 			$scheme = $this->tableService->getScheme($tableId);
@@ -186,6 +187,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function getTable(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->tableService->find($tableId)->jsonSerialize());
@@ -287,6 +289,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexViews(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->viewService->formatViews($this->viewService->findAll($this->tableService->find($tableId))));
@@ -350,6 +353,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function getView(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->viewService->find($viewId)->jsonSerialize());
@@ -729,6 +733,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexViewColumns(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->columnService->formatColumns($this->columnService->findAllByView($viewId)));
@@ -1045,6 +1050,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexTableRowsSimple(int $tableId, ?int $limit, ?int $offset): DataResponse {
 		try {
 			return new DataResponse($this->v1Api->getData($tableId, $limit, $offset, $this->userId));
@@ -1075,6 +1081,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexTableRows(int $tableId, ?int $limit, ?int $offset): DataResponse {
 		try {
 			return new DataResponse($this->rowService->formatRows($this->rowService->findAllByTable($tableId, $this->userId, $limit, $offset)));
@@ -1105,6 +1112,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexViewRows(int $viewId, ?int $limit, ?int $offset): DataResponse {
 		try {
 			return new DataResponse($this->rowService->formatRows($this->rowService->findAllByView($viewId, $this->userId, $limit, $offset)));
@@ -1579,8 +1587,5 @@ class Api1Controller extends ApiController {
 			$message = ['message' => $e->getMessage()];
 			return new DataResponse($message, Http::STATUS_NOT_FOUND);
 		}
-
-
-
 	}
 }

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -223,6 +223,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function updateTable(int $tableId, ?string $title = null, ?string $emoji = null, ?bool $archived = false): DataResponse {
 		try {
 			return new DataResponse($this->tableService->update($tableId, $title, $emoji, null, $archived, $this->userId)->jsonSerialize());
@@ -255,6 +256,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function deleteTable(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->tableService->delete($tableId)->jsonSerialize());
@@ -325,6 +327,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createView(int $tableId, string $title, ?string $emoji): DataResponse {
 		try {
 			return new DataResponse($this->viewService->create($title, $emoji, $this->tableService->find($tableId))->jsonSerialize());
@@ -388,6 +391,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function updateView(int $viewId, array $data): DataResponse {
 		try {
 			return new DataResponse($this->viewService->update($viewId, $data)->jsonSerialize());
@@ -420,6 +424,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function deleteView(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->viewService->delete($viewId)->jsonSerialize());
@@ -1511,6 +1516,7 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createTableColumn(
 		int $tableId,
 		string $title,

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -30,6 +30,9 @@ use OCP\AppFramework\ApiController;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\CORS;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -96,14 +99,13 @@ class Api1Controller extends ApiController {
 	/**
 	 * Returns all Tables
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @return DataResponse<Http::STATUS_OK, TablesTable[], array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: Tables returned
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function index(): DataResponse {
 		try {
 			return new DataResponse($this->tableService->formatTables($this->tableService->findAll($this->userId)));
@@ -117,10 +119,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Create a new table and return it
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param string $title Title of the table
 	 * @param string|null $emoji Emoji for the table
 	 * @param string $template Template to use if wanted
@@ -129,6 +127,9 @@ class Api1Controller extends ApiController {
 	 *
 	 * 200: Tables returned
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function createTable(string $title, ?string $emoji, string $template = 'custom'): DataResponse {
 		try {
 			return new DataResponse($this->tableService->create($title, $template, $emoji)->jsonSerialize());
@@ -142,10 +143,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * returns table scheme
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{'Content-Disposition'?:string,'Content-Type'?:string}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -153,6 +150,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function showScheme(int $tableId): DataResponse {
 		try {
@@ -176,10 +176,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Get a table object
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -187,6 +183,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function getTable(int $tableId): DataResponse {
 		try {
@@ -209,10 +208,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Update tables properties
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param string|null $title New table title
 	 * @param string|null $emoji New table emoji
@@ -223,6 +218,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function updateTable(int $tableId, ?string $title = null, ?string $emoji = null, ?bool $archived = false): DataResponse {
 		try {
@@ -245,10 +243,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -256,6 +250,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function deleteTable(int $tableId): DataResponse {
 		try {
@@ -280,10 +277,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Get all views for a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesView[], array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -291,6 +284,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexViews(int $tableId): DataResponse {
 		try {
@@ -313,10 +309,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Create a new view for a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID that will hold the view
 	 * @param string $title Title for the view
 	 * @param string|null $emoji Emoji for the view
@@ -327,6 +319,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createView(int $tableId, string $title, ?string $emoji): DataResponse {
 		try {
@@ -345,10 +340,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Get a view object
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesView, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -356,6 +347,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function getView(int $viewId): DataResponse {
 		try {
@@ -378,10 +372,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Update a view via key-value sets
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @param array{key: 'title'|'emoji'|'description', value: string}|array{key: 'columns', value: int[]}|array{key: 'sort', value: array{columnId: int, mode: 'ASC'|'DESC'}}|array{key: 'filter', value: array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'is-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}} $data key-value pairs
 	 * @return DataResponse<Http::STATUS_OK, TablesView, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
@@ -391,6 +381,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function updateView(int $viewId, array $data): DataResponse {
 		try {
@@ -413,10 +406,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a view
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesView, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -424,6 +413,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function deleteView(int $viewId): DataResponse {
 		try {
@@ -448,10 +440,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Get a share object
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $shareId Share ID
 	 * @return DataResponse<Http::STATUS_OK, TablesShare, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -459,6 +447,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function getShare(int $shareId): DataResponse {
 		try {
 			return new DataResponse($this->shareService->find($shareId)->jsonSerialize());
@@ -481,15 +472,14 @@ class Api1Controller extends ApiController {
 	 * Get all shares for a view
 	 * Will be empty if view does not exist
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesShare[], array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: Shares returned
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function indexViewShares(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->shareService->formatShares($this->shareService->findAll('view', $viewId)));
@@ -504,15 +494,14 @@ class Api1Controller extends ApiController {
 	 * Get all shares for a table
 	 * Will be empty if table does not exist
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesShare[], array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: Shares returned
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function indexTableShares(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->shareService->formatShares($this->shareService->findAll('table', $tableId)));
@@ -525,10 +514,6 @@ class Api1Controller extends ApiController {
 
 	/**
 	 * Create a new share
-	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 *
 	 * @param int $nodeId Node ID
 	 * @param 'table'|'view'|'context' $nodeType Node type
@@ -546,6 +531,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE)]
 	public function createShare(
 		int $nodeId,
@@ -579,10 +567,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a share
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $shareId Share ID
 	 * @return DataResponse<Http::STATUS_OK, TablesShare, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -590,6 +574,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function deleteShare(int $shareId): DataResponse {
 		try {
 			return new DataResponse($this->shareService->delete($shareId)->jsonSerialize());
@@ -611,10 +598,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Update a share permission
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $shareId Share ID
 	 * @param string $permissionType Permission type that should be changed
 	 * @param bool $permissionValue New permission value
@@ -624,6 +607,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function updateSharePermissions(int $shareId, string $permissionType, bool $permissionValue): DataResponse {
 		try {
 			return new DataResponse($this->shareService->updatePermission($shareId, $permissionType, $permissionValue)->jsonSerialize());
@@ -645,10 +631,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Updates the display mode of a context share
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $shareId Share ID
 	 * @param int $displayMode The new value for the display mode of the nav bar icon. 0: hidden, 1: visible for recipients, 2: visible for all
 	 * @param string $target "default" to set the default, "self" to set an override for the authenticated user
@@ -662,6 +644,9 @@ class Api1Controller extends ApiController {
 	 * @psalm-param int<0, 2> $displayMode
 	 * @psalm-param ("default"|"self") $target
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function updateShareDisplayMode(int $shareId, int $displayMode, string $target = 'default'): DataResponse {
 		if ($target === 'default') {
 			$userId = '';
@@ -697,10 +682,6 @@ class Api1Controller extends ApiController {
 	 * Get all columns for a table or a underlying view
 	 * Return an empty array if no columns were found
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param int|null $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn[], array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -709,6 +690,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function indexTableColumns(int $tableId, ?int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->columnService->formatColumns($this->columnService->findAllByTable($tableId, $viewId)));
@@ -727,10 +711,6 @@ class Api1Controller extends ApiController {
 	 * Get all columns for a view
 	 * Return an empty array if no columns were found
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn[], array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -738,6 +718,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexViewColumns(int $viewId): DataResponse {
 		try {
@@ -759,10 +742,6 @@ class Api1Controller extends ApiController {
 
 	/**
 	 * Create a column
-	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 *
 	 * @param int|null $tableId Table ID
 	 * @param int|null $viewId View ID
@@ -796,6 +775,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function createColumn(
 		?int $tableId,
 		?int $viewId,
@@ -877,10 +859,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Update a column
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $columnId Column ID that will be updated
 	 * @param string|null $title Title
 	 * @param string|null $subtype Column sub type
@@ -908,6 +886,9 @@ class Api1Controller extends ApiController {
 	 *
 	 * 200: Updated column
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function updateColumn(
 		int $columnId,
 		?string $title,
@@ -978,10 +959,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Returns a column object
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $columnId Wanted Column ID
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -989,6 +966,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function getColumn(int $columnId): DataResponse {
 		try {
 			return new DataResponse($this->columnService->find($columnId)->jsonSerialize());
@@ -1010,10 +990,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a column
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $columnId Wanted Column ID
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -1021,6 +997,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function deleteColumn(int $columnId): DataResponse {
 		try {
 			return new DataResponse($this->columnService->delete($columnId)->jsonSerialize());
@@ -1042,10 +1021,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * List all rows values for a table, first row are the column titles
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param int|null $limit Limit
 	 * @param int|null $offset Offset
@@ -1055,6 +1030,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexTableRowsSimple(int $tableId, ?int $limit, ?int $offset): DataResponse {
 		try {
@@ -1073,10 +1051,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * List all rows for a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param int|null $limit Limit
 	 * @param int|null $offset Offset
@@ -1086,6 +1060,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function indexTableRows(int $tableId, ?int $limit, ?int $offset): DataResponse {
 		try {
@@ -1104,10 +1081,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * List all rows for a view
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @param int|null $limit Limit
 	 * @param int|null $offset Offset
@@ -1117,6 +1090,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexViewRows(int $viewId, ?int $limit, ?int $offset): DataResponse {
 		try {
@@ -1135,10 +1111,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Create a row within a view
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $viewId View ID
 	 * @param string|array<string, mixed> $data Data as key - value store
 	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
@@ -1146,6 +1118,9 @@ class Api1Controller extends ApiController {
 	 * 200: Row returned
 	 * 403: No permissions
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function createRowInView(int $viewId, $data): DataResponse {
 		if(is_string($data)) {
@@ -1181,10 +1156,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Create a row within a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param string|array<string, mixed> $data Data as key - value store
 	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
@@ -1193,6 +1164,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createRowInTable(int $tableId, $data): DataResponse {
 		if(is_string($data)) {
@@ -1228,10 +1202,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Get a row
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $rowId Row ID
 	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -1239,6 +1209,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function getRow(int $rowId): DataResponse {
 		try {
 			return new DataResponse($this->rowService->find($rowId)->jsonSerialize());
@@ -1260,10 +1233,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Update a row
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $rowId Row ID
 	 * @param int|null $viewId View ID
 	 * @param string|array<string, mixed> $data Data as key - value store
@@ -1274,6 +1243,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function updateRow(int $rowId, ?int $viewId, $data): DataResponse {
 		if(is_string($data)) {
 			$data = json_decode($data, true);
@@ -1303,10 +1275,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a row
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $rowId Row ID
 	 *
 	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -1315,6 +1283,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function deleteRow(int $rowId): DataResponse {
 		try {
 			return new DataResponse($this->rowService->delete($rowId, null, $this->userId)->jsonSerialize());
@@ -1336,10 +1307,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Delete a row within a view
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $rowId Row ID
 	 * @param int $viewId View ID
 	 * @return DataResponse<Http::STATUS_OK, TablesRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -1348,6 +1315,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function deleteRowByView(int $rowId, int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->rowService->delete($rowId, $viewId, $this->userId)->jsonSerialize());
@@ -1369,9 +1339,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Import from file in to a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 * @param int $tableId Table ID
 	 * @param string $path Path to file
 	 * @param bool $createMissingColumns Create missing columns
@@ -1381,6 +1348,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function importInTable(int $tableId, string $path, bool $createMissingColumns = true): DataResponse {
 		try {
@@ -1404,9 +1374,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Import from file in to a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 * @param int $viewId View ID
 	 * @param string $path Path to file
 	 * @param bool $createMissingColumns Create missing columns
@@ -1416,6 +1383,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function importInView(int $viewId, string $path, bool $createMissingColumns = true): DataResponse {
 		try {
@@ -1441,10 +1411,6 @@ class Api1Controller extends ApiController {
 	/**
 	 * Create a share for a table
 	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
-	 *
 	 * @param int $tableId Table ID
 	 * @param string $receiver Receiver ID
 	 * @param 'user'|'group' $receiverType Receiver type
@@ -1459,6 +1425,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createTableShare(int $tableId, string $receiver, string $receiverType, bool $permissionRead, bool $permissionCreate, bool $permissionUpdate, bool $permissionDelete, bool $permissionManage): DataResponse {
 		try {
@@ -1480,10 +1449,6 @@ class Api1Controller extends ApiController {
 
 	/**
 	 * Create a new column for a table
-	 *
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 *
 	 * @param int $tableId Table ID
 	 * @param string $title Title
@@ -1516,6 +1481,9 @@ class Api1Controller extends ApiController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function createTableColumn(
 		int $tableId,

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -124,6 +124,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createNumberColumn(int $baseNodeId, string $title, ?float $numberDefault, ?int $numberDecimals, ?string $numberPrefix, ?string $numberSuffix, ?float $numberMin, ?float $numberMax, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
@@ -175,6 +176,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createTextColumn(int $baseNodeId, string $title, ?string $textDefault, ?string $textAllowedPattern, ?int $textMaxLength, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
@@ -222,6 +224,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createSelectionColumn(int $baseNodeId, string $title, string $selectionOptions, ?string $selectionDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
@@ -267,6 +270,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createDatetimeColumn(int $baseNodeId, string $title, ?string $datetimeDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
@@ -312,6 +316,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createUsergroupColumn(int $baseNodeId, string $title, ?string $usergroupDefault, bool $usergroupMultipleItems = null, bool $usergroupSelectUsers = null, bool $usergroupSelectGroups = null, bool $showUserStatus = null, string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -15,6 +15,7 @@ use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\ColumnService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -41,8 +42,6 @@ class ApiColumnsController extends AOCSController {
 	 *
 	 * Return an empty array if no columns were found
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $nodeId Node ID
 	 * @param 'table'|'view' $nodeType Node type
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn[], array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -51,6 +50,7 @@ class ApiColumnsController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function index(int $nodeId, string $nodeType): DataResponse {
 		try {
@@ -74,8 +74,6 @@ class ApiColumnsController extends AOCSController {
 	/**
 	 * [api v2] Get a column object
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $id Column ID
 	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -83,6 +81,7 @@ class ApiColumnsController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	public function show(int $id): DataResponse {
 		try {
 			return new DataResponse($this->service->find($id)->jsonSerialize());
@@ -99,8 +98,6 @@ class ApiColumnsController extends AOCSController {
 	 * [api v2] Create new numbered column
 	 *
 	 * Specify a subtype to use any special numbered column
-	 *
-	 * @NoAdminRequired
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
@@ -124,6 +121,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createNumberColumn(int $baseNodeId, string $title, ?float $numberDefault, ?int $numberDecimals, ?string $numberPrefix, ?string $numberSuffix, ?float $numberMin, ?float $numberMax, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
@@ -155,8 +153,6 @@ class ApiColumnsController extends AOCSController {
 	 *
 	 * Specify a subtype to use any special text column
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
 	 * @param string|null $textDefault Default
@@ -176,6 +172,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createTextColumn(int $baseNodeId, string $title, ?string $textDefault, ?string $textAllowedPattern, ?int $textMaxLength, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
@@ -204,8 +201,6 @@ class ApiColumnsController extends AOCSController {
 	 *
 	 * Specify a subtype to use any special selection column
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
 	 * @param string $selectionOptions Json array{id: int, label: string} with options that can be selected, eg [{"id": 1, "label": "first"},{"id": 2, "label": "second"}]
@@ -224,6 +219,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createSelectionColumn(int $baseNodeId, string $title, string $selectionOptions, ?string $selectionDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
@@ -251,8 +247,6 @@ class ApiColumnsController extends AOCSController {
 	 *
 	 * Specify a subtype to use any special datetime column
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
 	 * @param 'today'|'now'|null $datetimeDefault For a subtype 'date' you can set 'today'. For a main type or subtype 'time' you can set to 'now'.
@@ -270,6 +264,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createDatetimeColumn(int $baseNodeId, string $title, ?string $datetimeDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
@@ -294,8 +289,6 @@ class ApiColumnsController extends AOCSController {
 	/**
 	 * [api v2] Create new usergroup column
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
 	 * @param string|null $usergroupDefault Json array{id: string, type: int}, eg [{"id": "admin", "type": 0}, {"id": "user1", "type": 0}]
@@ -316,6 +309,7 @@ class ApiColumnsController extends AOCSController {
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
 	public function createUsergroupColumn(int $baseNodeId, string $title, ?string $usergroupDefault, bool $usergroupMultipleItems = null, bool $usergroupSelectUsers = null, bool $usergroupSelectGroups = null, bool $showUserStatus = null, string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table'): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -6,10 +6,12 @@
  */
 namespace OCA\Tables\Controller;
 
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Dto\Column as ColumnDto;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\ColumnService;
 use OCP\AppFramework\Http;
@@ -49,6 +51,7 @@ class ApiColumnsController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function index(int $nodeId, string $nodeType): DataResponse {
 		try {
 			if($nodeType === 'table') {

--- a/lib/Controller/ApiFavoriteController.php
+++ b/lib/Controller/ApiFavoriteController.php
@@ -16,6 +16,7 @@ use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\FavoritesService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception as DBException;
 use OCP\IL10N;
@@ -41,8 +42,6 @@ class ApiFavoriteController extends AOCSController {
 	/**
 	 * [api v2] Add a node (table or view) to user favorites
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $nodeType any Application::NODE_TYPE_* constant
 	 * @param int $nodeId identifier of the node
 	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -51,6 +50,7 @@ class ApiFavoriteController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function create(int $nodeType, int $nodeId): DataResponse {
 		try {
@@ -69,8 +69,6 @@ class ApiFavoriteController extends AOCSController {
 	/**
 	 * [api v2] Remove a node (table or view) to from favorites
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $nodeType any Application::NODE_TYPE_* constant
 	 * @param int $nodeId identifier of the node
 	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
@@ -79,6 +77,7 @@ class ApiFavoriteController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function destroy(int $nodeType, int $nodeId): DataResponse {
 		try {

--- a/lib/Controller/ApiFavoriteController.php
+++ b/lib/Controller/ApiFavoriteController.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 namespace OCA\Tables\Controller;
 
 use Exception;
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\FavoritesService;
 use OCP\AppFramework\Http;
@@ -49,6 +51,7 @@ class ApiFavoriteController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function create(int $nodeType, int $nodeId): DataResponse {
 		try {
 			$this->service->addFavorite($nodeType, $nodeId);
@@ -76,6 +79,7 @@ class ApiFavoriteController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ)]
 	public function destroy(int $nodeType, int $nodeId): DataResponse {
 		try {
 			$this->service->removeFavorite($nodeType, $nodeId);

--- a/lib/Controller/ApiGeneralController.php
+++ b/lib/Controller/ApiGeneralController.php
@@ -15,6 +15,7 @@ use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\TableService;
 use OCA\Tables\Service\ViewService;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -46,12 +47,11 @@ class ApiGeneralController extends AOCSController {
 	 *
 	 * Tables and views incl. shares
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @return DataResponse<Http::STATUS_OK, TablesIndex, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: Index returned
 	 */
+	#[NoAdminRequired]
 	public function index(): DataResponse {
 		try {
 			$tables = $this->tableService->formatTables($this->tableService->findAll($this->userId));

--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -230,6 +230,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function update(int $id, ?string $title = null, ?string $emoji = null, ?string $description = null, ?bool $archived = null): DataResponse {
 		try {
 			return new DataResponse($this->service->update($id, $title, $emoji, $description, $archived, $this->userId)->jsonSerialize());
@@ -254,6 +255,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		try {
 			return new DataResponse($this->service->delete($id)->jsonSerialize());

--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -20,6 +20,7 @@ use OCA\Tables\Service\TableService;
 use OCA\Tables\Service\ViewService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -59,12 +60,11 @@ class ApiTablesController extends AOCSController {
 	/**
 	 * [api v2] Returns all Tables
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @return DataResponse<Http::STATUS_OK, TablesTable[], array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: Tables returned
 	 */
+	#[NoAdminRequired]
 	public function index(): DataResponse {
 		try {
 			return new DataResponse($this->service->formatTables($this->service->findAll($this->userId)));
@@ -76,8 +76,6 @@ class ApiTablesController extends AOCSController {
 	/**
 	 * [api v2] Get a table object
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $id Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -85,6 +83,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		try {
@@ -101,8 +100,6 @@ class ApiTablesController extends AOCSController {
 	/**
 	 * [api v2] Get a table Scheme
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $id Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -110,6 +107,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function showScheme(int $id): DataResponse {
 		try {
@@ -124,8 +122,6 @@ class ApiTablesController extends AOCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * creates table from scheme
 	 *
 	 * @param string $title title of new table
@@ -137,6 +133,7 @@ class ApiTablesController extends AOCSController {
 	 *
 	 * 200: Tables returned
 	 */
+	#[NoAdminRequired]
 	public function createFromScheme(string $title, string $emoji, string $description, array $columns, array $views): DataResponse {
 		try {
 			$this->db->beginTransaction();
@@ -195,8 +192,6 @@ class ApiTablesController extends AOCSController {
 	/**
 	 * [api v2] Create a new table and return it
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param string $title Title of the table
 	 * @param string|null $emoji Emoji for the table
 	 * @param string|null $description Description for the table
@@ -206,6 +201,7 @@ class ApiTablesController extends AOCSController {
 	 *
 	 * 200: Tables returned
 	 */
+	#[NoAdminRequired]
 	public function create(string $title, ?string $emoji, ?string $description, string $template = 'custom'): DataResponse {
 		try {
 			return new DataResponse($this->service->create($title, $template, $emoji, $description)->jsonSerialize());
@@ -216,8 +212,6 @@ class ApiTablesController extends AOCSController {
 
 	/**
 	 * [api v2] Update tables properties
-	 *
-	 * @NoAdminRequired
 	 *
 	 * @param int $id Table ID
 	 * @param string|null $title New table title
@@ -230,6 +224,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function update(int $id, ?string $title = null, ?string $emoji = null, ?string $description = null, ?bool $archived = null): DataResponse {
 		try {
@@ -246,8 +241,6 @@ class ApiTablesController extends AOCSController {
 	/**
 	 * [api v2] Delete a table
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $id Table ID
 	 * @return DataResponse<Http::STATUS_OK, TablesTable, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
@@ -255,6 +248,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		try {
@@ -273,8 +267,6 @@ class ApiTablesController extends AOCSController {
 	 *
 	 * Transfer table from one user to another
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param int $id Table ID
 	 * @param string $newOwnerUserId New user ID
 	 *
@@ -284,6 +276,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	public function transfer(int $id, string $newOwnerUserId): DataResponse {
 		try {
 			return new DataResponse($this->service->setOwner($id, $newOwnerUserId)->jsonSerialize());

--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -8,10 +8,12 @@
 namespace OCA\Tables\Controller;
 
 use Exception;
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Dto\Column as ColumnDto;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\ColumnService;
 use OCA\Tables\Service\TableService;
@@ -83,6 +85,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		try {
 			return new DataResponse($this->service->find($id)->jsonSerialize());
@@ -107,6 +110,7 @@ class ApiTablesController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function showScheme(int $id): DataResponse {
 		try {
 			return new DataResponse($this->service->getScheme($id)->jsonSerialize());

--- a/lib/Controller/ColumnController.php
+++ b/lib/Controller/ColumnController.php
@@ -12,6 +12,7 @@ use OCA\Tables\Dto\Column as ColumnDto;
 use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\ColumnService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -36,27 +37,21 @@ class ColumnController extends Controller {
 		$this->userId = $userId;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function index(int $tableId, ?int $viewId): DataResponse {
 		return $this->handleError(function () use ($tableId, $viewId) {
 			return $this->service->findAllByTable($tableId, $viewId);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function indexTableByView(int $tableId, ?int $viewId): DataResponse {
 		return $this->handleError(function () use ($tableId, $viewId) {
 			return $this->service->findAllByTable($tableId, $viewId);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
@@ -64,18 +59,14 @@ class ColumnController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->find($id);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function create(
 		?int $tableId,
 		?int $viewId,
@@ -174,9 +165,7 @@ class ColumnController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function update(
 		int $id,
 		?int $tableId,
@@ -271,9 +260,7 @@ class ColumnController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id, false, $this->userId);

--- a/lib/Controller/ColumnController.php
+++ b/lib/Controller/ColumnController.php
@@ -9,6 +9,7 @@ namespace OCA\Tables\Controller;
 
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Dto\Column as ColumnDto;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\ColumnService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
@@ -56,6 +57,7 @@ class ColumnController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
 			return $this->service->findAllByView($viewId);

--- a/lib/Controller/ContextController.php
+++ b/lib/Controller/ContextController.php
@@ -18,6 +18,7 @@ use OCA\Tables\Service\ContextService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception;
 use OCP\IL10N;
@@ -51,9 +52,8 @@ class ContextController extends AOCSController {
 	 * @return DataResponse<Http::STATUS_OK, TablesContext[], array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * 200: reporting in available contexts
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function index(): DataResponse {
 		try {
 			$contexts = $this->contextService->findAll($this->userId);
@@ -72,8 +72,8 @@ class ContextController extends AOCSController {
 	 * 200: returning the full context information
 	 * 404: context not found or not available anymore
 	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function show(int $contextId): DataResponse {
 		try {
 			$context = $this->contextService->findById($contextId, $this->userId);
@@ -88,8 +88,6 @@ class ContextController extends AOCSController {
 	/**
 	 * [api v2] Create a new context and return it
 	 *
-	 * @NoAdminRequired
-	 *
 	 * @param string $name Name of the context
 	 * @param string $iconName Material design icon name of the context
 	 * @param string $description Descriptive text of the context
@@ -101,6 +99,7 @@ class ContextController extends AOCSController {
 	 * 400: invalid parameters were supplied
 	 * 403: lacking permissions on a resource
 	 */
+	#[NoAdminRequired]
 	public function create(string $name, string $iconName, string $description = '', array $nodes = []): DataResponse {
 		try {
 			return new DataResponse($this->contextService->create(
@@ -135,9 +134,9 @@ class ContextController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 *
-	 * @NoAdminRequired
 	 * @CanManageContext
 	 */
+	#[NoAdminRequired]
 	public function update(int $contextId, ?string $name, ?string $iconName, ?string $description, ?array $nodes): DataResponse {
 		try {
 			$nodes = $nodes !== null ? $this->sanitizeInputNodes($nodes) : null;
@@ -195,9 +194,9 @@ class ContextController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 *
-	 * @NoAdminRequired
 	 * @CanManageContext
 	 */
+	#[NoAdminRequired]
 	public function destroy(int $contextId): DataResponse {
 		try {
 			return new DataResponse($this->contextService->delete($contextId, $this->userId)->jsonSerialize());
@@ -222,12 +221,12 @@ class ContextController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 *
-	 * @NoAdminRequired
 	 * @CanManageContext
 	 *
 	 * @psalm-param int<0, max> $contextId
 	 * @psalm-param int<0, 0> $newOwnerType
 	 */
+	#[NoAdminRequired]
 	public function transfer(int $contextId, string $newOwnerId, int $newOwnerType = 0): DataResponse {
 		try {
 			return new DataResponse($this->contextService->transfer($contextId, $newOwnerId, $newOwnerType)->jsonSerialize());
@@ -249,7 +248,6 @@ class ContextController extends AOCSController {
 	 *
 	 * @return DataResponse<Http::STATUS_OK, TablesContext, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND|Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
 	 *
-	 * @NoAdminRequired
 	 * @CanManageContext
 	 *
 	 * 200: content updated successfully
@@ -257,6 +255,7 @@ class ContextController extends AOCSController {
 	 * 403: No permissions
 	 * 404: Not found
 	 */
+	#[NoAdminRequired]
 	public function updateContentOrder(int $contextId, int $pageId, array $content): DataResponse {
 		try {
 			$context = $this->contextService->findById($contextId, $this->userId);

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -13,6 +13,7 @@ use OCA\Tables\Service\ImportService;
 use OCA\Tables\UploadException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\NotPermittedException;
 use OCP\IL10N;
@@ -54,9 +55,7 @@ class ImportController extends Controller {
 		$this->l10n = $l10n;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function previewImportTable(int $tableId, String $path): DataResponse {
 		return $this->handleError(function () use ($tableId, $path) {
@@ -64,9 +63,7 @@ class ImportController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function importInTable(int $tableId, String $path, bool $createMissingColumns = true, array $columnsConfig = []): DataResponse {
 		return $this->handleError(function () use ($tableId, $path, $createMissingColumns, $columnsConfig) {
@@ -75,9 +72,7 @@ class ImportController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function previewImportView(int $viewId, String $path): DataResponse {
 		return $this->handleError(function () use ($viewId, $path) {
@@ -85,9 +80,7 @@ class ImportController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function importInView(int $viewId, String $path, bool $createMissingColumns = true, array $columnsConfig = []): DataResponse {
 		return $this->handleError(function () use ($viewId, $path, $createMissingColumns, $columnsConfig) {
@@ -96,9 +89,7 @@ class ImportController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function previewUploadImportTable(int $tableId): DataResponse {
 		try {
@@ -112,9 +103,7 @@ class ImportController extends Controller {
 		}
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function importUploadInTable(int $tableId, bool $createMissingColumns = true, string $columnsConfig = ''): DataResponse {
 		try {
@@ -130,9 +119,7 @@ class ImportController extends Controller {
 		}
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function previewUploadImportView(int $viewId): DataResponse {
 		try {
@@ -146,9 +133,7 @@ class ImportController extends Controller {
 		}
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function importUploadInView(int $viewId, bool $createMissingColumns = true, string $columnsConfig = ''): DataResponse {
 		try {

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -78,6 +78,7 @@ class ImportController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function previewImportView(int $viewId, String $path): DataResponse {
 		return $this->handleError(function () use ($viewId, $path) {
 			return $this->service->previewImport(null, $viewId, $path);
@@ -98,6 +99,7 @@ class ImportController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function previewUploadImportTable(int $tableId): DataResponse {
 		try {
 			$file = $this->getUploadedFile('uploadfile');
@@ -131,6 +133,7 @@ class ImportController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_CREATE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function previewUploadImportView(int $viewId): DataResponse {
 		try {
 			$file = $this->getUploadedFile('uploadfile');

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -57,6 +57,7 @@ class ImportController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function previewImportTable(int $tableId, String $path): DataResponse {
 		return $this->handleError(function () use ($tableId, $path) {
 			return $this->service->previewImport($tableId, null, $path);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -10,6 +10,9 @@ namespace OCA\Tables\Controller;
 use OCA\Tables\AppInfo\Application;
 use OCA\Text\Event\LoadEditor;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -29,12 +32,11 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @IgnoreOpenAPI
-	 *
 	 * Render default template
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 	public function index(): TemplateResponse {
 		Util::addScript(Application::APP_ID, 'tables-main');
 		Util::addStyle(Application::APP_ID, 'grid');
@@ -49,14 +51,13 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @IgnoreOpenAPI
-	 *
 	 * Render default template
 	 *
 	 * @psalm-param int<0, max> $appId
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 	public function context(int $contextId): TemplateResponse {
 		$navId = Application::APP_ID . '_application_' . $contextId;
 		$this->navigationManager->setActiveEntry($navId);

--- a/lib/Controller/RowController.php
+++ b/lib/Controller/RowController.php
@@ -8,6 +8,7 @@
 namespace OCA\Tables\Controller;
 
 use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\RowService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
@@ -39,6 +40,7 @@ class RowController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
 			return $this->service->findAllByTable($tableId, $this->userId);
@@ -48,6 +50,7 @@ class RowController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
 			return $this->service->findAllByView($viewId, $this->userId);

--- a/lib/Controller/RowController.php
+++ b/lib/Controller/RowController.php
@@ -11,6 +11,7 @@ use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\RowService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -37,9 +38,7 @@ class RowController extends Controller {
 		$this->userId = $userId;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
@@ -47,9 +46,7 @@ class RowController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
@@ -57,18 +54,14 @@ class RowController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->find($id);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function update(
 		int $id,
 		int $columnId,
@@ -87,9 +80,7 @@ class RowController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function updateSet(
 		int $id,
 		?int $viewId,
@@ -109,17 +100,13 @@ class RowController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id, null, $this->userId);
 		});
 	}
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function destroyByView(int $id, int $viewId): DataResponse {
 		return $this->handleError(function () use ($id, $viewId) {
 			return $this->service->delete($id, $viewId, $this->userId);

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Controller;
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Service\SearchService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -34,9 +35,7 @@ class SearchController extends Controller {
 	}
 
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function all(string $term = ''): DataResponse {
 		return $this->handleError(function () use ($term) {
 			return $this->service->all($term);

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -11,6 +11,7 @@ use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\ShareService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -37,9 +38,7 @@ class ShareController extends Controller {
 	}
 
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
@@ -47,9 +46,7 @@ class ShareController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
@@ -57,18 +54,14 @@ class ShareController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->find($id);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE)]
 	public function create(
 		int $nodeId,
@@ -87,9 +80,7 @@ class ShareController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function updatePermission(int $id, string $permission, bool $value): DataResponse {
 		return $this->handleError(function () use ($id, $permission, $value) {
 			return $this->service->updatePermission($id, $permission, $value);
@@ -97,10 +88,10 @@ class ShareController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @psalm-param int<0, 2> $displayMode
 	 * @psalm-param ("default"|"self") $target
 	 */
+	#[NoAdminRequired]
 	public function updateDisplayMode(int $id, int $displayMode, string $target = 'default') {
 		return $this->handleError(function () use ($id, $displayMode, $target) {
 			if ($target === 'default') {
@@ -115,9 +106,7 @@ class ShareController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id);

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -40,6 +40,7 @@ class ShareController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
 			return $this->service->findAll('table', $tableId);
@@ -49,6 +50,7 @@ class ShareController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
 			return $this->service->findAll('view', $viewId);

--- a/lib/Controller/TableController.php
+++ b/lib/Controller/TableController.php
@@ -11,6 +11,7 @@ use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\TableService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -37,18 +38,14 @@ class TableController extends Controller {
 	}
 
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function index(): DataResponse {
 		return $this->handleError(function () {
 			return $this->service->findAll($this->userId);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
@@ -56,18 +53,14 @@ class TableController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function create(string $title, string $template, string $emoji): DataResponse {
 		return $this->handleError(function () use ($title, $template, $emoji) {
 			return $this->service->create($title, $template, $emoji);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
@@ -75,9 +68,7 @@ class TableController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function update(int $id, ?string $title = null, ?string $emoji = null, ?bool $archived = null): DataResponse {
 		return $this->handleError(function () use ($id, $title, $emoji, $archived) {

--- a/lib/Controller/TableController.php
+++ b/lib/Controller/TableController.php
@@ -8,6 +8,7 @@
 namespace OCA\Tables\Controller;
 
 use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\TableService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
@@ -48,6 +49,7 @@ class TableController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->find($id);

--- a/lib/Controller/TableController.php
+++ b/lib/Controller/TableController.php
@@ -68,6 +68,7 @@ class TableController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id);
@@ -77,6 +78,7 @@ class TableController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'id')]
 	public function update(int $id, ?string $title = null, ?string $emoji = null, ?bool $archived = null): DataResponse {
 		return $this->handleError(function () use ($id, $title, $emoji, $archived) {
 			return $this->service->update($id, $title, $emoji, null, $archived, $this->userId);

--- a/lib/Controller/TableTemplateController.php
+++ b/lib/Controller/TableTemplateController.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Controller;
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Service\TableTemplateService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -30,9 +31,7 @@ class TableTemplateController extends Controller {
 		$this->service = $service;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function list(): DataResponse {
 		return $this->handleError(function () {
 			return $this->service->getTemplateList();

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -13,6 +13,7 @@ use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\TableService;
 use OCA\Tables\Service\ViewService;
 use OCP\AppFramework\Controller;
@@ -53,6 +54,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
 			return $this->service->findAll($this->getTable($tableId), $this->userId);
@@ -71,6 +73,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->find($id);

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -83,6 +83,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function create(int $tableId, string $title, ?string $emoji): DataResponse {
 		return $this->handleError(function () use ($tableId, $title, $emoji) {
 			return $this->service->create($title, $emoji, $this->getTable($tableId, true));
@@ -92,6 +93,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function update(int $id, array $data): DataResponse {
 		return $this->handleError(function () use ($id, $data) {
 			return $this->service->update($id, $data, $this->userId);
@@ -101,12 +103,12 @@ class ViewController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
 			return $this->service->delete($id);
 		});
 	}
-
 
 	/**
 	 * @param int $tableId

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -17,6 +17,7 @@ use OCA\Tables\Middleware\Attribute\RequirePermission;
 use OCA\Tables\Service\TableService;
 use OCA\Tables\Service\ViewService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -51,9 +52,7 @@ class ViewController extends Controller {
 	}
 
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
@@ -61,18 +60,14 @@ class ViewController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	public function indexSharedWithMe(): DataResponse {
 		return $this->handleError(function () {
 			return $this->service->findSharedViewsWithMe($this->userId);
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function show(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {
@@ -80,9 +75,7 @@ class ViewController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function create(int $tableId, string $title, ?string $emoji): DataResponse {
 		return $this->handleError(function () use ($tableId, $title, $emoji) {
@@ -90,9 +83,7 @@ class ViewController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function update(int $id, array $data): DataResponse {
 		return $this->handleError(function () use ($id, $data) {
@@ -100,9 +91,7 @@ class ViewController extends Controller {
 		});
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'id')]
 	public function destroy(int $id): DataResponse {
 		return $this->handleError(function () use ($id) {

--- a/lib/Middleware/PermissionMiddleware.php
+++ b/lib/Middleware/PermissionMiddleware.php
@@ -106,6 +106,7 @@ class PermissionMiddleware extends Middleware {
 		}
 
 		match ($attribute->getPermission()) {
+			Application::PERMISSION_READ => true, // this is guaranteed in the pre-test ^
 			Application::PERMISSION_MANAGE => $this->assertManagePermission($isContext, $nodeType, $nodeId),
 			Application::PERMISSION_CREATE => $this->assertCreatePermissions($nodeType, $nodeId),
 			Application::PERMISSION_UPDATE => $this->assertUpdatePermissions($nodeType, $nodeId),

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -45,9 +45,7 @@ Feature: APIv2
     And user "participant1-v2" sees the following table attributes on table "t1"
       | favorite | 0 |
     When user "participant3-v2" adds the table "t1" to favorites
-    Then the last response should have a "403" status code
-
-
+    Then the last response should have a "404" status code
 
   @api2
   Scenario: Basic column actions


### PR DESCRIPTION
Use the permission middleware in more places (I did not remove the service-level checks though) and remove depracted use of annotations towards attributes.