### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3114,15 +3114,6 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
-    "node_modules/@nextcloud/auth/node_modules/@nextcloud/browser-storage": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
-      "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
-      "license": "GPL-3.0-or-later",
-      "engines": {
-        "node": "^24 || ^22 || ^20"
-      }
-    },
     "node_modules/@nextcloud/axios": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.2.tgz",
@@ -3154,16 +3145,12 @@
       }
     },
     "node_modules/@nextcloud/browser-storage": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
+      "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
       "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "core-js": "3.37.0"
-      },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^24 || ^22 || ^20"
       }
     },
     "node_modules/@nextcloud/browserslist-config": {
@@ -3253,15 +3240,6 @@
       "peerDependencies": {
         "@nextcloud/vue": "^8.24.0",
         "vue": "^2.7.16"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/browser-storage": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
-      "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
-      "license": "GPL-3.0-or-later",
-      "engines": {
-        "node": "^24 || ^22 || ^20"
       }
     },
     "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
@@ -3558,14 +3536,14 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.7.1.tgz",
-      "integrity": "sha512-aAqh9UA7QDZhF8PApZPgL3Q8k7T1FujI7kdo5qh/S1YYrOjL5XKv4BZ5sCFGX3Ds5h8slWfjdFGQ0X14WaHcCw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.7.2.tgz",
+      "integrity": "sha512-5KILNBVEComCyFw6OI2QKvAT5bTMo3Z0o/YN+UpAm8LC3CnuLplRl5Z4UPQZMKdQeMHZ2WXmqL+biSfM7bweJw==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@rollup/plugin-replace": "^6.0.2",
-        "@vitejs/plugin-vue2": "^2.3.3",
+        "@vitejs/plugin-vue2": "^2.3.4",
         "browserslist-to-esbuild": "^2.1.1",
         "magic-string": "^0.30.19",
         "rollup-plugin-corejs": "^1.0.1",
@@ -3584,7 +3562,7 @@
       "peerDependencies": {
         "browserslist": ">=4.0",
         "sass": ">=1.60",
-        "vite": "^7.1.7"
+        "vite": "^7.1.10"
       }
     },
     "node_modules/@nextcloud/vite-config/node_modules/spdx-expression-parse": {
@@ -3599,16 +3577,16 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.32.0.tgz",
-      "integrity": "sha512-V2ICZh7K9aVneXjmBV9p2sosYKj4Xr4Da8/Elat0u/v9GprBcRnITMipPXDBqtdf341YjRbaAkfGnpaA7M2GyA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.33.0.tgz",
+      "integrity": "sha512-OtRWrWbiR66zmBUYL89I6hB+E4OmUShwkT2Fd6wcRpbuywLtrmWxayribsmwZs75ZtaPekZij2UVzXF87qCrhQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.5.2",
+        "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
-        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
@@ -3623,7 +3601,7 @@
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.7",
+        "dompurify": "^3.3.0",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
@@ -4575,16 +4553,16 @@
       "dev": true
     },
     "node_modules/@tiptap/core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.9.0.tgz",
-      "integrity": "sha512-2f460x1yMJ2vXctrbFw6m4/uZk7g5BgsxsJCJtDDjpyasMk5f+BdJTDCb0dwewWb75U+cbdH88AF7NXtLEs6XQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.1.tgz",
+      "integrity": "sha512-YY/u+RsjLVhcUaIn+wv6vjMx8kldO7SzFFnRu0iuC+QW57VrlqUzqz5PR6CenphwJHuqGM5b3SCr4K2ZPjN8jQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.9.0"
+        "@tiptap/pm": "^3.10.1"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -4614,9 +4592,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.9.0.tgz",
-      "integrity": "sha512-lpRNzW4zh/bI8QaImrdKgeiEifk/AaKIsruZbMVW3unRPoRUq+MmeRyeVI9OofgJtO+QsuWytqGvgy5YC02U3g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.10.1.tgz",
+      "integrity": "sha512-oNRXAupEeDCeI4nkIhCYSUuT9eZeHDWXcC5fQeWDzCPv3hOcm7W4jqUGJhWWD6qhcbmUSKmsGDTLkBfNk4NT4Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4627,8 +4605,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.9.0",
-        "@tiptap/pm": "^3.9.0"
+        "@tiptap/core": "^3.10.1",
+        "@tiptap/pm": "^3.10.1"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
@@ -4711,9 +4689,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.9.0.tgz",
-      "integrity": "sha512-EU5GiVe9Q3p2Ag3JgCBCN2/iiYEtXVj42uQhZIQ2fdVySgq3ah4uet3B4As6WpuTf6PvKJPFgRbkJ1c5osMOeg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.10.1.tgz",
+      "integrity": "sha512-D5ociNnOI3OP4NxS8eKiiqjUdO7geOguK4ZhJo1CFiIXXoLyV20wqqu4fe8Hq9+4gbEyyJ55Tz/AzLiaXw/GPQ==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -4722,8 +4700,8 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.9.0",
-        "@tiptap/pm": "^3.9.0"
+        "@tiptap/core": "^3.10.1",
+        "@tiptap/pm": "^3.10.1"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
@@ -4955,9 +4933,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.9.0.tgz",
-      "integrity": "sha512-MN1gL1OZWD489a/OmwV+InyNoRY+nKMKZ2EuZGL5ouQRdi5qSTvtMCmqzBHqrDzJCDPNCaY4NWW5DiKqIiJ2Og==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.1.tgz",
+      "integrity": "sha512-LhTRI+bECLFqitWN821A7faVFVw5OitFGWn45LIIRc/1Jg3lkqsaqx3LcLN1sjXd+f/vfoeXLKSD6VJvv/B/nQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -5021,9 +4999,9 @@
       }
     },
     "node_modules/@tiptap/vue-2": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-3.9.0.tgz",
-      "integrity": "sha512-BAQZNig0VCzI6RwbwMk+EOT4uMmJl3yT2nwLoOWzJYkddHTDTV30TS6Pmq9fousx4C0Is+Pko72oUNBs4G+0Jw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-2/-/vue-2-3.10.1.tgz",
+      "integrity": "sha512-bPHF+lXqbgC8ST5wqR3+PLnU3/JVyywSNXB+txoIptYP3F4io3r7QCdnIr0HprYm7t8D2dmND4hK6IxpJ0DLEg==",
       "license": "MIT",
       "dependencies": {
         "vue-ts-types": "1.6.2"
@@ -5033,12 +5011,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.9.0",
-        "@tiptap/extension-floating-menu": "^3.9.0"
+        "@tiptap/extension-bubble-menu": "^3.10.1",
+        "@tiptap/extension-floating-menu": "^3.10.1"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.9.0",
-        "@tiptap/pm": "^3.9.0",
+        "@tiptap/core": "^3.10.1",
+        "@tiptap/pm": "^3.10.1",
         "vue": "^2.6.0"
       }
     },
@@ -7935,9 +7913,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -16446,9 +16424,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
-      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 14 vulnerabilities found in your project.

## Updated dependencies
* [vite](#user-content-vite)
## Fixed vulnerabilities

### `vite` <a href="#user-content-vite" id="vite">#</a>
* vite allows server.fs.deny bypass via backslash on Windows
* Severity: **moderate**
* Reference: [https://github.com/advisories/GHSA-93m4-6634-74q7](https://github.com/advisories/GHSA-93m4-6634-74q7)
* Affected versions: 7.1.0 - 7.1.10
* Package usage:
  * `node_modules/vite`