### PR TITLE
fix: make it possible to use first option as default

### DIFF
--- a/src/shared/components/ncTable/partials/rowTypePartials/SelectionForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/SelectionForm.vue
@@ -44,7 +44,7 @@ export default {
 			return this.column?.selectionOptions || null
 		},
 		getDefaultId() {
-			return parseInt(this.column.selectionDefault) || null
+			return !isNaN(this.column.selectionDefault) ? parseInt(this.column.selectionDefault) : null
 		},
 		getDefaultOptionObject() {
 			return this.getOptionObject(this.getDefaultId) || null


### PR DESCRIPTION
The type of field is selection (single selection). The first option has id 0. If this value is set as the default, it will not work. My pull request fixes this. I shot a video before and after the fix.

Before:
https://github.com/user-attachments/assets/73356fef-b897-44fa-b150-7566b2ff0cb2

After:
https://github.com/user-attachments/assets/499b19e7-ccaa-4dc5-9261-c36dbc66b9d9

