### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,19 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
 
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../../lib/base.php';
+require_once __DIR__ . '/../../../../tests/autoload.php';
 
-\OC::$loader->addValidRoot(\OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('tables');
-if (!class_exists('\PHPUnit\Framework\TestCase')) {
+Server::get(IAppManager::class)->loadApp('tables');
+
+if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
+
 OC_Hook::clear();

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -23,5 +23,3 @@ Server::get(IAppManager::class)->loadApp('tables');
 if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
-
-OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.