### PR TITLE
Analytics: get default values for number columns

### DIFF
--- a/lib/Analytics/AnalyticsDatasource.php
+++ b/lib/Analytics/AnalyticsDatasource.php
@@ -241,6 +241,10 @@ class AnalyticsDatasource implements IDatasource {
 						}
 					}
 				}
+				// Tables does not deliver any values for "blank" default columns
+				if ($value === '' && $column->getType() === 'number') {
+					$value = $column->getNumberDefault();
+				}
 				$line[] = $value;
 			}
 			$data[] = $line;


### PR DESCRIPTION
Analytics App:
normal ->getData does not deliver any values for numbers with just default values.
the default number will be delivered in that case to the Analytics data source