### PR TITLE
fix: Background of text inputs when rows are selected

### DIFF
--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -522,7 +522,7 @@ export default {
 		td {
 			text-align: left;
 			vertical-align: middle;
-			border: 1px solid var(--color-border-dark);	
+			border: 1px solid var(--color-border-dark);
 		}
 
 		tr:active, tr:hover, tr:focus, tr:hover .editor-wrapper .editor {


### PR DESCRIPTION
fixes #1983 

Now looks like this:
<img width="1893" height="915" alt="Screenshot from 2025-08-14 03-41-01" src="https://github.com/user-attachments/assets/e819eacd-5dc3-4337-865b-fd76e8336473" />
