### PR TITLE
Reverse column and row order when deleting

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -767,7 +767,7 @@ class Row2Mapper {
 				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value) {
 					// For a usergroup field with mutiple values, each is inserted as a new cell
 					// we need to delete all previous cells for this row and column, otherwise we get duplicates
-					$cellMapper->deleteAllForRowAndColumn($rowId, $columnId);
+					$cellMapper->deleteAllForColumnAndRow($columnId, $rowId);
 					$this->insertCell($rowId, $columnId, $value);
 				}, $this->db);
 			} else {

--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -75,14 +75,14 @@ class RowCellMapperSuper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
-	public function deleteAllForRowAndColumn(int $rowId, int $columnId): void {
+	public function deleteAllForColumnAndRow(int $columnId, int $rowId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
 			->where(
-				$qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT))
+				$qb->expr()->eq('column_id', $qb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT))
 			)
 			->andWhere(
-				$qb->expr()->eq('column_id', $qb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT))
+				$qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT))
 			);
 		$qb->executeStatement();
 	}


### PR DESCRIPTION
Addressing @juliusknorr comment at https://github.com/nextcloud/tables/pull/1750/files#r2046431317:

> The column order may matter when using database indices