### PR TITLE
ci: Hotfix to make login work as long as we are on older cypress version

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,12 +28,53 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 import { addCommands } from '@nextcloud/cypress'
+import { emit } from '@nextcloud/event-bus'
 require('cypress-downloadfile/lib/downloadFileCommand')
 
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
+const silent = { log: false }
 
 addCommands()
+
+// Copy of the new login command as long as we are blocked to upgrade @nextcloud/cypress by cypress crashes
+const login = function(user) {
+	cy.session(user, function() {
+		cy.request('/csrftoken').then(({ body }) => {
+			const requestToken = body.token
+			cy.request({
+				method: 'POST',
+				url: '/login',
+				body: {
+					user: user.userId,
+					password: user.password,
+					requesttoken: requestToken,
+				},
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+					// Add the Origin header so that the request is not blocked by the browser.
+					Origin: (Cypress.config('baseUrl') ?? '').replace('index.php/', ''),
+				},
+				followRedirect: false,
+			})
+		})
+	}, {
+		validate() {
+			cy.request('/apps/files').its('status').should('eq', 200)
+		},
+	})
+}
+
+// Prepare the csrf-token for axios
+Cypress.Commands.overwrite('login', (_login, user) => {
+	cy.window(silent).then((win) => {
+		win.location.href = 'about:blank'
+	})
+	login(user)
+	cy.request('/csrftoken', silent)
+		.then(({ body }) => emit('csrf-token-update', body))
+	cy.wrap(user, silent).as('currentUser')
+})
 
 Cypress.Commands.add('createTable', (title) => {
 	cy.get('.icon-loading').should('not.exist')


### PR DESCRIPTION
Server changed at https://github.com/nextcloud/server/pull/49560, so tests are failing. The ideal solution is to update  @nextcloud/cypress to benefit from https://github.com/nextcloud-libraries/nextcloud-cypress/pull/703, but doing this gives ResizeObserver errors. This is a temporary fix while we figure out how to fix that