### PR TITLE
ci(config): stop updates for 0.8

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable0.8']
+        branches: ['main']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,7 @@
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
 	"baseBranches": [
-		"main",
-		"stable0.8"
+		"main"
 	],
 	"enabledManagers": [
 		"npm",


### PR DESCRIPTION
Tables 0.8 series is only relevant for NC 28 anymore. We do a last release of it at https://github.com/nextcloud/tables/pull/1773, and otherwise keep it low (i.e. disabling dependency updates and such), unless there's an issue targeting that version.