### PR TITLE
chore: pin versions for config packages in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,6 +118,24 @@
 				"@vue/test-utils"
 			],
 			"allowedVersions": "<2"
+		},
+		{
+			"matchPackageNames": [
+				"@nextcloud/vite-config"
+			],
+			"allowedVersions": "<=1.5.6"
+		},
+		{
+			"matchPackageNames": [
+				"@vue/tsconfig"
+			],
+			"allowedVersions": "<=0.5.1"
+		},
+		{
+			"matchPackageNames": [
+				"typescript"
+			],
+			"allowedVersions": "<=5.3.3"
 		}
 	]
 }


### PR DESCRIPTION
Vite-related  packages updates at https://github.com/nextcloud/tables/pull/1862, https://github.com/nextcloud/tables/pull/1860 and https://github.com/nextcloud/tables/pull/1858 do not work properly. I'm pinning these versions to avoid automatic updates in the meantime.