### PR TITLE
fix: Prevent inline editing on Ctrl-Click for URL columns

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellLink.vue
+++ b/src/shared/components/ncTable/partials/TableCellLink.vue
@@ -212,6 +212,10 @@ export default {
 		t,
 
 		handleStartEditing(event) {
+			if (event && (event.ctrlKey || event.metaKey)) {
+				return
+			}
+
 			this.isInitialEditClick = true
 			this.startEditing()
 			if (event) {


### PR DESCRIPTION
Makes clicking links a bit easier, I'm unsure if we should also change the default behaviour and maybe add a small edit icon instead, but this makes working with URL columns a lot more convenient already