### PR TITLE
refactor: streamline row and column data handling by implementing cac…

### DIFF
--- a/lib/Command/Clean.php
+++ b/lib/Command/Clean.php
@@ -178,7 +178,7 @@ class Clean extends Command {
 		$this->row->setData(array_values($data));
 
 		try {
-			$this->rowMapper->update($this->row, $this->columnService->findAllByTable($this->row->getTableId()));
+			$this->rowMapper->update($this->row);
 			$this->print('Row successfully updated', self::PRINT_LEVEL_SUCCESS);
 		} catch (InternalError|PermissionError $e) {
 			$this->print('Error while updating row to db.', self::PRINT_LEVEL_ERROR);

--- a/lib/Db/LegacyRowMapper.php
+++ b/lib/Db/LegacyRowMapper.php
@@ -425,7 +425,7 @@ class LegacyRowMapper extends QBMapper {
 	 * @throws InternalError
 	 */
 	public function transferLegacyRow(LegacyRow $legacyRow, array $columns) {
-		$this->rowMapper->insert($this->migrateLegacyRow($legacyRow, $columns), $columns);
+		$this->rowMapper->insert($this->migrateLegacyRow($legacyRow, $columns));
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces caching at the ColumnMapper level, which allowed the following improvements:

* Removed the allColumns and columns properties from Row2Mapper, which were previously passed implicitly between methods.
* Simplified the signatures of several methods.
* Made the overall mapping logic more transparent, understandable, and reliable.

These changes reduce hidden dependencies and improve code readability.