### PR TITLE
fix: Properly filter empty text values

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -539,7 +539,14 @@ class Row2Mapper {
 				break;
 			case 'is-empty':
 				$includeDefault = empty($defaultValue);
-				$filterExpression = $qb->expr()->isNull('value');
+				if ($column->getType() === Column::TYPE_TEXT) {
+					$filterExpression = $qb2->expr()->orX(
+						$qb->expr()->isNull('value'),
+						$qb->expr()->eq('value', $qb->createNamedParameter('', $paramType))
+					);
+				} else {
+					$filterExpression = $qb->expr()->isNull('value');
+				}
 				break;
 			default:
 				throw new InternalError('Operator ' . $operator . ' is not supported.');


### PR DESCRIPTION
At the moment, if you filter a text column by `is empty`, it doesn't give any rows even if there are empty unfilled rows in the table. This fixes it. 