### PR TITLE
 Add "Internal Link" Sharing Tile with Copy-to-Clipboard

### DIFF
--- a/src/modules/sidebar/partials/ShareInternalLink.vue
+++ b/src/modules/sidebar/partials/ShareInternalLink.vue
@@ -1,29 +1,33 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
-  <div class="share-internal-link">
-    <div class="share-internal-link__icon">
-      <OpenInNew :size="20" />
-    </div>
+	<div class="share-internal-link">
+		<div class="share-internal-link__icon">
+			<OpenInNew :size="20" />
+		</div>
 
-    <div class="share-internal-link__info">
-      <span class="share-internal-link__title">
-        {{ t('tables', 'Internal link') }}
-      </span>
-      <span class="share-internal-link__subtitle">
-        {{ t('tables', 'Only works for users with access to this folder') }}
-      </span>
-    </div>
+		<div class="share-internal-link__info">
+			<span class="share-internal-link__title">
+				{{ t('tables', 'Internal link') }}
+			</span>
+			<span class="share-internal-link__subtitle">
+				{{ t('tables', 'Only works for users with access to this folder') }}
+			</span>
+		</div>
 
-    <NcButton
-      :title="copyTooltip"
-      :aria-label="copyTooltip"
-      class="share-internal-link__button"
-      @click="copyUrl"
-      variant="tertiary">
-      <template #icon>
-        <ContentCopy :size="20" />
-      </template>
-    </NcButton>
-  </div>
+		<NcButton
+			:title="copyTooltip"
+			:aria-label="copyTooltip"
+			class="share-internal-link__button"
+			variant="tertiary"
+			@click="copyUrl">
+			<template #icon>
+				<ContentCopy :size="20" />
+			</template>
+		</NcButton>
+	</div>
 </template>
 
 <script>
@@ -35,34 +39,34 @@ import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 
 export default {
-  name: 'ShareInternalLink',
+	name: 'ShareInternalLink',
 
-  components: {
-    NcButton,
-    OpenInNew,
-    ContentCopy,
-  },
+	components: {
+		NcButton,
+		OpenInNew,
+		ContentCopy,
+	},
 
-  mixins: [copyToClipboard],
+	mixins: [copyToClipboard],
 
-  props: {
-    currentUrl: {
-      type: String,
-      required: true,
-    },
-  },
+	props: {
+		currentUrl: {
+			type: String,
+			required: true,
+		},
+	},
 
-  computed: {
-    copyTooltip() {
-      return t('tables', 'Copy internal link to clipboard')
-    },
-  },
+	computed: {
+		copyTooltip() {
+			return t('tables', 'Copy internal link to clipboard')
+		},
+	},
 
-  methods: {
-    copyUrl() {
-      this.copyToClipboard(this.currentUrl, false)
-    },
-  },
+	methods: {
+		copyUrl() {
+			this.copyToClipboard(this.currentUrl, false)
+		},
+	},
 }
 </script>
 

--- a/src/modules/sidebar/partials/ShareInternalLink.vue
+++ b/src/modules/sidebar/partials/ShareInternalLink.vue
@@ -13,11 +13,16 @@
       </span>
     </div>
 
-    <NcActionButton :title="copyTooltip" :aria-label="copyTooltip" @click="copyUrl" class="share-internal-link__button">
+    <NcButton
+      :title="copyTooltip"
+      :aria-label="copyTooltip"
+      class="share-internal-link__button"
+      @click="copyUrl"
+      variant="tertiary">
       <template #icon>
         <ContentCopy :size="20" />
       </template>
-    </NcActionButton>
+    </NcButton>
   </div>
 </template>
 
@@ -25,20 +30,20 @@
 import copyToClipboard from '../../../shared/mixins/copyToClipboard.js'
 import { t } from '@nextcloud/l10n'
 
-import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import { NcButton } from '@nextcloud/vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 
 export default {
   name: 'ShareInternalLink',
 
-  mixins: [copyToClipboard],
-
   components: {
-    NcActionButton,
+    NcButton,
     OpenInNew,
     ContentCopy,
   },
+
+  mixins: [copyToClipboard],
 
   props: {
     currentUrl: {
@@ -73,8 +78,8 @@ export default {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
+    width: var(--default-clickable-area);
+    height: var(--default-clickable-area);
     background-color: var(--color-text-maxcontrast);
     border-radius: 50%;
     color: var(--color-main-background);
@@ -102,16 +107,6 @@ export default {
   &__subtitle {
     font-size: 0.85em;
     color: var(--color-text-light);
-  }
-
-  &__button {
-    margin-inline-start: auto;
-    padding: 0.25rem !important;
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 }
 </style>

--- a/src/modules/sidebar/partials/ShareInternalLink.vue
+++ b/src/modules/sidebar/partials/ShareInternalLink.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="share-internal-link">
+    <div class="share-internal-link__icon">
+      <OpenInNew :size="20" />
+    </div>
+
+    <div class="share-internal-link__info">
+      <span class="share-internal-link__title">
+        {{ t('tables', 'Internal link') }}
+      </span>
+      <span class="share-internal-link__subtitle">
+        {{ t('tables', 'Only works for users with access to this folder') }}
+      </span>
+    </div>
+
+    <NcActionButton :title="copyTooltip" :aria-label="copyTooltip" @click="copyUrl" class="share-internal-link__button">
+      <template #icon>
+        <ContentCopy :size="20" />
+      </template>
+    </NcActionButton>
+  </div>
+</template>
+
+<script>
+import copyToClipboard from '../../../shared/mixins/copyToClipboard.js'
+import { t } from '@nextcloud/l10n'
+
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+
+export default {
+  name: 'ShareInternalLink',
+
+  mixins: [copyToClipboard],
+
+  components: {
+    NcActionButton,
+    OpenInNew,
+    ContentCopy,
+  },
+
+  props: {
+    currentUrl: {
+      type: String,
+      required: true,
+    },
+  },
+
+  computed: {
+    copyTooltip() {
+      return t('tables', 'Copy internal link to clipboard')
+    },
+  },
+
+  methods: {
+    copyUrl() {
+      this.copyToClipboard(this.currentUrl, false)
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+.share-internal-link {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  gap: 12px;
+
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    background-color: var(--color-text-maxcontrast);
+    border-radius: 50%;
+    color: var(--color-main-background);
+    flex-shrink: 0;
+
+    svg {
+      fill: currentColor;
+    }
+  }
+
+  &__info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  &__title {
+    font-weight: 500;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  &__subtitle {
+    font-size: 0.85em;
+    color: var(--color-text-light);
+  }
+
+  &__button {
+    margin-inline-start: auto;
+    padding: 0.25rem !important;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+</style>

--- a/src/modules/sidebar/sections/SidebarSharing.vue
+++ b/src/modules/sidebar/sections/SidebarSharing.vue
@@ -5,6 +5,7 @@
 <template>
 	<div v-if="activeElement" class="sharing">
 		<div v-if="canShareElement(activeElement)">
+			<ShareInternalLink :currentUrl="currentUrl" />
 			<ShareForm :shares="shares" @add="addShare" @update="updateShare" />
 			<ShareList :shares="shares" @remove="removeShare" @update="updateShare" />
 		</div>
@@ -17,6 +18,7 @@ import { mapState, mapActions } from 'pinia'
 import shareAPI from '../mixins/shareAPI.js'
 import ShareForm from '../partials/ShareForm.vue'
 import ShareList from '../partials/ShareList.vue'
+import ShareInternalLink from '../partials/ShareInternalLink.vue'
 import { getCurrentUser } from '@nextcloud/auth'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 
@@ -24,6 +26,7 @@ export default {
 	components: {
 		ShareForm,
 		ShareList,
+		ShareInternalLink
 	},
 
 	mixins: [shareAPI, permissionsMixin],
@@ -38,6 +41,13 @@ export default {
 
 	computed: {
 		...mapState(useTablesStore, ['activeElement', 'isView']),
+		currentUrl() {
+			const url = this.activeElement
+				? `${window.location.origin}/index.php/apps/tables/#/table/${this.activeElement.id}`
+				: ''
+			console.log('Generated currentUrl:', url)
+			return url
+		}
 	},
 
 	watch: {

--- a/src/modules/sidebar/sections/SidebarSharing.vue
+++ b/src/modules/sidebar/sections/SidebarSharing.vue
@@ -27,7 +27,7 @@ export default {
 	components: {
 		ShareForm,
 		ShareList,
-		ShareInternalLink
+		ShareInternalLink,
 	},
 
 	mixins: [shareAPI, permissionsMixin],
@@ -46,8 +46,8 @@ export default {
 			if (!this.activeElement) {
 				return ''
 			}
-			const baseUrl = generateUrl('/apps/tables/', {}, { baseURL: window.location.origin })
-			
+			const baseUrl = generateUrl('/apps/tables/')
+
 			if (this.isView) {
 				return `${baseUrl}#/view/${this.activeElement.id}`
 			}

--- a/src/modules/sidebar/sections/SidebarSharing.vue
+++ b/src/modules/sidebar/sections/SidebarSharing.vue
@@ -5,7 +5,7 @@
 <template>
 	<div v-if="activeElement" class="sharing">
 		<div v-if="canShareElement(activeElement)">
-			<ShareInternalLink :currentUrl="currentUrl" />
+			<ShareInternalLink :current-url="currentUrl" />
 			<ShareForm :shares="shares" @add="addShare" @update="updateShare" />
 			<ShareList :shares="shares" @remove="removeShare" @update="updateShare" />
 		</div>
@@ -20,6 +20,7 @@ import ShareForm from '../partials/ShareForm.vue'
 import ShareList from '../partials/ShareList.vue'
 import ShareInternalLink from '../partials/ShareInternalLink.vue'
 import { getCurrentUser } from '@nextcloud/auth'
+import { generateUrl } from '@nextcloud/router'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 
 export default {
@@ -42,12 +43,16 @@ export default {
 	computed: {
 		...mapState(useTablesStore, ['activeElement', 'isView']),
 		currentUrl() {
-			const url = this.activeElement
-				? `${window.location.origin}/index.php/apps/tables/#/table/${this.activeElement.id}`
-				: ''
-			console.log('Generated currentUrl:', url)
-			return url
-		}
+			if (!this.activeElement) {
+				return ''
+			}
+			const baseUrl = generateUrl('/apps/tables/', {}, { baseURL: window.location.origin })
+			
+			if (this.isView) {
+				return `${baseUrl}#/view/${this.activeElement.id}`
+			}
+			return `${baseUrl}#/table/${this.activeElement.id}`
+		},
 	},
 
 	watch: {


### PR DESCRIPTION
This PR introduces a new sharing option component called "Internal Link", which allows users to copy a direct link to the currently selected table or view. This feature is useful for quickly sharing internal resources with users who already have access to the folder.

Features:
- New ShareInternalLink.vue component
- Displays an icon, title, and description for internal links
- Includes a copy-to-clipboard button using NcActionButton and ContentCopy icon
- Localized (t('tables', ...)) and translations for English and German added

![Screenshot from 2025-06-03 08-08-08](https://github.com/user-attachments/assets/469d3e78-9224-46d8-aefb-4ec2db194548)
