### PR TITLE
feat: Enhance "Contains" filter to support "selection" type

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/selection.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selection.js
@@ -54,7 +54,7 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const cellLabel = this.getLabel(cell.value)
 		const filterMethod = {
-			[FilterIds.Contains]() { return cellLabel?.includes(filterValue) },
+			[FilterIds.Contains]() { return cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
 			[FilterIds.BeginsWith]() { return cellLabel?.startsWith(filterValue) },
 			[FilterIds.EndsWith]() { return cellLabel?.endsWith(filterValue) },
 			[FilterIds.IsEqual]() { return cellLabel === filterValue },

--- a/src/shared/components/ncTable/mixins/filter.js
+++ b/src/shared/components/ncTable/mixins/filter.js
@@ -53,7 +53,7 @@ export const Filters = {
 	Contains: new Filter({
 		id: FilterIds.Contains,
 		label: t('tables', 'Contains'),
-		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup],
+		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup, ColumnTypes.Selection],
 		incompatibleWith: [FilterIds.IsEmpty, FilterIds.IsEqual],
 	}),
 	BeginsWith: new Filter({


### PR DESCRIPTION
I think this filter will improve the UX. Because now you don't have to remember the exact value.

![image](https://github.com/user-attachments/assets/3d8bca45-7dd2-4123-b60c-c9551455b5b3)
