### PR TITLE
chore: Pin cypress version for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,8 +71,20 @@
 		{
 			"groupName": "cypress",
 			"matchPackageNames": [
-				"cypress",
-				"@nextcloud/cypress",
+				"cypress"
+			],
+			"allowedVersions": "<=13.6.4"
+		},
+		{
+			"groupName": "cypress",
+			"matchPackageNames": [
+				"@nextcloud/cypress"
+			],
+			"allowedVersions": "<=1.0.0-beta.7"
+		},
+		{
+			"groupName": "cypress",
+			"matchPackageNames": [
 				"@cypress/"
 			]
 		},


### PR DESCRIPTION
In later versions, the Cypress version crash with:
```
We detected that the Electron Renderer process just crashed.

We have failed the current spec but will continue running the next spec.

This can happen for a number of different reasons.

If you're running lots of tests on a memory intense application.
  - Try increasing the CPU/memory on the machine you're running on.
  - Try enabling experimentalMemoryManagement in your config file.
  - Try lowering numTestsKeptInMemory in your config file during 'cypress open'.
  ```
See https://github.com/nextcloud/tables/pull/1833

It's an upstream problem, so nothing we can seemingly do for now: https://github.com/cypress-io/cypress/issues/27415 . So pausing updates for now. 