### PR TITLE
fix: avoid marking empty link fields as invalid protocol

### DIFF
--- a/src/shared/components/ncTable/mixins/rowHelper.js
+++ b/src/shared/components/ncTable/mixins/rowHelper.js
@@ -39,7 +39,10 @@ export default {
 		},
 
 		isValidUrlProtocol(value) {
-			value = JSON.parse(value ?? '{}')
+			if (!value) {
+				return true
+			}
+			value = JSON.parse(value)
 			try {
 				const parsedUrl = new URL(value?.value)
 				return ALLOWED_PROTOCOLS.includes(parsedUrl.protocol)


### PR DESCRIPTION
fixes #1761 

For an empty link field, we should return `true` when checking if the field has a valid URL protocol. Otherwise, even for non-mandatory fields, the "Save" button is not clickable if no input is provided. 
### Before (grayed out Save button, unable to save empty non-mandatory link field)
![Screenshot from 2025-04-22 18-05-14](https://github.com/user-attachments/assets/ea125835-9f88-4f0f-b289-07c11e39c7dd)


### After (able to save empty non-mandatory link field)
![image](https://github.com/user-attachments/assets/5ea8d947-85a1-4531-9467-37addc6b44ac)
