### PR TITLE
fix: Properly update usergroup cells

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -770,7 +770,9 @@ class Row2Mapper {
 		try {
 			if ($cellMapper->hasMultipleValues()) {
 				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value) {
-					$cellMapper->deleteAllForRow($rowId);
+					// For a usergroup field with mutiple values, each is inserted as a new cell
+					// we need to delete all previous cells for this row and column, otherwise we get duplicates
+					$cellMapper->deleteAllForRowAndColumn($rowId, $columnId);
 					$this->insertCell($rowId, $columnId, $value);
 				}, $this->db);
 			} else {

--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -75,6 +75,22 @@ class RowCellMapperSuper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
+	public function deleteAllForRowAndColumn(int $rowId, int $columnId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where(
+				$qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT))
+			)
+			->andWhere(
+				$qb->expr()->eq('column_id', $qb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT))
+			);
+		$qb->executeStatement();
+	}
+
+
+	/**
+	 * @throws Exception
+	 */
 	public function deleteAllForColumn(int $columnId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)


### PR DESCRIPTION
fixes #1558 
When a usergroup field has multiple values, each is saved as a separate row in the `oc_tables_row_cells_usergroup`. So, when we want to update a a field, we should delete all previous values and insert to avoid duplicates. Problem was, we were assuming that the row only has one usergroup column, so we were deleting all usergroup cells for that row. But when there are multiple usergroup columns, only the last is kept since others are deleting. Instead, we should be deleting based on the row and column, not just the row. 
