### PR TITLE
fix: set Create row modal size to match edit modal

### DIFF
--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcDialog v-if="showModal"
 		:name="t('tables', 'Create row')"
-		size="normal"
+		size="large"
 		data-cy="createRowModal"
 		@closing="actionCancel">
 		<div class="modal__content" @keydown="onKeydown">
@@ -155,8 +155,7 @@ export default {
 .modal__content {
 	padding: 20px;
 
-	.row .space-T,
-	.row.space-T {
+	:where(.row .space-T, .row.space-T) {
 		padding-top: 20px;
 	}
 
@@ -172,14 +171,13 @@ export default {
 		justify-content: end;
 	}
 
-	:where(.fix-col-1.end) {
-		display: inline-block;
-		position: relative;
-		left: 65%;
-	}
-
 	:where(.slot.fix-col-2) {
 		min-width: 50%;
+	}
+
+	:where(.fix-col-1.end) {
+		display: flex;
+		justify-content: flex-end;
 	}
 
 	:where(.fix-col-3) {


### PR DESCRIPTION
I suppose that when updating the styles of the “edit” form, they forgot about the “create” form.

**Before:**
Create row:
![image](https://github.com/user-attachments/assets/624c45fa-e449-4ed1-9543-a7eb6d8de8db)


Edit row:
![image](https://github.com/user-attachments/assets/5ef9d6e9-6e13-4a7a-bf13-ca4c9589e194)


**After:**

Create row:

![image](https://github.com/user-attachments/assets/1021b61c-3be2-432c-a3ba-56857554fd96)
