### PR TITLE
enhancement: UI fixes for create/edit row dialogs

### DIFF
--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcDialog v-if="showModal"
 		:name="t('tables', 'Create row')"
-		size="normal"
+		size="large"
 		data-cy="createRowModal"
 		@closing="actionCancel">
 		<div class="modal__content" @keydown="onKeydown">

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -172,12 +172,6 @@ export default {
 		justify-content: end;
 	}
 
-	:where(.fix-col-1.end) {
-		display: inline-block;
-		position: relative;
-		left: 65%;
-	}
-
 	:where(.slot.fix-col-2) {
 		min-width: 50%;
 	}

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -6,7 +6,7 @@
 	<NcDialog v-if="showModal"
 		data-cy="editRowModal"
 		:name="t('tables', 'Edit row')"
-		size="large"
+		size="normal"
 		@closing="actionCancel">
 		<div class="modal__content" @keydown="onKeydown">
 			<div v-for="column in nonMetaColumns" :key="column.id">

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -6,7 +6,7 @@
 	<NcDialog v-if="showModal"
 		data-cy="editRowModal"
 		:name="t('tables', 'Edit row')"
-		size="normal"
+		size="large"
 		@closing="actionCancel">
 		<div class="modal__content" @keydown="onKeydown">
 			<div v-for="column in nonMetaColumns" :key="column.id">

--- a/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
@@ -91,7 +91,11 @@ export default {
 }
 
 pre {
-	white-space: pre;
+	white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
 }
 
 </style>

--- a/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RowFormWrapper.vue
@@ -92,10 +92,10 @@ export default {
 
 pre {
 	white-space: pre-wrap;
-    white-space: -moz-pre-wrap;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
-    word-wrap: break-word;
+	white-space: -moz-pre-wrap;
+	white-space: -pre-wrap;
+	white-space: -o-pre-wrap;
+	word-wrap: break-word;
 }
 
 </style>


### PR DESCRIPTION
- Realign "expand" icon for rich text in the "create row" modal
- Wrap column description text to avoid overflow

### Before
![Screenshot from 2025-02-17 13-29-03](https://github.com/user-attachments/assets/1e26160e-593d-4a9f-b6b0-36ae01cb3786)

### After
![Screenshot from 2025-02-17 13-32-17](https://github.com/user-attachments/assets/285d3d64-3adb-41a2-ad56-399fb7c65fd5)


- Resizes "edit row" modal since it was too large
### Before
![Screenshot from 2025-02-17 13-40-14](https://github.com/user-attachments/assets/92b7ff3f-edb5-484b-8658-f4ae649ae415)

### After
![Screenshot from 2025-02-17 13-39-50](https://github.com/user-attachments/assets/ec24256a-0b78-45cf-bc00-9cd25475b88d)

