### PR TITLE
ci: do not force old phpunit in server`s own integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,7 +106,6 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-          cd build/integration && composer require --dev phpunit/phpunit:~9
 
       - name: Checkout app
         uses: actions/checkout@v4


### PR DESCRIPTION
Let's see whether it turns the integration tests greeen again. Not sure why we were having this in first place.