### PR TITLE
[stable0.8] refactor: simplify Columns::findAllByTable method

### DIFF
--- a/lib/Analytics/AnalyticsDatasource.php
+++ b/lib/Analytics/AnalyticsDatasource.php
@@ -207,7 +207,7 @@ class AnalyticsDatasource implements IDatasource {
 			$rows = $this->rowService->findAllByView($nodeId, $this->userId, $limit, $offset);
 		} else {
 			// if no nodeType is provided, the old table selection is used to not break anything
-			$columns = $this->columnService->findAllByTable($nodeId, null, $this->userId);
+			$columns = $this->columnService->findAllByTable($nodeId, $this->userId);
 			$rows = $this->rowService->findAllByTable($nodeId, $this->userId, $limit, $offset);
 		}
 

--- a/lib/Api/V1Api.php
+++ b/lib/Api/V1Api.php
@@ -46,7 +46,7 @@ class V1Api {
 			$rows = $this->rowService->findAllByView($nodeId, $this->userId, $limit, $offset);
 		} else {
 			// if no nodeType is provided, the old table selection is used to not break anything
-			$columns = $this->columnService->findAllByTable($nodeId, null, $this->userId);
+			$columns = $this->columnService->findAllByTable($nodeId, $this->userId);
 			$rows = $this->rowService->findAllByTable($nodeId, $this->userId, $limit, $offset);
 		}
 

--- a/lib/Command/Clean.php
+++ b/lib/Command/Clean.php
@@ -97,7 +97,7 @@ class Clean extends Command {
 				return;
 			}
 			$tableId = $this->rowMapper->getTableIdForRow($nextRowId);
-			$columns = $this->columnService->findAllByTable($tableId, null, '');
+			$columns = $this->columnService->findAllByTable($tableId, '');
 			$this->row = $this->rowMapper->find($nextRowId, $columns);
 			$this->offset = $this->row->getId();
 		} catch (Exception $e) {

--- a/lib/Command/TransferLegacyRows.php
+++ b/lib/Command/TransferLegacyRows.php
@@ -94,7 +94,7 @@ class TransferLegacyRows extends Command {
 				}
 			}
 		} else {
-			$output->writeln("🤷🏻‍ Add at least one table id or add the option --all to transfer all tables.");
+			$output->writeln("��‍ Add at least one table id or add the option --all to transfer all tables.");
 			return 2;
 		}
 		if ($optionDelete) {
@@ -134,7 +134,7 @@ class TransferLegacyRows extends Command {
 	 * @throws Exception
 	 */
 	private function transferTable(Table $table, OutputInterface $output): void {
-		$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+		$columns = $this->columnService->findAllByTable($table->getId(), '');
 		$output->writeln("---- Found " . count($columns) . " columns");
 
 		$legacyRows = $this->legacyRowMapper->findAllByTable($table->getId());
@@ -155,13 +155,13 @@ class TransferLegacyRows extends Command {
 		$output->writeln("Start deleting data for tables that should be transferred.");
 		foreach ($tables as $table) {
 			try {
-				$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+				$columns = $this->columnService->findAllByTable($table->getId(), '');
 			} catch (InternalError|PermissionError $e) {
 				$output->writeln("Could not delete data for table " . $table->getId());
 				break;
 			}
 			$this->rowMapper->deleteAllForTable($table->getId(), $columns);
-			$output->writeln("🗑️  Data for table " . $table->getId() . " (" . $table->getTitle() . ")" . " removed.");
+			$output->writeln("�️  Data for table " . $table->getId() . " (" . $table->getTitle() . ")" . " removed.");
 		}
 	}
 }

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -695,7 +695,21 @@ class Api1Controller extends ApiController {
 	#[CORS]
 	public function indexTableColumns(int $tableId, ?int $viewId): DataResponse {
 		try {
-			return new DataResponse($this->columnService->formatColumns($this->columnService->findAllByTable($tableId, $viewId)));
+			try {
+				// permission check in service class
+				// they might be missing legally when only the view was shared
+				$columns = $this->columnService->findAllByTable($tableId);
+			} catch (PermissionError $e) {
+				if (!$viewId) {
+					throw $e;
+				}
+				$view = $this->viewService->find($viewId, false, $this->userId);
+				if ($tableId !== $view->getTableId()) {
+					throw new PermissionError('Given table is not a parent of the given view.');
+				}
+				$columns = $this->columnService->findAllByManagedView($view, $this->userId);
+			}
+			return new DataResponse($this->columnService->formatColumns($columns));
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: '.$e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
@@ -704,6 +718,10 @@ class Api1Controller extends ApiController {
 			$this->logger->error('An internal error or exception occurred: '.$e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
 			return new DataResponse($message, Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (NotFoundError $e) {
+			$this->logger->warning('The view could not be found: ' . $e->getMessage(), ['exception' => $e]);
+			$message = ['message' => $e->getMessage()];
+			return new DataResponse($message, Http::STATUS_NOT_FOUND);
 		}
 	}
 

--- a/lib/Migration/NewDbStructureRepairStep.php
+++ b/lib/Migration/NewDbStructureRepairStep.php
@@ -92,7 +92,7 @@ class NewDbStructureRepairStep implements IRepairStep {
 	 * @throws Exception
 	 */
 	private function transferTable(Table $table, IOutput $output) {
-		$columns = $this->columnService->findAllByTable($table->getId(), null, '');
+		$columns = $this->columnService->findAllByTable($table->getId(), '');
 		$output->info("---- Found " . count($columns) . " columns");
 
 		$legacyRows = $this->legacyRowMapper->findAllByTable($table->getId());

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -435,7 +435,7 @@ class TableService extends SuperService {
 
 		// delete all columns for that table
 		try {
-			$columns = $this->columnService->findAllByTable($id, null, $userId);
+			$columns = $this->columnService->findAllByTable($id, $userId);
 		} catch (InternalError|PermissionError $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': '.$e->getMessage());

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -268,7 +268,7 @@ class ViewService extends SuperService {
 					// we have to fetch the service here as ColumnService already depends on the ViewService, i.e. no DI
 					$columnService = \OCP\Server::get(ColumnService::class);
 					$columnIds = \json_decode($value, true);
-					$availableColumns = $columnService->findAllByTable($view->getTableId(), $view->getId(), $this->userId);
+					$availableColumns = $columnService->findAllByManagedView($view, $userId);
 					$availableColumns = array_map(static fn (Column $column) => $column->getId(), $availableColumns);
 					foreach ($columnIds as $columnId) {
 						if (!Column::isValidMetaTypeId($columnId) && !in_array($columnId, $availableColumns, true)) {


### PR DESCRIPTION
- simply this method, kill a lot of `null`s in the majority of the calls
- add a destinct method to cover the edge case
- improves clarity

rebased on the workflow update for testing