### PR TITLE
fix: fix creation failure when using creator filter

### DIFF
--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -261,6 +261,11 @@ class RowService extends SuperService {
 					continue;
 				}
 
+				// For meta columns, we don't need to add them to the data since they are handled separately
+				if (Column::isValidMetaTypeId($filter['columnId'])) {
+					continue;
+				}
+
 				// Only handle simple equality filters for now
 				if (!in_array($filter['operator'], ['is-equal'])) {
 					continue;


### PR DESCRIPTION
When create view with filter

![image](https://github.com/user-attachments/assets/40ecb227-0763-41ba-a4b0-dbb8aa4916a9)

when adding new records, I get an error

```
An internal error or exception occurred: OCA\\Tables\\Service\\RowService - create: OCA\\Tables\\Db\\Row2Mapper - insertCell: Can not insert cell, because the given column-id is not known
```

this PR fixes this bug