### PR TITLE
fix: use 0 for falsy number progress values during sorting

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/numberProgress.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/numberProgress.js
@@ -16,9 +16,9 @@ export default class NumberProgressColumn extends AbstractNumberColumn {
 	sort(mode, nextSorts) {
 		const factor = mode === 'DESC' ? -1 : 1
 		return (rowA, rowB) => {
-			const tmpA = rowA.data.find(item => item.columnId === this.id)?.value || null
+			const tmpA = rowA.data.find(item => item.columnId === this.id)?.value || 0
 			const valueA = parseInt(tmpA)
-			const tmpB = rowB.data.find(item => item.columnId === this.id)?.value || null
+			const tmpB = rowB.data.find(item => item.columnId === this.id)?.value || 0
 			const valueB = parseInt(tmpB)
 			return ((valueA < valueB) ? -1 : (valueA > valueB) ? 1 : 0) * factor || super.getNextSortsResult(nextSorts, rowA, rowB)
 		}


### PR DESCRIPTION
Fixes #1441 