### PR TITLE
ci: unblock integration test on irrelevant changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,26 +4,51 @@ name: Integration tests
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/integration.yml'
-      - 'appinfo/**'
-      - 'lib/**'
-      - 'templates/**'
-      - 'tests/**'
-      - 'composer.json'
-      - 'composer.lock'
   push:
     branches:
       - main
       - master
       - stable*
 
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-pgsql-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   APP_NAME: tables
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/integration/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - 'composer.json'
+              - 'composer.lock'
+
   integration:
     runs-on: ubuntu-latest
+
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
 
     strategy:
       fail-fast: false
@@ -177,7 +202,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: integration
+    needs: [changes, integration]
 
     if: always()
 
@@ -185,4 +210,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.integration.result != 'success' && needs.integration.result != 'skipped' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.integration.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
Currently we have to force merge on non-PHP changes, because integration-summary does not run. This is supposed to fix it.