### PR TITLE
fix: wrap usergroup's cell values

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellUsergroup.vue
+++ b/src/shared/components/ncTable/partials/TableCellUsergroup.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<!-- eslint-disable-next-line vue/no-v-html -->
-	<div v-if="value">
+	<div v-if="value" class="table-cell-usergroup">
 		<div v-for="item in value" :key="item.id" class="inline usergroup-entry">
 			<NcUserBubble :user="item.id" :avatar-image="item.type === 1 ? 'icon-group' : ''" :is-no-user="item.type !== 0" :display-name="item.displayName ?? item.id" :show-user-status="isUser(item) && column.showUserStatus" :size="column.showUserStatus ? 34 : 20" :primary="isCurrentUser(item)" />
 		</div>
@@ -48,6 +48,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+	.table-cell-usergroup {
+		display: flex;
+		flex-wrap: wrap;
+		padding: 10px;
+	}
+
 	.usergroup-entry {
 		padding-right: 10px;
 	}


### PR DESCRIPTION
We need to wrap the container of usergroup items. Otherwise, they overflow the container when there are too many items. 

### Before
![Screenshot from 2025-01-20 18-11-57](https://github.com/user-attachments/assets/555f7d51-e040-4269-9989-7d0c7e40c340)


### After
![Screenshot from 2025-01-20 18-18-56](https://github.com/user-attachments/assets/aa83057d-ffb1-444d-b164-0f04a3a206ae)

