### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2703,19 +2703,19 @@
       }
     },
     "node_modules/@nextcloud/dialogs": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.3.0.tgz",
-      "integrity": "sha512-6WbWiBnGKvcj5UCG0raQhhU7fso1bNX1KEH2iN8PKTAGfxtXAD6XQ48HLuPjUtSZgrpm1azc2cAkECA18SXJaA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.3.1.tgz",
+      "integrity": "sha512-lklTssGdphRZKoR07pYU88btqguEKcQjEpKYom342i1eiMPiejgmoPZEignWJvJhpaN9CT5FoGndCrqqS3BswA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
-        "@nextcloud/auth": "^2.5.0",
+        "@nextcloud/auth": "^2.5.1",
         "@nextcloud/axios": "^2.5.1",
         "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/files": "^3.10.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/l10n": "^3.3.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "@nextcloud/typings": "^1.9.1",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4334,9 +4334,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5721,10 +5721,11 @@
       "peer": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17514,9 +17515,9 @@
       }
     },
     "node_modules/webdav/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
# Audit report

This audit fix resolves 3 of the total 11 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [brace-expansion](#user-content-brace-expansion)
* [vue-resize](#user-content-vue-resize)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: 4.2.0-beta.1 - 6.3.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### brace-expansion <a href="#user-content-brace-expansion" id="brace-expansion">#</a>
* brace-expansion Regular Expression Denial of Service vulnerability
* Severity: **low** (CVSS 3.1)
* Reference: [https://github.com/advisories/GHSA-v6h2-p8h4-qcjw](https://github.com/advisories/GHSA-v6h2-p8h4-qcjw)
* Affected versions: 1.0.0 - 1.1.11 || 2.0.0 - 2.0.1
* Package usage:
  * `node_modules/@redocly/openapi-core/node_modules/brace-expansion`
  * `node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion`
  * `node_modules/brace-expansion`
  * `node_modules/webdav/node_modules/brace-expansion`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`