### PR TITLE
ci: reduce assumptions about paths on the ci host

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,7 +141,7 @@ jobs:
           cat config/config.php
           ./occ user:list
           ./occ app:enable --force ${{ env.APP_NAME }}
-          ./occ config:system:set query_log_file --value '/home/runner/work/${{ env.APP_NAME }}/${{ env.APP_NAME }}/query.log'
+          ./occ config:system:set query_log_file --value "$PWD/query.log"
           php -S localhost:8080 &
 
       - name: Run behat
@@ -155,7 +155,7 @@ jobs:
 
       - name: Query count
         if: ${{ matrix.databases == 'mysql' && matrix.php-versions == '8.2' && matrix.server-versions == 'master' && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -171,12 +171,12 @@ jobs:
                 myError += data.toString()
               }
             }
-            await exec.exec(`/bin/bash -c "cat /home/runner/work/${{ env.APP_NAME }}/${{ env.APP_NAME }}/query.log | wc -l"`, [], options)
+            await exec.exec(`/bin/bash -c "cat query.log | egrep '(DELETE|UPDATE|INSERT|SELECT)' | awk 'sub(/^[^DISU]*/, \\"\\")' | wc -l"`, [], options)
             msg = myOutput
             const queryCount = parseInt(myOutput, 10)
 
             myOutput = ''
-            await exec.exec('cat', ['/home/runner/work/${{ env.APP_NAME }}/${{ env.APP_NAME }}/apps/${{ env.APP_NAME }}/tests/integration/base-query-count.txt'], options)
+            await exec.exec('cat', ['apps/${{ env.APP_NAME }}/tests/integration/base-query-count.txt'], options)
             const baseCount = parseInt(myOutput, 10)
 
             const absoluteIncrease = queryCount - baseCount


### PR DESCRIPTION
- every now and then we see the error: cat: /home/runner/work/tables/tables/query.log: No such file or directory
- also count the query log properly, as a single query may span multiple lines