### PR TITLE
ci(upgrade tests): use server list from appinfo

### DIFF
--- a/.github/workflows/app-upgrade-mysql.yml
+++ b/.github/workflows/app-upgrade-mysql.yml
@@ -14,6 +14,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+      outputs:
+        php-version: ${{ steps.versions.outputs.php-available-list }}
+        server-max: ${{ steps.versions.outputs.branches-max-list }}
+      steps:
+        - name: Checkout app
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+        - name: Get version matrix
+          id: versions
+          uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+
   changes:
     runs-on: ubuntu-latest
 
@@ -43,11 +56,6 @@ jobs:
 
     needs: changes
     if: needs.changes.outputs.src != 'false'
-
-    strategy:
-      matrix:
-        php-versions: ['8.2']
-        server-versions: ['master']
 
     services:
       mysql:


### PR DESCRIPTION
Currently the tests against master fail, as the appstore does not offer versions against 32.

:no_entry: not ready to merge yet