### PR TITLE
enh: add read-only property to view columns (backend only)

### DIFF
--- a/lib/Service/ValueObject/ViewColumnInformation.php
+++ b/lib/Service/ValueObject/ViewColumnInformation.php
@@ -17,12 +17,14 @@ use JsonSerializable;
 class ViewColumnInformation implements ArrayAccess, JsonSerializable {
 	public const KEY_ID = 'columnId';
 	public const KEY_ORDER = 'order';
+	public const KEY_READONLY = 'readonly';
 
-	/** @var array{columndId?: int, order?: int} */
+	/** @var array{columndId?: int, order?: int, readonly?: bool} */
 	protected array $data = [];
 	protected const KEYS = [
 		self::KEY_ID,
 		self::KEY_ORDER,
+		self::KEY_READONLY,
 	];
 
 	public function __construct(
@@ -31,6 +33,10 @@ class ViewColumnInformation implements ArrayAccess, JsonSerializable {
 	) {
 		$this->offsetSet(self::KEY_ID, $columnId);
 		$this->offsetSet(self::KEY_ORDER, $order);
+	}
+
+	public function getId(): int {
+		return $this->offsetGet(self::KEY_ID);
 	}
 
 	public function getOrder(): int {
@@ -57,6 +63,7 @@ class ViewColumnInformation implements ArrayAccess, JsonSerializable {
 		if (!$this->offsetExists($offset)) {
 			return;
 		}
+		$this->ensureType($offset, $value);
 		$this->data[(string)$offset] = $value;
 	}
 
@@ -69,5 +76,17 @@ class ViewColumnInformation implements ArrayAccess, JsonSerializable {
 
 	public function jsonSerialize(): array {
 		return $this->data;
+	}
+
+	protected function ensureType(string $offset, mixed &$value): void {
+		switch ($offset) {
+			case self::KEY_ID:
+			case self::KEY_ORDER:
+				$value = (int)$value;
+				break;
+			case self::KEY_READONLY:
+				$value = (bool)$value;
+				break;
+		}
 	}
 }


### PR DESCRIPTION
contributes to #1154 

Currently work in progress. 

The approach is here to to still continue with the save operation and only leave out a provided column value if it is set to read-only instead to throw an error for the whole request. 

- [ ] needs tests
- [ ] need to check for completeness