### PR TITLE
fix return status in a few cases and add integration tests against content modification through Applications

### DIFF
--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -344,6 +344,7 @@ class RowService extends SuperService {
 	 *
 	 * @throws InternalError
 	 * @throws NotFoundError
+	 * @throws PermissionError
 	 * @noinspection DuplicatedCode
 	 */
 	public function updateSet(
@@ -367,7 +368,7 @@ class RowService extends SuperService {
 			if (!$this->permissionsService->canUpdateRowsByViewId($viewId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+				throw new PermissionError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
 			}
 
 			try {
@@ -402,7 +403,7 @@ class RowService extends SuperService {
 			if (!$this->permissionsService->canUpdateRowsByTableId($tableId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+				throw new PermissionError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
 			}
 			try {
 				$columns = $this->columnMapper->findAllByTable($tableId);

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -460,7 +460,7 @@ class RowService extends SuperService {
 			if (!$this->permissionsService->canDeleteRowsByViewId($viewId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+				throw new PermissionError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
 			}
 			try {
 				$view = $this->viewMapper->find($viewId);

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -365,6 +365,11 @@ class RowService extends SuperService {
 
 		if ($viewId) {
 			// security
+			if (!$this->permissionsService->canReadRowsByElementId($viewId, 'view', $userId)) {
+				$e = new \Exception('Row not found.');
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+			}
 			if (!$this->permissionsService->canUpdateRowsByViewId($viewId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
@@ -400,6 +405,11 @@ class RowService extends SuperService {
 			$tableId = $item->getTableId();
 
 			// security
+			if (!$this->permissionsService->canReadRowsByElementId($item->getTableId(), 'table', $userId)) {
+				$e = new \Exception('Row not found.');
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+			}
 			if (!$this->permissionsService->canUpdateRowsByTableId($tableId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
@@ -457,6 +467,11 @@ class RowService extends SuperService {
 
 		if ($viewId) {
 			// security
+			if (!$this->permissionsService->canReadRowsByElementId($viewId, 'view', $userId)) {
+				$e = new \Exception('Row not found.');
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+			}
 			if (!$this->permissionsService->canDeleteRowsByViewId($viewId)) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
@@ -475,6 +490,11 @@ class RowService extends SuperService {
 			}
 		} else {
 			// security
+			if (!$this->permissionsService->canReadRowsByElementId($item->getTableId(), 'table', $userId)) {
+				$e = new \Exception('Row not found.');
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());
+			}
 			if (!$this->permissionsService->canDeleteRowsByTableId($item->getTableId())) {
 				$e = new \Exception('Update row is not allowed.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -1275,3 +1275,45 @@ Feature: APIv2
     Then the reported status is "403"
     And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-not-updatable,r-not-deletable"
     And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Ensure elements cannot be modified in an unavailable table or view, otherwise shared through a context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions               |
+      | t1    | table | read,create,update,delete |
+      | v1    | view  | read,create,update,delete |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant3-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "404"
+    When user "participant3-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "404"
+    When user "participant3-v2" deletes row "r-not-deletable"
+    Then the reported status is "404"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+    And using view "v1"
+    When user "participant3-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "404"
+    When user "participant3-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "404"
+    When user "participant3-v2" deletes row "r-not-deletable"
+    Then the reported status is "404"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -1095,3 +1095,183 @@ Feature: APIv2
     Then the reported status is "403"
     And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-not-deletable"
     And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRUD permissions on a table available through a context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions              |
+      | v1    | view | read,create,update,delete |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-updatable,r-inserted"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRU permissions on a table available through a context, ensure D is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type | permissions               |
+      | v1    | view | read,create,update        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-updatable,r-inserted,r-not-deletable"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRD permissions on a table available through a context, ensure U is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type | permissions               |
+      | v1    | view | read,create,delete        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-not-updatable,r-inserted"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute RUD permissions on a table available through a context, ensure C is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type | permissions               |
+      | v1    | view | read,update,delete        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "403"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-updatable"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CR permissions on a table available through a context, ensure UD is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type | permissions        |
+      | v1    | view | read,create        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-not-updatable,r-inserted,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute R permissions on a table available through a context, ensure CUD is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" create view "v1" with emoji "⚡️" for "t1" as "v1"
+    And user "participant1-v2" sets columns "statement" to view "v1"
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type | permissions |
+      | v1    | view | read        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using view "v1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "403"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches view "v1", it has exactly these rows "r-not-updatable,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"

--- a/tests/integration/features/APIv2.feature
+++ b/tests/integration/features/APIv2.feature
@@ -927,3 +927,171 @@ Feature: APIv2
       | four          | 2023-12-24              |
       | five          | [{"id": "admin", "type": 0}] |
     Then the reported status is 404
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRUD permissions on a table available through a context
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions               |
+      | t1    | table | read,create,update,delete |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-updatable,r-inserted"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRU permissions on a table available through a context, ensure D is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions               |
+      | t1    | table | read,create,update        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-updatable,r-inserted,r-not-deletable"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CRD permissions on a table available through a context, ensure U is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions               |
+      | t1    | table | read,create,delete        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-inserted"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute RUD permissions on a table available through a context, ensure C is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions               |
+      | t1    | table | read,update,delete        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-updatable" with following values:
+      | statement     | testing update |
+    And user "participant1-v2" creates row "r-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "403"
+    When user "participant2-v2" updates row "r-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "200"
+    When user "participant2-v2" deletes row "r-deletable"
+    Then the reported status is "200"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-updatable"
+    And the column "statement" of row "r-updatable" has the value "update accomplished"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute CR permissions on a table available through a context, ensure UD is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions        |
+      | t1    | table | read,create        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "200"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-inserted,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"
+
+  @api2 @contexts @contexts-content
+  Scenario: Execute R permissions on a table available through a context, ensure CUD is not possible
+    Given table "Table 1 via api v2" with emoji "👋" exists for user "participant1-v2" as "t1" via v2
+    And column "statement" exists with following properties
+      | type          | text                |
+      | subtype       | line                |
+      | mandatory     | 1                   |
+      | description   | State your business |
+    And user "participant1-v2" creates the Context "c1" with name "Enchanting Guitar" with icon "tennis" and description "Lorem ipsum dolor etc pp" and nodes:
+      | alias | type  | permissions |
+      | t1    | table | read        |
+    And user "participant1-v2" shares the Context "c1" to "user" "participant2-v2"
+    And using table "t1"
+    And user "participant1-v2" creates row "r-not-updatable" with following values:
+      | statement     | testing not updated |
+    And user "participant1-v2" creates row "r-not-deletable" with following values:
+      | statement     | testing delete |
+    When user "participant2-v2" creates row "r-not-inserted" with following values:
+      | statement     | testing insert |
+    Then the reported status is "403"
+    When user "participant2-v2" updates row "r-not-updatable" with following values:
+      | statement     | update accomplished |
+    Then the reported status is "403"
+    When user "participant2-v2" deletes row "r-not-deletable"
+    Then the reported status is "403"
+    And the user "participant1-v2" fetches table "t1", it has exactly these rows "r-not-updatable,r-not-deletable"
+    And the column "statement" of row "r-not-updatable" has the value "testing not updated"

--- a/tests/integration/features/bootstrap/CollectionManager.php
+++ b/tests/integration/features/bootstrap/CollectionManager.php
@@ -44,7 +44,8 @@ class CollectionManager {
 		if ($alias) {
 			unset($this->mapByAlias[$this->makeKey($type, $alias)]);
 		}
-		unset($this->itemsById[$this->makeKey($type, $id)]);
+		$idKey = $this->makeKey($type, $id);
+		unset($this->cleanUp[$idKey], $this->itemsById[$idKey]);
 	}
 
 	public function cleanUp(): void {

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -318,6 +318,9 @@ class FeatureContext implements Context {
 
 		Assert::assertEquals(200, $this->response->getStatusCode());
 		Assert::assertEquals($updatedTable['ownership'], $newUser);
+		$this->collectionManager->update($updatedTable, 'table', $updatedTable['id'], function () use ($newUser, $tableName): void {
+			$this->deleteTableV2($newUser, $tableName);
+		});
 	}
 
 	/**
@@ -367,6 +370,9 @@ class FeatureContext implements Context {
 		Assert::assertEquals(404, $this->response->getStatusCode());
 
 		unset($this->tableIds[$tableName]);
+		if ($table = $this->collectionManager->getByAlias('table', $tableName)) {
+			$this->collectionManager->forget('table', $table['id']);
+		}
 	}
 
 	/**
@@ -914,6 +920,10 @@ class FeatureContext implements Context {
 		Assert::assertEquals(200, $this->response->getStatusCode());
 		Assert::assertEquals($deletedTable['title'], $table['title']);
 		Assert::assertEquals($deletedTable['id'], $table['id']);
+
+		if ($tableItem = $this->collectionManager->getById('table', $table['id'])) {
+			$this->collectionManager->forget('table', $tableItem['id']);
+		}
 
 		$this->sendRequest(
 			'GET',

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2508,7 +2508,7 @@ class FeatureContext implements Context {
 		$row = $this->collectionManager->getByAlias('row', $rowAlias);
 
 		if ($this->activeNode['type'] === 'view') {
-			$endpoint = sprintf('/apps/tables/api/1/views/%s/rows/%s',$this->activeNode['id'], $row['id']);
+			$endpoint = sprintf('/apps/tables/api/1/views/%s/rows/%s', $this->activeNode['id'], $row['id']);
 		} else {
 			$endpoint = sprintf('/apps/tables/api/1/rows/%s', $row['id']);
 		}

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2464,8 +2464,8 @@ class FeatureContext implements Context {
 			['data' => $props]
 		);
 
-		$newRow = $this->getDataFromResponse($this->response)['ocs']['data'];
 		if ($this->response->getStatusCode() === 200) {
+			$newRow = $this->getDataFromResponse($this->response)['ocs']['data'];
 			$this->collectionManager->register($newRow, 'row', $newRow['id'], $rowAlias);
 		}
 	}


### PR DESCRIPTION
The fixes include a few cases were `500` was returned, where `403` was expected, and also where it should be `404`.

These were all found when writing the missing tests – the fifth batch – for #1006.

Closes #1006 