### PR TITLE
Avoid renovate vueuse updates above version 11 until we migrate to vue3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,15 +92,15 @@
 		},
 		{
 			"matchPackageNames": [
-				"vuex"
+				"vue-router"
 			],
 			"allowedVersions": "<4"
 		},
 		{
 			"matchPackageNames": [
-				"vue-router"
+				"vueuse"
 			],
-			"allowedVersions": "<4"
+			"allowedVersions": "<12"
 		},
 		{
 			"matchPackageNames": [


### PR DESCRIPTION
@vueuse/core versions above 12 use vue3, which we don't support yet. We keep getting auto updates that need to be closed e.g https://github.com/nextcloud/tables/pull/1693

Also remove vuex since no longer necessary now that we've switched to Pinia