### PR TITLE
Enhancement: Reduce logs for non-existent circles

### DIFF
--- a/lib/Helper/CircleHelper.php
+++ b/lib/Helper/CircleHelper.php
@@ -12,6 +12,7 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
 use OCP\App\IAppManager;
+use OCP\IL10N;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -29,6 +30,7 @@ class CircleHelper {
 	public function __construct(
 		private LoggerInterface $logger,
 		IAppManager $appManager,
+		private IL10N $l10n,
 	) {
 		$this->circlesEnabled = $appManager->isEnabledForUser('circles');
 		$this->circlesManager = null;
@@ -59,6 +61,10 @@ class CircleHelper {
 			$circle = $this->circlesManager->getCircle($circleId);
 			return $circle ? ($circle->getDisplayName() ?: $circleId) : $circleId;
 		} catch (Throwable $e) {
+			if ($e->getCode() === 404) {
+				return $this->l10n->t('Deleted circle %s.', [$circleId]);
+			}
+
 			$this->logger->warning('Failed to get circle display name: ' . $e->getMessage(), [
 				'circleId' => $circleId,
 				'userId' => $userId


### PR DESCRIPTION
We have really large tables and dynamic circles that can be removed. For now we suffer from logs like `Failed to get circle display name`. This PR aims to get rid of this log for non existing circles (but keep log for other errors).