### PR TITLE
fix: use actual providerId in link rows

### DIFF
--- a/lib/Service/ColumnTypes/TextLinkBusiness.php
+++ b/lib/Service/ColumnTypes/TextLinkBusiness.php
@@ -38,7 +38,7 @@ class TextLinkBusiness extends SuperBusiness implements IColumnTypeBusiness {
 				return json_encode(json_encode([
 					'title' => $data['title'] ?? $data['resourceUrl'],
 					'value' => $data['resourceUrl'],
-					'providerId' => 'url',
+					'providerId' => $data['providerId'] ?? 'url',
 				]));
 			}
 			// at least title and resUrl have to be set


### PR DESCRIPTION
fixes #1442 

### Before

https://github.com/user-attachments/assets/8a89c889-a1a4-4e80-a025-8b294db22aeb



### After

https://github.com/user-attachments/assets/28dc5e97-c480-476d-b1d9-b5cf786855e2


TODO:
- [x] check that other provider links also work