### PR TITLE
Enhancement: Add description field for views

### DIFF
--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -5,6 +5,7 @@
 <template>
 	<div>
 		<ElementTitle :active-element="view" :is-table="false" :view-setting.sync="localViewSetting" />
+		<TableDescription :description="view.description" :read-only="true" />
 		<div class="table-wrapper">
 			<EmptyView v-if="columns.length === 0" :view="view" />
 			<TableView v-else
@@ -86,9 +87,11 @@ import PlaylistEdit from 'vue-material-design-icons/PlaylistEdit.vue'
 import IconImport from 'vue-material-design-icons/Import.vue'
 import Connection from 'vue-material-design-icons/Connection.vue'
 import ElementTitle from './ElementTitle.vue'
+import TableDescription from './TableDescription.vue'
 
 export default {
 	components: {
+		TableDescription,
 		EmptyView,
 		TableView,
 		PlaylistEdit,

--- a/src/modules/modals/ViewSettings.vue
+++ b/src/modules/modals/ViewSettings.vue
@@ -9,19 +9,30 @@
 		</NcAppSettingsSection>
 		<!--title & emoji-->
 		<NcAppSettingsSection v-if="columns != null" id="title" :name="t('tables', 'Title')" data-cy="viewSettingsDialogSection">
-			<div class="col-4" style="display: inline-flex;">
-				<NcEmojiPicker :close-on-select="true" @select="setIcon">
-					<NcButton type="tertiary"
-						:aria-label="t('tables', 'Select emoji for view')"
-						:title="t('tables', 'Select emoji')"
-						@click.prevent>
-						{{ icon }}
-					</NcButton>
-				</NcEmojiPicker>
-				<input v-model="title"
-					:class="{missing: errorTitle}"
-					type="text"
-					:placeholder="createView ? t('tables', 'Title of the new view') : t('tables', 'New title of the view')">
+			<div class="row">
+				<div class="col-4" style="display: inline-flex;">
+					<NcEmojiPicker :close-on-select="true" @select="setIcon">
+						<NcButton type="tertiary"
+							:aria-label="t('tables', 'Select emoji for view')"
+							:title="t('tables', 'Select emoji')"
+							@click.prevent>
+							{{ icon }}
+						</NcButton>
+					</NcEmojiPicker>
+					<input v-model="title"
+						:class="{missing: errorTitle}"
+						type="text"
+						:placeholder="createView ? t('tables', 'Title of the new view') : t('tables', 'New title of the view')">
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-4 space-T mandatory">
+					{{ t('tables', 'Description') }}
+				</div>
+				<div class="col-4">
+					<TableDescription :description.sync="description" />
+				</div>
 			</div>
 		</NcAppSettingsSection>
 		<!--columns & order-->
@@ -72,6 +83,7 @@ import '@nextcloud/dialogs/style.css'
 import FilterForm from '../main/partials/editViewPartials/filter/FilterForm.vue'
 import SortForm from '../main/partials/editViewPartials/sort/SortForm.vue'
 import SelectedViewColumns from '../main/partials/editViewPartials/SelectedViewColumns.vue'
+import TableDescription from '../main/sections/TableDescription.vue'
 import { MetaColumns } from '../../shared/components/ncTable/mixins/metaColumns.js'
 import permissionsMixin from '../../shared/components/ncTable/mixins/permissionsMixin.js'
 import { mapActions } from 'pinia'
@@ -88,6 +100,7 @@ export default {
 		FilterForm,
 		SelectedViewColumns,
 		SortForm,
+		TableDescription,
 	},
 	mixins: [permissionsMixin],
 	props: {
@@ -114,6 +127,7 @@ export default {
 		return {
 			open: false,
 			title: '',
+			description: '',
 			icon: '',
 			errorTitle: false,
 			selectedColumns: [],
@@ -267,6 +281,7 @@ export default {
 			const data = {
 				tableId: this.mutableView.tableId,
 				title: this.title,
+				description: this.description,
 				emoji: this.icon,
 			}
 			const res = await this.insertNewView({ data })
@@ -281,6 +296,7 @@ export default {
 			const data = {
 				data: {
 					title: this.title,
+					description: this.description,
 					emoji: this.icon,
 					columns: JSON.stringify(newSelectedColumnIds),
 				},
@@ -308,6 +324,7 @@ export default {
 			this.mutableView = JSON.parse(JSON.stringify(this.generateViewConfigData))
 			this.generatedView = JSON.parse(JSON.stringify(this.generateViewConfigData))
 			this.title = this.mutableView.title ?? ''
+			this.description = this.mutableView.description ?? ''
 			this.icon = this.mutableView.emoji ?? this.loadEmoji()
 			this.errorTitle = false
 			this.selectedColumns = this.mutableView.columns ? [...this.mutableView.columns] : null
@@ -334,6 +351,11 @@ export default {
 	width: auto;
 	flex: 1;
 	padding: calc(var(--default-grid-baseline) * 2);
+}
+
+:deep(.element-description) {
+	padding-inline: 0 !important;
+	max-width: 100%;
 }
 
 .sticky {


### PR DESCRIPTION
There is a column `description` in database and BE part is ready to store it. But for some reason its not used on FE side.

<details><summary>:mag: Preview</summary>
<p>

![image](https://github.com/user-attachments/assets/c74f566c-4a7a-4b79-99cc-9b8cc7461da2)

![image](https://github.com/user-attachments/assets/edcae119-1880-4f79-b11b-a7d4f55711b7)

</p>
</details> 