### PR TITLE
refactor: simplify Columns::findAllByTable method

### DIFF
--- a/lib/Analytics/AnalyticsDatasource.php
+++ b/lib/Analytics/AnalyticsDatasource.php
@@ -208,7 +208,7 @@ class AnalyticsDatasource implements IDatasource {
 			$rows = $this->rowService->findAllByView($nodeId, $this->userId, $limit, $offset);
 		} else {
 			// if no nodeType is provided, the old table selection is used to not break anything
-			$columns = $this->columnService->findAllByTable($nodeId, null, $this->userId);
+			$columns = $this->columnService->findAllByTable($nodeId, $this->userId);
 			$rows = $this->rowService->findAllByTable($nodeId, $this->userId, $limit, $offset);
 		}
 

--- a/lib/Api/V1Api.php
+++ b/lib/Api/V1Api.php
@@ -47,7 +47,7 @@ class V1Api {
 			$rows = $this->rowService->findAllByView($nodeId, $this->userId, $limit, $offset);
 		} else {
 			// if no nodeType is provided, the old table selection is used to not break anything
-			$columns = $this->columnService->findAllByTable($nodeId, null, $this->userId);
+			$columns = $this->columnService->findAllByTable($nodeId, $this->userId);
 			$rows = $this->rowService->findAllByTable($nodeId, $this->userId, $limit, $offset);
 		}
 

--- a/lib/Command/Clean.php
+++ b/lib/Command/Clean.php
@@ -97,7 +97,7 @@ class Clean extends Command {
 				return;
 			}
 			$tableId = $this->rowMapper->getTableIdForRow($nextRowId);
-			$columns = $this->columnService->findAllByTable($tableId, null, '');
+			$columns = $this->columnService->findAllByTable($tableId, '');
 			$this->row = $this->rowMapper->find($nextRowId, $columns);
 			$this->offset = $this->row->getId();
 		} catch (Exception $e) {

--- a/lib/Command/TransferLegacyRows.php
+++ b/lib/Command/TransferLegacyRows.php
@@ -134,7 +134,7 @@ class TransferLegacyRows extends Command {
 	 * @throws Exception
 	 */
 	private function transferTable(Table $table, OutputInterface $output): void {
-		$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+		$columns = $this->columnService->findAllByTable($table->getId(), '');
 		$output->writeln('---- Found ' . count($columns) . ' columns');
 
 		$legacyRows = $this->legacyRowMapper->findAllByTable($table->getId());
@@ -155,7 +155,7 @@ class TransferLegacyRows extends Command {
 		$output->writeln('Start deleting data for tables that should be transferred.');
 		foreach ($tables as $table) {
 			try {
-				$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+				$columns = $this->columnService->findAllByTable($table->getId(), '');
 			} catch (InternalError|PermissionError $e) {
 				$output->writeln('Could not delete data for table ' . $table->getId());
 				break;

--- a/lib/Migration/NewDbStructureRepairStep.php
+++ b/lib/Migration/NewDbStructureRepairStep.php
@@ -92,7 +92,7 @@ class NewDbStructureRepairStep implements IRepairStep {
 	 * @throws Exception
 	 */
 	private function transferTable(Table $table, IOutput $output) {
-		$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+		$columns = $this->columnService->findAllByTable($table->getId(), '');
 		$output->info('---- Found ' . count($columns) . ' columns');
 
 		$legacyRows = $this->legacyRowMapper->findAllByTable($table->getId());

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -12,6 +12,7 @@ use Exception;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
 use OCA\Tables\Db\TableMapper;
+use OCA\Tables\Db\View;
 use OCA\Tables\Dto\Column as ColumnDto;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
@@ -64,8 +65,8 @@ class ColumnService extends SuperService {
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	public function findAllByTable(int $tableId, ?int $viewId = null, ?string $userId = null): array {
-		if ($this->permissionsService->canReadColumnsByTableId($tableId, $userId) || ($viewId != null && $this->permissionsService->canReadColumnsByViewId($viewId, $userId))) {
+	public function findAllByTable(int $tableId, ?string $userId = null): array {
+		if ($this->permissionsService->canReadColumnsByTableId($tableId, $userId)) {
 			try {
 				return $this->enhanceColumns($this->mapper->findAllByTable($tableId));
 			} catch (\OCP\DB\Exception $e) {
@@ -74,6 +75,24 @@ class ColumnService extends SuperService {
 			}
 		} else {
 			throw new PermissionError('no read access to table id = ' . $tableId);
+		}
+	}
+
+	/**
+	 * @throws InternalError
+	 * @throws PermissionError
+	 * @return Column[]
+	 */
+	public function findAllByManagedView(View $view, string $userId): array {
+		if ($this->permissionsService->canManageView($view, $userId)) {
+			try {
+				return $this->enhanceColumns($this->mapper->findAllByTable($view->getTableId()));
+			} catch (\OCP\DB\Exception $e) {
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			}
+		} else {
+			throw new PermissionError('no manage access to view id = ' . $view->getId());
 		}
 	}
 
@@ -428,7 +447,7 @@ class ColumnService extends SuperService {
 		if ($viewId) {
 			$allColumns = $this->findAllByView($viewId, $userId);
 		} elseif ($tableId) {
-			$allColumns = $this->findAllByTable($tableId, null, $userId);
+			$allColumns = $this->findAllByTable($tableId, $userId);
 		} else {
 			$e = new Exception('Either tableId nor viewId is given.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -404,7 +404,7 @@ class TableService extends SuperService {
 
 		// delete all columns for that table
 		try {
-			$columns = $this->columnService->findAllByTable($id, null, $userId);
+			$columns = $this->columnService->findAllByTable($id, $userId);
 		} catch (InternalError|PermissionError $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -287,7 +287,7 @@ class ViewService extends SuperService {
 					$columnService = \OCP\Server::get(ColumnService::class);
 					$columnIds = array_column(\json_decode($value, true), 'columnId');
 
-					$availableColumns = $columnService->findAllByTable($view->getTableId(), $view->getId(), $this->userId);
+					$availableColumns = $columnService->findAllByManagedView($view, $userId);
 					$availableColumns = array_map(static fn (Column $column) => $column->getId(), $availableColumns);
 					foreach ($columnIds as $columnId) {
 						if (!Column::isValidMetaTypeId($columnId) && !in_array($columnId, $availableColumns, true)) {


### PR DESCRIPTION
- simply this method, kill a lot of `null`s in the majority of the calls
- add a destinct method to cover the edge case
- improves clarity