### PR TITLE
fix: allow adding meta data columns to views again

### DIFF
--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -84,6 +84,8 @@ class Column extends Entity implements JsonSerializable {
 	public const TYPE_META_UPDATED_BY = -3;
 	public const TYPE_META_CREATED_AT = -4;
 	public const TYPE_META_UPDATED_AT = -5;
+	// In case a new one is added, add it to isValidMetaTypeId() as well.
+	// When we drop PHP 8.0, we can switch to enums.
 
 	public const TYPE_SELECTION = 'selection';
 	public const TYPE_TEXT = 'text';
@@ -151,6 +153,16 @@ class Column extends Entity implements JsonSerializable {
 		$this->addType('usergroupSelectUsers', 'boolean');
 		$this->addType('usergroupSelectGroups', 'boolean');
 		$this->addType('showUserStatus', 'boolean');
+	}
+
+	public static function isValidMetaTypeId(int $metaTypeId): bool {
+		return in_array($metaTypeId, [
+			self::TYPE_META_ID,
+			self::TYPE_META_CREATED_BY,
+			self::TYPE_META_UPDATED_BY,
+			self::TYPE_META_CREATED_AT,
+			self::TYPE_META_UPDATED_AT,
+		], true);
 	}
 
 	public static function fromDto(ColumnDto $data): self {

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -271,7 +271,7 @@ class ViewService extends SuperService {
 					$availableColumns = $columnService->findAllByTable($view->getTableId(), $view->getId(), $this->userId);
 					$availableColumns = array_map(static fn (Column $column) => $column->getId(), $availableColumns);
 					foreach ($columnIds as $columnId) {
-						if (!in_array($columnId, $availableColumns, true)) {
+						if (!Column::isValidMetaTypeId($columnId) && !in_array($columnId, $availableColumns, true)) {
 							throw new InvalidArgumentException('Invalid column ID provided');
 						}
 					}

--- a/tests/integration/features/APIv1.feature
+++ b/tests/integration/features/APIv1.feature
@@ -243,7 +243,7 @@ Feature: APIv1
       | mandatory     | 0               |
       | description   | Note me a thing |
     And user "participant1" create view "Simple View" with emoji "🙃" for "table_p1" as "simple-view"
-    When user "participant1" sets columns "Volatile Notes" to view "simple-view"
+    When user "participant1" sets columns "Volatile Notes,-1" to view "simple-view"
     Then the reported status is "200"
 
   @api1 @views

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -868,6 +868,9 @@ class FeatureContext implements Context {
 
 		$columns = explode(',', $columnList);
 		$columns = array_map(function (string $columnAlias) {
+			if (is_numeric($columnAlias)) {
+				return (int)$columnAlias;
+			}
 			$col = $this->collectionManager->getByAlias('column', $columnAlias);
 			return $col['id'];
 		}, $columns);


### PR DESCRIPTION
Regression was introduced in https://github.com/nextcloud/tables/commit/94da27afcb6aaddf01ab7b00d9f353ea2fba04bb#diff-94c64cbe53bdc638784b9674d36ee5fdb26835b2c4a5b421195dd18711b48349 – the check was a little too strict now.

(partially) fixes #1499 