### PR TITLE
fix(l10n): Spelling mistake in 'Export CSV' DE translation

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -499,7 +499,7 @@ OC.L10N.register(
     "Go to next page" : "Zur nächsten Seite springen",
     "Go to last page" : "Zur letzten Seite springen",
     "Create Row" : "Zeile erstellen",
-    "Export CSV" : "CSV esportieren",
+    "Export CSV" : "CSV exportieren",
     "Uncheck all" : "Auswahl aufheben",
     "_%n selected row_::_%n selected rows_" : ["%n gewählte Zeile","%n gewählte Zeilen"],
     "Confirmation" : "Bestätigung",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -497,7 +497,7 @@
     "Go to next page" : "Zur nächsten Seite springen",
     "Go to last page" : "Zur letzten Seite springen",
     "Create Row" : "Zeile erstellen",
-    "Export CSV" : "CSV esportieren",
+    "Export CSV" : "CSV exportieren",
     "Uncheck all" : "Auswahl aufheben",
     "_%n selected row_::_%n selected rows_" : ["%n gewählte Zeile","%n gewählte Zeilen"],
     "Confirmation" : "Bestätigung",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -499,7 +499,7 @@ OC.L10N.register(
     "Go to next page" : "Zur nächsten Seite springen",
     "Go to last page" : "Zur letzten Seite springen",
     "Create Row" : "Zeile erstellen",
-    "Export CSV" : "CSV esportieren",
+    "Export CSV" : "CSV exportieren",
     "Uncheck all" : "Auswahl aufheben",
     "_%n selected row_::_%n selected rows_" : ["%n gewählte Zeile","%n gewählte Zeilen"],
     "Confirmation" : "Bestätigung",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -497,7 +497,7 @@
     "Go to next page" : "Zur nächsten Seite springen",
     "Go to last page" : "Zur letzten Seite springen",
     "Create Row" : "Zeile erstellen",
-    "Export CSV" : "CSV esportieren",
+    "Export CSV" : "CSV exportieren",
     "Uncheck all" : "Auswahl aufheben",
     "_%n selected row_::_%n selected rows_" : ["%n gewählte Zeile","%n gewählte Zeilen"],
     "Confirmation" : "Bestätigung",


### PR DESCRIPTION
Fixes #1790

See in dictionary: https://www.dwds.de/wb/exportieren