### PR TITLE
fix(Row): find out necessary tableId for fetching the row

### DIFF
--- a/lib/Controller/RowController.php
+++ b/lib/Controller/RowController.php
@@ -65,13 +65,11 @@ class RowController extends Controller {
 	public function update(
 		int $id,
 		int $columnId,
-		?int $tableId,
 		?int $viewId,
 		string $data,
 	): DataResponse {
 		return $this->handleError(function () use (
 			$id,
-			$tableId,
 			$viewId,
 			$columnId,
 			$data


### PR DESCRIPTION
The Row service's `find()` method took an `id` parameter and used it as tableId as well as rowId. I am surprised that integration tests did not fail, as this is the only place where we use the endpoint.

I renamed the parameter for clarity and fetch the tableId now, which is needed for the permission check as well as figuring out the columns to return.