### PR TITLE
perf: Parallelize initial requests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,10 +54,12 @@ export default {
 	},
 	async created() {
 		const store = useTablesStore()
-		await store.loadTablesFromBE()
-		await store.getAllContexts()
-		await store.loadViewsSharedWithMeFromBE()
-		await store.loadTemplatesFromBE()
+		await Promise.all([
+			store.loadTablesFromBE(),
+			store.getAllContexts(),
+			store.loadViewsSharedWithMeFromBE(),
+			store.loadTemplatesFromBE(),
+		])
 		this.routing(this.$router.currentRoute)
 		this.observeAppContent()
 	},


### PR DESCRIPTION
Instead of calling some initial request sequentially, we parallelize the calls. As a result, we save >1 second during the initial load

### Before
![Screenshot from 2025-05-21 05-46-15](https://github.com/user-attachments/assets/2c1cdfc5-481e-4bed-a271-231e9b5d8ccd)


### After
![image](https://github.com/user-attachments/assets/85d8a3da-31e6-40aa-879d-ac61873bd83f)
