### PR TITLE
fix: add check for column index existence before processing

### DIFF
--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -163,6 +163,10 @@ class ImportService extends SuperService {
 				$colIndex = $cellIterator->getCurrentColumnIndex() - 1;
 				$column = $this->columns[$colIndex];
 
+				if (!array_key_exists($colIndex, $this->columns)) {
+					continue;
+				}
+
 				if (
 					($column && $column->getType() === Column::TYPE_DATETIME)
 					|| (is_array($columns[$colIndex])


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d59326cc-4bd4-4820-99bc-6b2cc21a49f3)

In such a case, or when the cells are empty, there will be a "Undefined array key "