### PR TITLE
fix: Add key to pre-existing usergroup items

### DIFF
--- a/cypress/e2e/column-usergroup.cy.js
+++ b/cypress/e2e/column-usergroup.cy.js
@@ -59,6 +59,7 @@ describe('Test column ' + columnTitle, () => {
         cy.get('[data-cy="ncTable"] table tr td .user-bubble__name').contains(localUser.userId).should('be.visible')
 
         cy.get('[data-cy="ncTable"] [data-cy="editRowBtn"]').click()
+        cy.get('[data-cy="usergroupRowSelect"] .vs__deselect').click({ multiple: true })
         cy.get('[data-cy="usergroupRowSelect"] input').clear().type(nonLocalUser.userId)
         cy.get(`.vs__dropdown-menu [id="${nonLocalUser.userId}"]`).click()
         cy.get('[data-cy="editRowSaveButton"]').click()

--- a/src/shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue
@@ -69,19 +69,19 @@ export default {
 		// Doing this in data() doesn't work due to timing issues,
 		// since the data() function runs before the capabilities are fully initialized
 		this.selectCircles = this.isCirclesEnabled ? this.column.usergroupSelectTeams : false
-		
+
 		let initialValue = this.value
 		if (!initialValue || (Array.isArray(initialValue) && initialValue.length === 0)) {
 			initialValue = this.column.usergroupDefault || []
 		}
-		
+
 		const formatted = (Array.isArray(initialValue) ? initialValue : []).map(item => ({
 			...(item ?? {}),
 			// Adding a unique key such that removing items works correctly
 			key: this.getKeyPrefix(item?.type) + (item?.id ?? ''),
 		}))
 		this.internalLocalValue = formatted
-		
+
 		if (formatted.length > 0) {
 			this.$emit('update:value', formatted)
 		}


### PR DESCRIPTION
To reproduce the problem:
- Create a table and add a usergroup column with "multiple" turned on
- Add a new row with multiple users and save
- Try to remove one of the users/groups. All of the users get cleared

This happens because there's no key associated with the item. So, we therefore add keys to the pre-existing usergroup items. With keys, only the clicked item is cleared. 