### PR TITLE
feat(Inline editing): prevent editing read-only values

### DIFF
--- a/src/shared/components/ncTable/mixins/cellEditMixin.js
+++ b/src/shared/components/ncTable/mixins/cellEditMixin.js
@@ -47,6 +47,11 @@ export default {
 				return false
 			}
 
+			// Prevent editing for readonly columns
+			if (this.isView && this.column?.viewColumnInformation?.readonly) {
+				return false
+			}
+
 			return true
 		},
 

--- a/src/shared/components/ncTable/partials/TableCellDateTime.vue
+++ b/src/shared/components/ncTable/partials/TableCellDateTime.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-datetime">
+	<div class="cell-datetime" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" class="non-edit-mode" role="button" aria-label="Edit date/time"
 			tabindex="0"
 			@click="handleStartEditing">

--- a/src/shared/components/ncTable/partials/TableCellEditor.vue
+++ b/src/shared/components/ncTable/partials/TableCellEditor.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-editor">
+	<div class="cell-editor" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" @click="handleStartEditing">
 			<NcEditor v-if="value && value.trim()"
 				:can-edit="false"

--- a/src/shared/components/ncTable/partials/TableCellHtml.vue
+++ b/src/shared/components/ncTable/partials/TableCellHtml.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-editor tables-tiptap-wrapper">
+	<div class="cell-editor tables-tiptap-wrapper" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" @click="handleStartEditing">
 			<EditorContent :editor="editor" />
 		</div>

--- a/src/shared/components/ncTable/partials/TableCellMultiSelection.vue
+++ b/src/shared/components/ncTable/partials/TableCellMultiSelection.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-multi-selection">
+	<div class="cell-multi-selection" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" class="non-edit-mode" @click="handleStartEditing">
 			<ul>
 				<li v-for="v in getObjects()" :key="v.id">

--- a/src/shared/components/ncTable/partials/TableCellNumber.vue
+++ b/src/shared/components/ncTable/partials/TableCellNumber.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-number">
+	<div class="cell-number" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" class="number-display" @click="startEditing">
 			{{ column.numberPrefix }}{{ getValue }}{{ column.numberSuffix }}
 		</div>

--- a/src/shared/components/ncTable/partials/TableCellProgress.vue
+++ b/src/shared/components/ncTable/partials/TableCellProgress.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-progress" @click="startEditingProgress">
+	<div class="cell-progress" :style="{ opacity: !canEditCell() ? 0.6 : 1 }" @click="startEditingProgress">
 		<div v-if="!isEditing" class="progress-display">
 			<NcProgressBar :value="getValue" />
 		</div>

--- a/src/shared/components/ncTable/partials/TableCellStars.vue
+++ b/src/shared/components/ncTable/partials/TableCellStars.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-stars">
+	<div class="cell-stars" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" @click="startEditing">
 			<div class="stars-display">
 				{{ getValue }}

--- a/src/shared/components/ncTable/partials/TableCellTextLine.vue
+++ b/src/shared/components/ncTable/partials/TableCellTextLine.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-text-line">
+	<div class="cell-text-line" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" @click="startEditing">
 			{{ value || '' }}
 		</div>

--- a/src/shared/components/ncTable/partials/TableCellUsergroup.vue
+++ b/src/shared/components/ncTable/partials/TableCellUsergroup.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="cell-usergroup">
+	<div class="cell-usergroup" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
 		<div v-if="!isEditing" class="non-edit-mode" @click="handleStartEditing">
 			<div v-if="value" class="table-cell-usergroup">
 				<div v-for="item in value" :key="item.id" class="inline usergroup-entry">

--- a/src/shared/components/ncTable/partials/TableCellYesNo.vue
+++ b/src/shared/components/ncTable/partials/TableCellYesNo.vue
@@ -3,8 +3,13 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="inline-editing-container">
-		<NcCheckboxRadioSwitch v-model="localValue" :loading="localLoading" type="switch" @update:modelValue="onToggle" />
+	<div class="inline-editing-container" :class="{ 'readonly': !canEditCell() }" :style="{ opacity: !canEditCell() ? 0.6 : 1 }">
+		<NcCheckboxRadioSwitch
+			v-model="localValue"
+			:loading="localLoading"
+			:disabled="!canEditCell()"
+			type="switch"
+			@update:modelValue="onToggle" />
 	</div>
 </template>
 
@@ -41,6 +46,12 @@ export default {
 
 	methods: {
 		async onToggle() {
+			// Prevent changes if column is readonly
+			if (!this.canEditCell()) {
+				this.localValue = !this.localValue // revert the change
+				return
+			}
+
 			const response = await this.updateCellValue(this.localValue)
 			if (!response) {
 				this.localValue = !this.localValue // revert to previous value


### PR DESCRIPTION
fixes https://github.com/nextcloud/tables/issues/1980, and a follow up for https://github.com/nextcloud/tables/pull/1958. 
For inline editing in views, we prevent editing for read-only columns. 
We also gray it out:
<img width="2075" height="435" alt="Screenshot from 2025-09-07 09-02-01" src="https://github.com/user-attachments/assets/fd493abd-a2c7-4964-b48f-44fadde1e77b" />
