### PR TITLE
feat: display percentage value above progress bar in table cell

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellProgress.vue
+++ b/src/shared/components/ncTable/partials/TableCellProgress.vue
@@ -4,6 +4,7 @@
 -->
 <template>
 	<div>
+		<div v-if="getValue !== null" class="progress-percentage">{{ Math.round(getValue) }}%</div>
 		<NcProgressBar v-if="getValue !== null" :value="getValue" />
 	</div>
 </template>
@@ -44,6 +45,13 @@ export default {
 div {
 	padding-right: 10px;
 	min-width: 12vw;
+}
+
+.progress-percentage {
+	text-align: center;
+	font-weight: 500;
+	margin-bottom: 4px;
+	color: #666;
 }
 
 </style>


### PR DESCRIPTION
## Enhancement: Show Percentage Value Above Progress Bar

### Description
This PR addresses the feature request to display the percentage value above the progress bar in the table cell. Previously, the progress bar cell did not show its value, making it unclear what the bar represented. 

### Changes
-> Updated `TableCellProgress.vue` to render the percentage value (rounded) above the progress bar.
->Added styling for the percentage value to ensure it is clear and visually distinct.


### Closes
Closes #1885 
