### PR TITLE
enh: Restrict text link protocols

### DIFF
--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -17,6 +17,10 @@
 					type="error">
 					{{ t('tables', '"{columnTitle}" should not be empty', { columnTitle: column.title }) }}
 				</NcNoteCard>
+				<NcNoteCard v-if="row[column.id] && column.type === 'text-link' && !isValidUrlProtocol(row[column.id])"
+					type="error">
+					{{ t('tables', 'Invalid protocol. Allowed: {allowed}', {allowed: allowedProtocols.join(', ')}) }}
+				</NcNoteCard>
 			</div>
 			<div class="row">
 				<div class="fix-col-4 space-T end">
@@ -25,7 +29,7 @@
 							{{ t('tables', 'Add more') }}
 						</NcCheckboxRadioSwitch>
 					</div>
-					<NcButton v-if="!localLoading" class="primary" :aria-label="t('tables', 'Save row')" :disabled="hasEmptyMandatoryRows" data-cy="createRowSaveButton" @click="actionConfirm()">
+					<NcButton v-if="!localLoading" class="primary" :aria-label="t('tables', 'Save row')" :disabled="hasEmptyMandatoryRows || hasInvalidUrlProtocol" data-cy="createRowSaveButton" @click="actionConfirm()">
 						{{ t('tables', 'Save') }}
 					</NcButton>
 				</div>
@@ -43,6 +47,7 @@ import { translate as t } from '@nextcloud/l10n'
 import rowHelper from '../../shared/components/ncTable/mixins/rowHelper.js'
 import { useDataStore } from '../../store/data.js'
 import { mapActions } from 'pinia'
+import { ALLOWED_PROTOCOLS } from '../../shared/constants.js'
 
 export default {
 	name: 'CreateRow',
@@ -77,6 +82,7 @@ export default {
 			row: {},
 			localLoading: false,
 			addNewAfterSave: false,
+			allowedProtocols: ALLOWED_PROTOCOLS,
 		}
 	},
 	computed: {
@@ -85,6 +91,9 @@ export default {
 		},
 		hasEmptyMandatoryRows() {
 			return this.checkMandatoryFields(this.row)
+		},
+		hasInvalidUrlProtocol() {
+			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.row[col.id]))
 		},
 	},
 	watch: {

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -17,6 +17,10 @@
 					type="error">
 					{{ t('tables', '"{columnTitle}" should not be empty', { columnTitle: column.title }) }}
 				</NcNoteCard>
+				<NcNoteCard v-if="localRow[column.id] && column.type === 'text-link' && !isValidUrlProtocol(localRow[column.id])"
+					type="error">
+					{{ t('tables', 'Invalid protocol. Allowed: {allowed}', {allowed: allowedProtocols.join(', ')}) }}
+				</NcNoteCard>
 			</div>
 			<div class="row">
 				<div class="fix-col-4 space-T" :class="{'justify-between': showDeleteButton, 'end': !showDeleteButton}">
@@ -35,7 +39,7 @@
 					</div>
 					<NcButton v-if="canUpdateData(element) && !localLoading" :aria-label="t('tables', 'Save')" type="primary"
 						data-cy="editRowSaveButton"
-						:disabled="hasEmptyMandatoryRows"
+						:disabled="hasEmptyMandatoryRows || hasInvalidUrlProtocol"
 						@click="actionConfirm">
 						{{ t('tables', 'Save') }}
 					</NcButton>
@@ -57,6 +61,7 @@ import rowHelper from '../../shared/components/ncTable/mixins/rowHelper.js'
 import { mapActions } from 'pinia'
 import { useTablesStore } from '../../store/store.js'
 import { useDataStore } from '../../store/data.js'
+import { ALLOWED_PROTOCOLS } from '../../shared/constants.js'
 
 export default {
 	name: 'EditRow',
@@ -94,6 +99,7 @@ export default {
 			localRow: null,
 			prepareDeleteRow: false,
 			localLoading: false,
+			allowedProtocols: ALLOWED_PROTOCOLS,
 		}
 	},
 	computed: {
@@ -105,6 +111,9 @@ export default {
 		},
 		hasEmptyMandatoryRows() {
 			return this.checkMandatoryFields(this.localRow)
+		},
+		hasInvalidUrlProtocol() {
+			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.localRow[col.id]))
 		},
 	},
 	watch: {

--- a/src/shared/components/ncTable/mixins/rowHelper.js
+++ b/src/shared/components/ncTable/mixins/rowHelper.js
@@ -41,7 +41,7 @@ export default {
 		isValidUrlProtocol(value) {
 			value = JSON.parse(value ?? '{}')
 			try {
-				const parsedUrl = new URL(value?.title)
+				const parsedUrl = new URL(value?.value)
 				return ALLOWED_PROTOCOLS.includes(parsedUrl.protocol)
 			} catch (e) {
 				return false

--- a/src/shared/components/ncTable/mixins/rowHelper.js
+++ b/src/shared/components/ncTable/mixins/rowHelper.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { ColumnTypes } from './columnHandler.js'
+import { ALLOWED_PROTOCOLS } from '../../../constants.js'
+
 export default {
 	methods: {
 		isValueValidForColumn(value, column) {
@@ -34,6 +36,16 @@ export default {
 				}
 			})
 			return mandatoryFieldsEmpty
+		},
+
+		isValidUrlProtocol(value) {
+			value = JSON.parse(value ?? '{}')
+			try {
+				const parsedUrl = new URL(value?.title)
+				return ALLOWED_PROTOCOLS.includes(parsedUrl.protocol)
+			} catch (e) {
+				return false
+			}
 		},
 	},
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -31,3 +31,5 @@ export const NAV_ENTRY_MODE = {
 	// NAV_ENTRY_MODE_RECIPIENTS: 1, // nav bar entry for share recipients, but not the owner. Currently unused.
 	NAV_ENTRY_MODE_ALL: 2, // nav bar entry for everybody
 }
+
+export const ALLOWED_PROTOCOLS = ['http:', 'https:']


### PR DESCRIPTION
We want to only allow certain protocols for the text link field. For now, just http and https.

Error when an invalid protocol is entered looks like this, and you're unable to save:
![Screenshot from 2025-02-25 05-17-01](https://github.com/user-attachments/assets/3579bd92-3fe1-4a02-b7c9-c613c743a046)
