### PR TITLE
Fix: computed property duplicates action on import

### DIFF
--- a/src/modules/modals/ImportPreview.vue
+++ b/src/modules/modals/ImportPreview.vue
@@ -111,7 +111,6 @@ export default {
 
 	computed: {
 		...mapState(useTablesStore, ['isView']),
-		...mapState(useDataStore, ['getColumnsFromBE']),
 		existingColumnOptions() {
 			if (!this.existingColumns.length) {
 				return []


### PR DESCRIPTION
Right now we have duplicated `getColumnsFromBE` import: in computed and in actions. Let's keep actions only