### PR TITLE
fix: Export JSON scheme

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -149,7 +149,7 @@ class Api1Controller extends ApiController {
 	 * returns table scheme
 	 *
 	 * @param int $tableId Table ID
-	 * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{'Content-Disposition': string, 'Content-Type': string}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return JSONResponse<Http::STATUS_OK, TablesTable, array{'Content-Disposition': string, 'Content-Type': string}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
 	 * 200: Scheme returned
 	 * 403: No permissions

--- a/openapi.json
+++ b/openapi.json
@@ -1383,10 +1383,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "object"
-                                    }
+                                    "$ref": "#/components/schemas/Table"
                                 }
                             }
                         }

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1406,9 +1406,7 @@ export interface operations {
                     readonly [name: string]: unknown;
                 };
                 content: {
-                    readonly "application/json": {
-                        readonly [key: string]: Record<string, never>;
-                    };
+                    readonly "application/json": components["schemas"]["Table"];
                 };
             };
             /** @description Current user is not logged in */


### PR DESCRIPTION
Right now, if you select the "Export" option for a table, you get the error

```
Trace
#0 /var/www/html/lib/private/AppFramework/Http/Dispatcher.php(227): OCP\AppFramework\Controller->buildResponse(Object(OCP\AppFramework\Http\DataResponse), 'xhtml+xml')
#1 /var/www/html/lib/private/AppFramework/Http/Dispatcher.php(118): OC\AppFramework\Http\Dispatcher->executeController(Object(OCA\Tables\Controller\Api1Controller), 'showScheme')
#2 /var/www/html/lib/private/AppFramework/App.php(153): OC\AppFramework\Http\Dispatcher->dispatch(Object(OCA\Tables\Controller\Api1Controller), 'showScheme')
#3 /var/www/html/lib/private/Route/Router.php(321): OC\AppFramework\App::main('OCA\Tables\Cont...', 'showScheme', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#4 /var/www/html/lib/base.php(1061): OC\Route\Router->match('/apps/tables/ap...')
#5 /var/www/html/index.php(25): OC::handleRequest()
#6 {main}
```


This fixes it. 