### PR TITLE
fix(Views): allow to sort for meta columns

### DIFF
--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -449,13 +449,18 @@ class ViewService extends SuperService {
 			$rawSortArray = $view->getSortArray();
 			if ($rawSortArray) {
 				$view->setSortArray(
-					array_map(static function ($sortRule) use ($view) {
+					array_map(static function (array $sortRule) use ($view): array {
 						$columnsArray = $view->getColumnsArray();
-						if (isset($sortRule['columnId']) && $columnsArray && in_array($sortRule['columnId'], $columnsArray, true)) {
+						if (isset($sortRule['columnId'])
+							&& (
+								Column::isValidMetaTypeId($sortRule['columnId'])
+								|| in_array($sortRule['columnId'], $columnsArray, true)
+							)
+						) {
 							return $sortRule;
 						}
 						// Instead of sort rule just indicate that there is a rule, but hide details
-						return null;
+						return [];
 					},
 						$rawSortArray));
 			}


### PR DESCRIPTION
- meta columns included in sorting do not need to be hidden from the response
- changed the return value to an empty array, to avoid a Vue error in the frontend (it expects an array)

Now however, for owners the sorting is working ~~,but for share recipients it is not (but the content is at least visible).~~

~~Not sure this is the best approach, and the sorting needs frontend changes as well. Hoping for your feedback @enjeck~~

addresses #1524