### PR TITLE
fix(RowMappers): value might at least be null

### DIFF
--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -41,10 +41,7 @@ class RowCellMapperSuper extends QBMapper {
 	 * Transform value from a filter rule to the actual query parameter used
 	 * for constructing the view filter query
 	 */
-	/**
-	 * @param float|string $value
-	 */
-	public function filterValueToQueryParam(Column $column, string|float $value) {
+	public function filterValueToQueryParam(Column $column, mixed $value): mixed {
 		return $value;
 	}
 

--- a/lib/Db/RowCellSelectionMapper.php
+++ b/lib/Db/RowCellSelectionMapper.php
@@ -19,7 +19,7 @@ class RowCellSelectionMapper extends RowCellMapperSuper {
 		parent::__construct($db, $this->table, RowCellSelection::class);
 	}
 
-	public function filterValueToQueryParam(Column $column, $value) {
+	public function filterValueToQueryParam(Column $column, mixed $value): mixed {
 		return $this->valueToJsonDbValue($column, $value);
 	}
 

--- a/lib/Db/RowCellUsergroupMapper.php
+++ b/lib/Db/RowCellUsergroupMapper.php
@@ -18,7 +18,7 @@ class RowCellUsergroupMapper extends RowCellMapperSuper {
 		parent::__construct($db, $this->table, RowCellUsergroup::class);
 	}
 
-	public function filterValueToQueryParam(Column $column, $value) {
+	public function filterValueToQueryParam(Column $column, mixed $value): mixed {
 		return $value;
 	}
 


### PR DESCRIPTION
I war running today into this exception:

<details><summary>OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866 in file '/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php' line 47</summary>

```json
{
  "reqId": "J0E9GurC2VQmwSVeG9Dx",
  "level": 3,
  "time": "2025-01-10T14:50:48+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "master",
  "app": "index",
  "method": "GET",
  "url": "/index.php/apps/tables/table",
  "message": "OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866 in file '/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php' line 47",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0",
  "version": "31.0.0.8",
  "exception": {
    "Exception": "Exception",
    "Message": "OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866 in file '/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php' line 47",
    "Code": 0,
    "Trace": [
      {
        "file": "/path/to/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Tables\\Controller\\TableController"
          },
          "index"
        ]
      },
      {
        "file": "/path/to/nextcloud/lib/private/Route/Router.php",
        "line": 306,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Tables\\Controller\\TableController",
          "index",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "_route": "tables.table.index"
          }
        ]
      },
      {
        "file": "/path/to/nextcloud/lib/base.php",
        "line": 1019,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/tables/table"
        ]
      },
      {
        "file": "/path/to/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
    "Line": 146,
    "Previous": {
      "Exception": "TypeError",
      "Message": "OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866",
      "Code": 0,
      "Trace": [
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 866,
          "function": "filterValueToQueryParam",
          "class": "OCA\\Tables\\Db\\RowCellMapperSuper",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\Column",
              "id": 2424
            },
            null
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 336,
          "function": "getFormattedDefaultValue",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\Column",
              "id": 2424
            }
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 305,
          "function": "getFilterExpression",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
            },
            {
              "__class__": "OCA\\Tables\\Db\\Column",
              "id": 2424
            },
            "is-greater-than-or-equal",
            "4"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 282,
          "function": "getFilter",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
            },
            [
              {
                "columnId": 2424,
                "operator": "is-greater-than-or-equal",
                "value": "4"
              }
            ]
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 260,
          "function": "getFilterGroups",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
            },
            [
              [
                {
                  "columnId": 2424,
                  "operator": "is-greater-than-or-equal",
                  "value": "4"
                }
              ]
            ]
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 142,
          "function": "addFilterToQuery",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
            },
            [
              [
                {
                  "columnId": 2424,
                  "operator": "is-greater-than-or-equal",
                  "value": "4"
                }
              ]
            ],
            "master"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php",
          "line": 848,
          "function": "getWantedRowIds",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            "master",
            828,
            [
              [
                {
                  "columnId": 2424,
                  "operator": "is-greater-than-or-equal",
                  "value": "4"
                }
              ]
            ]
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Service/RowService.php",
          "line": 575,
          "function": "countRowsForView",
          "class": "OCA\\Tables\\Db\\Row2Mapper",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\View",
              "id": 132
            },
            "master",
            [
              {
                "__class__": "OCA\\Tables\\Db\\Column",
                "id": 2415
              },
              {
                "__class__": "OCA\\Tables\\Db\\Column",
                "id": 2416
              },
              {
                "__class__": "OCA\\Tables\\Db\\Column",
                "id": 2417
              },
              {
                "__class__": "OCA\\Tables\\Db\\Column",
                "id": 2418
              },
              {
                "__class__": "OCA\\Tables\\Db\\Column",
                "id": 2419
              },
              "And 5 more entries, set log level to debug to see all entries"
            ]
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Service/ViewService.php",
          "line": 434,
          "function": "getViewRowsCount",
          "class": "OCA\\Tables\\Service\\RowService",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\View",
              "id": 132
            },
            "master"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Service/ViewService.php",
          "line": 94,
          "function": "enhanceView",
          "class": "OCA\\Tables\\Service\\ViewService",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\View",
              "id": 132
            },
            "master"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Service/TableService.php",
          "line": 237,
          "function": "findAll",
          "class": "OCA\\Tables\\Service\\ViewService",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\Table",
              "id": 828
            }
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Service/TableService.php",
          "line": 159,
          "function": "enhanceTable",
          "class": "OCA\\Tables\\Service\\TableService",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Db\\Table",
              "id": 828
            },
            "master"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Controller/TableController.php",
          "line": 44,
          "function": "findAll",
          "class": "OCA\\Tables\\Service\\TableService",
          "type": "->",
          "args": [
            "master"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Controller/Errors.php",
          "line": 22,
          "function": "OCA\\Tables\\Controller\\{closure}",
          "class": "OCA\\Tables\\Controller\\TableController",
          "type": "->",
          "args": [
            "*** sensitive parameters replaced ***"
          ]
        },
        {
          "file": "/path/to/nextcloud/apps-repos/tables/lib/Controller/TableController.php",
          "line": 43,
          "function": "handleError",
          "class": "OCA\\Tables\\Controller\\TableController",
          "type": "->",
          "args": [
            {
              "__class__": "Closure"
            }
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 200,
          "function": "index",
          "class": "OCA\\Tables\\Controller\\TableController",
          "type": "->",
          "args": []
        },
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 114,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Controller\\TableController"
            },
            "index"
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/App.php",
          "line": 161,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Tables\\Controller\\TableController"
            },
            "index"
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/Route/Router.php",
          "line": 306,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::",
          "args": [
            "OCA\\Tables\\Controller\\TableController",
            "index",
            {
              "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
            },
            {
              "_route": "tables.table.index"
            }
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/base.php",
          "line": 1019,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->",
          "args": [
            "/apps/tables/table"
          ]
        },
        {
          "file": "/path/to/nextcloud/index.php",
          "line": 24,
          "function": "handleRequest",
          "class": "OC",
          "type": "::",
          "args": []
        }
      ],
      "File": "/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php",
      "Line": 47
    },
    "message": "OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866 in file '/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php' line 47",
    "exception": {},
    "CustomMessage": "OCA\\Tables\\Db\\RowCellMapperSuper::filterValueToQueryParam(): Argument #2 ($value) must be of type string|float, null given, called in /path/to/nextcloud/apps-repos/tables/lib/Db/Row2Mapper.php on line 866 in file '/path/to/nextcloud/apps-repos/tables/lib/Db/RowCellMapperSuper.php' line 47"
  }
}
```
</details>

It turns out that the passed `$value` is legitimately null, and the restriction to `string|float` was introduced in  https://github.com/nextcloud/tables/commit/5dacb827de05371b54c5df3fb88fde597d30bebb#r151180391

This happens against filter rules that check values of empty optional columns.

This PR lifts the constraint and is open to any value type. I did not double check, but I suppose integers could suffer from the same.