### PR TITLE
1296 infinite loading when visiting non existent application

### DIFF
--- a/cypress/e2e/entity-not-found.cy.js
+++ b/cypress/e2e/entity-not-found.cy.js
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+let localUser
+
+describe('Entity not found error handling', () => {
+	before(function() {
+		cy.createRandomUser().then(user => {
+			localUser = user
+			cy.login(localUser)
+		})
+	})
+
+	beforeEach(function() {
+		cy.login(localUser)
+
+		cy.intercept('GET', '**/tables/999', { statusCode: 404 }).as('getTable')
+		cy.intercept('GET', '**/views/999', { statusCode: 404 }).as('getView')
+		cy.intercept('GET', '**/contexts/999*', { statusCode: 404 }).as('getContext')
+
+		cy.visit('apps/tables')
+	})
+
+	it('Shows error message when Table is not found', () => {
+		cy.visit('/apps/tables/#/table/999')
+
+		cy.get('.error-container', { timeout: 10000 })
+			.should('contain.text', 'This table could not be found')
+	})
+
+	it('Shows error message when View is not found', () => {
+		cy.visit('/apps/tables/#/view/999')
+
+		cy.get('.error-container', { timeout: 10000 })
+			.should('contain.text', 'This view could not be found')
+	})
+
+	// In Cypress, a programmatic navigation (this.$router.push('/')) is triggered
+	// when an activeContextId exists but the context itself cannot be found.
+	// This causes a redirect to the start page. In contrast, Table.vue and View.vue
+	// only display an error message when a resource is not found, without redirecting.
+	// In a normal browser scenario, manually navigating to a non-existent context
+	// will also show the error message, keeping the user on the current page.
+
+	it('Redirect to startpage when Context is not found', () => {
+		cy.visit('/apps/tables/#/application/999')
+		cy.location('hash', { timeout: 10000 })
+			.should('eq', '#/')
+	})
+})

--- a/cypress/e2e/entity-not-found.cy.js
+++ b/cypress/e2e/entity-not-found.cy.js
@@ -22,30 +22,24 @@ describe('Entity not found error handling', () => {
 		cy.visit('apps/tables')
 	})
 
-	it('Shows error message when Table is not found', () => {
+	it('Shows error message when table is not found', () => {
 		cy.visit('/apps/tables/#/table/999')
 
 		cy.get('.error-container', { timeout: 10000 })
 			.should('contain.text', 'This table could not be found')
 	})
 
-	it('Shows error message when View is not found', () => {
+	it('Shows error message when view is not found', () => {
 		cy.visit('/apps/tables/#/view/999')
 
 		cy.get('.error-container', { timeout: 10000 })
 			.should('contain.text', 'This view could not be found')
 	})
 
-	// In Cypress, a programmatic navigation (this.$router.push('/')) is triggered
-	// when an activeContextId exists but the context itself cannot be found.
-	// This causes a redirect to the start page. In contrast, Table.vue and View.vue
-	// only display an error message when a resource is not found, without redirecting.
-	// In a normal browser scenario, manually navigating to a non-existent context
-	// will also show the error message, keeping the user on the current page.
-
-	it('Redirect to startpage when Context is not found', () => {
+	it('Shows error message when application is not found', () => {
 		cy.visit('/apps/tables/#/application/999')
-		cy.location('hash', { timeout: 10000 })
-			.should('eq', '#/')
+
+		cy.get('.error-container', { timeout: 10000 })
+			.should('contain.text', 'This application could not be found')
 	})
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,7 +88,8 @@ export default {
 			}
 			if (currentRoute.path.startsWith('/table/')) {
 				this.setActiveTableId(parseInt(currentRoute.params.tableId))
-				this.setPageTitle(this.activeTable.title)
+				const tableName = this.activeTable?.title || t('tables', 'Table')
+				this.setPageTitle(tableName)
 				if (!currentRoute.path.includes('/row/')) {
 					const targetElement = document.querySelector(`header .header-start .app-menu a[href="${url}"]`)
 						|| document.querySelector(`header .header-left .app-menu a[href="${url}"]`)
@@ -96,7 +97,8 @@ export default {
 				}
 			} else if (currentRoute.path.startsWith('/view/')) {
 				this.setActiveViewId(parseInt(currentRoute.params.viewId))
-				this.setPageTitle(this.activeView.title)
+				const viewName = this.activeView?.title || t('tables', 'View')
+				this.setPageTitle(viewName)
 				if (!currentRoute.path.includes('/row/')) {
 					const targetElement = document.querySelector(`header .header-start .app-menu a[href="${url}"]`)
 						|| document.querySelector(`header .header-left .app-menu a[href="${url}"]`)
@@ -105,11 +107,12 @@ export default {
 			} else if (currentRoute.path.startsWith('/application/')) {
 				const contextId = parseInt(currentRoute.params.contextId)
 				this.setActiveContextId(contextId)
-				this.setPageTitle(this.activeContext.name)
+				const contextName = this.activeContext?.name || t('tables', 'Tables')
+				this.setPageTitle(contextName)
 
 				// This breaks if there are multiple contexts with the same name or another app has the same name. We need a better way to identify the correct element.
-				const targetElement = document.querySelector(`header .header-start .app-menu [title="${this.activeContext.name}"]`)
-					|| document.querySelector(`header .header-left .app-menu [title="${this.activeContext.name}"]`)
+				const targetElement = document.querySelector(`header .header-start .app-menu [title="${contextName}"]`)
+					|| document.querySelector(`header .header-left .app-menu [title="${contextName}"]`)
 				if (targetElement) {
 					this.switchActiveMenuEntry(targetElement)
 				}
@@ -127,8 +130,8 @@ export default {
 		switchActiveMenuEntry(targetElement) {
 			targetElement = targetElement?.tagName?.toLowerCase() === 'a' ? targetElement.parentElement : targetElement
 			const currentlyActive = document.querySelector('header .header-start .app-menu li.app-menu-entry--active') || document.querySelector('header .header-left .app-menu li.app-menu-entry--active')
-			currentlyActive.classList.remove('app-menu-entry--active')
-			targetElement.classList.add('app-menu-entry--active')
+			currentlyActive?.classList.remove('app-menu-entry--active')
+			targetElement?.classList.add('app-menu-entry--active')
 		},
 		setPageTitle(title) {
 			if (this.defaultPageTitle === false) {

--- a/src/modules/main/partials/ErrorMessage.vue
+++ b/src/modules/main/partials/ErrorMessage.vue
@@ -1,5 +1,5 @@
 <!--
-  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 

--- a/src/modules/main/partials/ErrorMessage.vue
+++ b/src/modules/main/partials/ErrorMessage.vue
@@ -1,0 +1,48 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="error-container">
+		<IconTables :size="64" style="margin-bottom: 1rem;" />
+		<p>{{ message }}</p>
+	</div>
+</template>
+
+<script>
+import IconTables from '../../../shared/assets/icons/IconTables.vue'
+
+export default {
+	name: 'ErrorMessage',
+	components: { IconTables },
+	props: {
+		message: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss">
+.error-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 2rem;
+	height: 100dvh;
+	min-height: 100%;
+	color: var(--color-text);
+	opacity: 0.6;
+
+	p {
+		font-size: clamp(1.2rem, 4vw, 2rem);
+		font-weight: 600;
+		max-width: 90%;
+		word-wrap: break-word;
+	}
+}
+</style>

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -121,14 +121,12 @@ export default {
 	},
 
 	watch: {
-		// Watch for changes to active context to make page reactive
 		async activeContext() {
-			if (this.activeContextId && !this.activeContext) {
-				// context does not exists, go to startpage
-				this.$router.push('/').catch(err => err)
-			} else {
-				await this.reload()
+			if (this.errorMessage) {
+				// Already showing an error, don't redirect
+				return
 			}
+			await this.reload()
 		},
 		'context.iconName': {
 			async handler(value) {

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -171,37 +171,42 @@ export default {
 
 				if (this.context && this.context.nodes) {
 					for (const [, node] of Object.entries(this.context.nodes)) {
-						const nodeType = parseInt(node.node_type)
-						if (nodeType === NODE_TYPE_TABLE) {
-							const table = this.tables.find(table => table.id === node.node_id)
-							if (table) {
-								await this.loadColumnsFromBE({
-									view: null,
-									tableId: table.id,
-								})
-								await this.loadRowsFromBE({
-									viewId: null,
-									tableId: table.id,
-								})
-								table.key = (table.id).toString()
-								table.isView = false
-								this.contextResources.push(table)
-							}
+						try {
+							const nodeType = parseInt(node.node_type)
+							if (nodeType === NODE_TYPE_TABLE) {
+								const table = this.tables.find(table => table.id === node.node_id)
+								if (table) {
+									await this.loadColumnsFromBE({
+										view: null,
+										tableId: table.id,
+									})
+									await this.loadRowsFromBE({
+										viewId: null,
+										tableId: table.id,
+									})
+									table.key = (table.id).toString()
+									table.isView = false
+									this.contextResources.push(table)
+								}
 
-						} else if (nodeType === NODE_TYPE_VIEW) {
-							const view = this.views.find(view => view.id === node.node_id)
-							if (view) {
-								await this.loadColumnsFromBE({
-									view,
-								})
-								await this.loadRowsFromBE({
-									viewId: view.id,
-									tableId: view.tableId,
-								})
-								view.key = 'view-' + (view.id).toString()
-								view.isView = true
-								this.contextResources.push(view)
+							} else if (nodeType === NODE_TYPE_VIEW) {
+								const view = this.views.find(view => view.id === node.node_id)
+								if (view) {
+									await this.loadColumnsFromBE({
+										view,
+									})
+									await this.loadRowsFromBE({
+										viewId: view.id,
+										tableId: view.tableId,
+									})
+									view.key = 'view-' + (view.id).toString()
+									view.isView = true
+									this.contextResources.push(view)
+								}
 							}
+						} catch (err) {
+							console.error(`Failed to load resource ${node.node_id}:`, err)
+							this.errorMessage = t('tables', 'Some resources in this application could not be loaded')
 						}
 					}
 				}

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -4,12 +4,9 @@
 -->
 <template>
 	<div class="row">
-		<div v-if="loading" class="icon-loading" />
+		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
-		<div v-else-if="errorMessage" class="error-container">
-			<IconTables :size="64" style="margin-bottom: 1rem;" />
-			<p>{{ errorMessage }}</p>
-		</div>
+		<div v-else-if="loading" class="icon-loading" />
 
 		<div v-else>
 			<div class="content context">
@@ -56,13 +53,14 @@ import exportTableMixin from '../shared/components/ncTable/mixins/exportTableMix
 import svgHelper from '../shared/components/ncIconPicker/mixins/svgHelper.js'
 import { useTablesStore } from '../store/store.js'
 import { useDataStore } from '../store/data.js'
-import IconTables from '../shared/assets/icons/IconTables.vue'
+import ErrorMessage from '../modules/main/partials/ErrorMessage.vue'
+import displayError, { getNotFoundError, getGenericLoadError } from '../shared/utils/displayError.js'
 
 export default {
 	components: {
 		MainModals,
 		NcIconSvgWrapper,
-		IconTables,
+		ErrorMessage,
 		TableWrapper,
 		CustomView,
 	},
@@ -212,10 +210,10 @@ export default {
 				}
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
-					this.errorMessage = t('tables', 'This application could not be found')
+					this.errorMessage = getNotFoundError('application')
 				} else {
-					this.errorMessage = t('tables', 'An error occurred while loading the application')
-					console.error(e)
+					this.errorMessage = getGenericLoadError('application')
+					displayError(e, this.errorMessage)
 				}
 			} finally {
 				this.loading = false
@@ -264,26 +262,6 @@ export default {
 	&:deep(.row.first-row) {
 		margin-left: 20px;
 		padding-left: 0px;
-	}
-}
-
-.error-container {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	padding: 2rem;
-	height: 100dvh;
-	min-height: 100%;
-	color: var(--color-text);
-	opacity: 0.6;
-
-	p {
-		font-size: clamp(1.2rem, 4vw, 2rem);
-		font-weight: 600;
-		max-width: 90%;
-		word-wrap: break-word;
 	}
 }
 </style>

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -4,11 +4,9 @@
 -->
 <template>
 	<div class="row">
-		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
+		<div v-if="loading" class="icon-loading" />
 
-		<div v-else-if="loading" class="icon-loading" />
-
-		<div v-else>
+		<div v-else-if="activeContext">
 			<div class="content context">
 				<div class="row first-row">
 					<h1 class="context__title" data-cy="context-title">
@@ -35,9 +33,11 @@
 					</div>
 				</div>
 			</div>
-
-			<MainModals />
 		</div>
+
+		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+		<MainModals />
 	</div>
 </template>
 

--- a/src/pages/Table.vue
+++ b/src/pages/Table.vue
@@ -51,6 +51,19 @@ export default {
 				this.checkTable()
 			},
 		},
+		activeTable: {
+			handler(newVal, oldVal) {
+				if (this.activeTableId && !newVal) {
+					if (oldVal) {
+						// Table was deleted, redirect to home
+						this.$router.push({ path: '/' })
+					} else {
+						// Table did not exist from the beginning -> ErrorMessage
+						this.errorMessage = getNotFoundError('table')
+					}
+				}
+			},
+		},
 	},
 
 	methods: {
@@ -61,10 +74,12 @@ export default {
 			if (!id) return
 
 			try {
-				if (!this.activeTable) {
-					await this.loadContextTable({ id })
+				if (this.activeTableId !== id) {
+					this.setActiveTableId(parseInt(id))
 				}
-				this.setActiveTableId(parseInt(id))
+
+				await this.loadContextTable({ id })
+
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
 					this.errorMessage = getNotFoundError('table')

--- a/src/pages/Table.vue
+++ b/src/pages/Table.vue
@@ -4,16 +4,17 @@
 -->
 <template>
 	<div class="main-table-view">
-		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
-
-		<div v-else-if="!activeTable">
+		<div v-if="!activeTable && !errorMessage">
 			<div class="icon-loading" />
 		</div>
 
-		<div v-else>
+		<div v-else-if="activeTable">
 			<MainWrapper :element="activeTable" :is-view="false" />
-			<MainModals />
 		</div>
+
+		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+		<MainModals />
 	</div>
 </template>
 

--- a/src/pages/Table.vue
+++ b/src/pages/Table.vue
@@ -4,10 +4,7 @@
 -->
 <template>
 	<div class="main-table-view">
-		<div v-if="errorMessage" class="error-container">
-			<IconTables :size="64" style="margin-bottom: 1rem;" />
-			<p>{{ errorMessage }}</p>
-		</div>
+		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
 		<div v-else-if="!activeTable">
 			<div class="icon-loading" />
@@ -25,13 +22,14 @@ import { mapState, mapActions } from 'pinia'
 import { useTablesStore } from '../store/store.js'
 import MainWrapper from '../modules/main/sections/MainWrapper.vue'
 import MainModals from '../modules/modals/Modals.vue'
-import IconTables from '../shared/assets/icons/IconTables.vue'
+import ErrorMessage from '../modules/main/partials/ErrorMessage.vue'
+import displayError, { getNotFoundError, getGenericLoadError } from '../shared/utils/displayError.js'
 
 export default {
 	components: {
 		MainWrapper,
 		MainModals,
-		IconTables,
+		ErrorMessage,
 	},
 
 	data() {
@@ -62,19 +60,16 @@ export default {
 			if (!id) return
 
 			try {
-				if (!this.activeTableId) {
-					this.setActiveTableId(parseInt(id))
-				}
-
 				if (!this.activeTable) {
 					await this.loadContextTable({ id })
 				}
+				this.setActiveTableId(parseInt(id))
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
-					this.errorMessage = t('tables', 'This table could not be found')
+					this.errorMessage = getNotFoundError('table')
 				} else {
-					this.errorMessage = t('tables', 'An error occurred while loading the table')
-					console.error(e)
+					this.errorMessage = getGenericLoadError('table')
+					displayError(e, this.errorMessage)
 				}
 			}
 		},
@@ -91,26 +86,6 @@ export default {
 @page {
 	size: auto;
 	margin: 5mm;
-}
-
-.error-container {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	padding: 2rem;
-	height: 100dvh;
-	min-height: 100%;
-	color: var(--color-text);
-	opacity: 0.6;
-
-	p {
-		font-size: clamp(1.2rem, 4vw, 2rem);
-		font-weight: 600;
-		max-width: 90%;
-		word-wrap: break-word;
-	}
 }
 
 @media print {

--- a/src/pages/Table.vue
+++ b/src/pages/Table.vue
@@ -74,12 +74,8 @@ export default {
 			if (!id) return
 
 			try {
-				if (this.activeTableId !== id) {
-					this.setActiveTableId(parseInt(id))
-				}
-
 				await this.loadContextTable({ id })
-
+				this.setActiveTableId(parseInt(id))
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
 					this.errorMessage = getNotFoundError('table')

--- a/src/pages/View.vue
+++ b/src/pages/View.vue
@@ -62,12 +62,8 @@ export default {
 			if (!id) return
 
 			try {
-				if (this.activeViewId !== id) {
-					this.setActiveViewId(parseInt(id))
-				}
-				if (!this.activeView) {
-					await this.loadContextView({ id })
-				}
+				await this.loadContextView({ id })
+				this.setActiveViewId(parseInt(id))
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
 					this.errorMessage = getNotFoundError('view')

--- a/src/pages/View.vue
+++ b/src/pages/View.vue
@@ -4,22 +4,41 @@
 -->
 <template>
 	<div class="main-view-view">
-		<MainWrapper :element="activeView" :is-view="true" />
-		<MainModals />
+		<div v-if="!activeView && errorMessage" class="error-container">
+			<IconTables :size="64" style="margin-bottom: 1rem;" />
+			<p>{{ errorMessage }}</p>
+		</div>
+
+		<div v-else-if="!activeView">
+			<div class="icon-loading" />
+		</div>
+
+		<div v-else>
+			<MainWrapper :element="activeView" :is-view="true" />
+			<MainModals />
+		</div>
 	</div>
 </template>
 
 <script>
-import { mapState } from 'pinia'
+import { mapState, mapActions } from 'pinia'
 import { useTablesStore } from '../store/store.js'
 import MainWrapper from '../modules/main/sections/MainWrapper.vue'
 import MainModals from '../modules/modals/Modals.vue'
+import IconTables from '../shared/assets/icons/IconTables.vue'
 
 export default {
 
 	components: {
 		MainWrapper,
 		MainModals,
+		IconTables,
+	},
+
+	data() {
+		return {
+			errorMessage: null,
+		}
 	},
 
 	computed: {
@@ -27,10 +46,36 @@ export default {
 	},
 
 	watch: {
-		activeViewId() {
-			if (this.activeViewId && !this.activeView) {
-				// view does not exist, go to startpage
-				this.$router.push('/').catch(err => err)
+		'$route.params.viewId': {
+			immediate: true,
+			handler() {
+				this.errorMessage = null
+				this.checkView()
+			},
+		},
+	},
+
+	methods: {
+		...mapActions(useTablesStore, ['setActiveViewId', 'loadContextView']),
+		async checkView() {
+			const id = this.activeViewId || this.$route.params.viewId
+			if (!id) return
+
+			try {
+				if (!this.activeViewId) {
+					this.setActiveViewId(parseInt(id))
+				}
+
+				if (!this.activeView) {
+					await this.loadContextView({ id })
+				}
+			} catch (e) {
+				if (e.message === 'NOT_FOUND') {
+					this.errorMessage = t('tables', 'This view could not be found')
+				} else {
+					this.errorMessage = t('tables', 'An error occurred while loading the view')
+					console.error(e)
+				}
 			}
 		},
 	},
@@ -40,5 +85,25 @@ export default {
 .main-view-view {
 	width: max-content;
 	min-width: var(--app-content-width, 100%);
+
+.error-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 2rem;
+	height: 100dvh;
+	min-height: 100%;
+	color: var(--color-text);
+	opacity: 0.6;
+
+	p {
+		font-size: clamp(1.2rem, 4vw, 2rem);
+		font-weight: 600;
+		max-width: 90%;
+		word-wrap: break-word;
+	}
+}
 }
 </style>

--- a/src/pages/View.vue
+++ b/src/pages/View.vue
@@ -56,15 +56,15 @@ export default {
 
 	methods: {
 		...mapActions(useTablesStore, ['setActiveViewId', 'loadContextView']),
+
 		async checkView() {
 			const id = this.activeViewId || this.$route.params.viewId
 			if (!id) return
 
 			try {
-				if (!this.activeViewId) {
+				if (this.activeViewId !== id) {
 					this.setActiveViewId(parseInt(id))
 				}
-
 				if (!this.activeView) {
 					await this.loadContextView({ id })
 				}

--- a/src/pages/View.vue
+++ b/src/pages/View.vue
@@ -4,16 +4,17 @@
 -->
 <template>
 	<div class="main-view-view">
-		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
-
-		<div v-else-if="!activeView">
+		<div v-if="!activeView && !errorMessage">
 			<div class="icon-loading" />
 		</div>
 
-		<div v-else>
+		<div v-else-if="activeView">
 			<MainWrapper :element="activeView" :is-view="true" />
-			<MainModals />
 		</div>
+
+		<ErrorMessage v-else-if="errorMessage" :message="errorMessage" />
+
+		<MainModals />
 	</div>
 </template>
 

--- a/src/pages/View.vue
+++ b/src/pages/View.vue
@@ -4,10 +4,7 @@
 -->
 <template>
 	<div class="main-view-view">
-		<div v-if="!activeView && errorMessage" class="error-container">
-			<IconTables :size="64" style="margin-bottom: 1rem;" />
-			<p>{{ errorMessage }}</p>
-		</div>
+		<ErrorMessage v-if="errorMessage" :message="errorMessage" />
 
 		<div v-else-if="!activeView">
 			<div class="icon-loading" />
@@ -25,14 +22,15 @@ import { mapState, mapActions } from 'pinia'
 import { useTablesStore } from '../store/store.js'
 import MainWrapper from '../modules/main/sections/MainWrapper.vue'
 import MainModals from '../modules/modals/Modals.vue'
-import IconTables from '../shared/assets/icons/IconTables.vue'
+import ErrorMessage from '../modules/main/partials/ErrorMessage.vue'
+import displayError, { getNotFoundError, getGenericLoadError } from '../shared/utils/displayError.js'
 
 export default {
 
 	components: {
 		MainWrapper,
 		MainModals,
-		IconTables,
+		ErrorMessage,
 	},
 
 	data() {
@@ -71,10 +69,10 @@ export default {
 				}
 			} catch (e) {
 				if (e.message === 'NOT_FOUND') {
-					this.errorMessage = t('tables', 'This view could not be found')
+					this.errorMessage = getNotFoundError('view')
 				} else {
-					this.errorMessage = t('tables', 'An error occurred while loading the view')
-					console.error(e)
+					this.errorMessage = getGenericLoadError('view')
+					displayError(e, this.errorMessage)
 				}
 			}
 		},
@@ -85,25 +83,5 @@ export default {
 .main-view-view {
 	width: max-content;
 	min-width: var(--app-content-width, 100%);
-
-.error-container {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	text-align: center;
-	padding: 2rem;
-	height: 100dvh;
-	min-height: 100%;
-	color: var(--color-text);
-	opacity: 0.6;
-
-	p {
-		font-size: clamp(1.2rem, 4vw, 2rem);
-		font-weight: 600;
-		max-width: 90%;
-		word-wrap: break-word;
-	}
-}
 }
 </style>

--- a/src/shared/utils/displayError.js
+++ b/src/shared/utils/displayError.js
@@ -5,11 +5,11 @@
 import { showError } from '@nextcloud/dialogs'
 
 export function getNotFoundError(type) {
-	return t('tables', `This ${type} could not be found`)
+	return t('tables', 'This {type} could not be found', { type })
 }
 
 export function getGenericLoadError(type) {
-	return t('tables', `An error occurred while loading the ${type}`)
+	return t('tables', 'An error occurred while loading the {type}', { type })
 }
 
 /**

--- a/src/shared/utils/displayError.js
+++ b/src/shared/utils/displayError.js
@@ -4,6 +4,14 @@
  */
 import { showError } from '@nextcloud/dialogs'
 
+export function getNotFoundError(type) {
+	return t('tables', `This ${type} could not be found`)
+}
+
+export function getGenericLoadError(type) {
+	return t('tables', `An error occurred while loading the ${type}`)
+}
+
 /**
  * @param {Error} e error object
  * @param {string} message Error print message

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -470,8 +470,12 @@ export const useTablesStore = defineStore('store', {
 				const res = await axios.get(generateOcsUrl('/apps/tables/api/2/contexts/' + id))
 				this.setContext(res.data.ocs.data)
 			} catch (e) {
+				if (e?.response?.status === 404) {
+					throw new Error('NOT_FOUND')
+				}
 				displayError(e, t('tables', 'Could not load application.'))
 				showError(t('tables', 'Could not fetch application'))
+				throw e
 			}
 			return true
 		},
@@ -501,8 +505,12 @@ export const useTablesStore = defineStore('store', {
 				tables.push(res.data.ocs.data)
 				this.setTables([...tables])
 			} catch (e) {
+				if (e?.response?.status === 404) {
+					throw new Error('NOT_FOUND')
+				}
 				displayError(e, t('tables', 'Could not load table.'))
 				showError(t('tables', 'Could not fetch table'))
+				throw e
 			}
 			return res?.data.ocs.data
 		},
@@ -519,8 +527,12 @@ export const useTablesStore = defineStore('store', {
 				views.push(res.data)
 				this.setViews([...views])
 			} catch (e) {
+				if (e?.response?.status === 404) {
+					throw new Error('NOT_FOUND')
+				}
 				displayError(e, t('tables', 'Could not load view'))
 				showError(t('tables', 'Could not fetch view'))
+				throw e
 			}
 			return res?.data
 		},


### PR DESCRIPTION
This PR improves error handling when navigating to non-existent tables, views, or contexts in the Tables app.

Previously, accessing a non-existent resource (e.g. /view/999 or /context/999) would result in an unhandled exception (TypeError: undefined) and show only a loading spinner. This was confusing to users and cluttered the console with errors.

### Changes

- Added proper error catching in Table.vue, View.vue, and Context.vue
- Display a user-friendly error message and icon when a resource is not found (404)
- Ensured layout is visually centered and styled consistently with other apps (e.g. Deck)

<img width="1838" height="1031" alt="404_table" src="https://github.com/user-attachments/assets/8558e8a7-1a81-4927-80b4-26aa0c3880d8" />
