### PR TITLE
Perf: Do not recreate `Cell` entity just for formatting value

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -679,12 +679,10 @@ class Row2Mapper {
 
 			$column = $this->columnMapper->find($rowData['column_id']);
 			$columnType = $column->getType();
-			$cellClassName = 'OCA\Tables\Db\RowCell' . ucfirst($columnType);
-			$entity = call_user_func($cellClassName . '::fromRowData', $rowData); // >5.2.3
 			if (!isset($cellMapperCache[$columnType])) {
 				$cellMapperCache[$columnType] = $this->getCellMapperFromType($columnType);
 			}
-			$value = $cellMapperCache[$columnType]->formatEntity($column, $entity);
+			$value = $cellMapperCache[$columnType]->formatRowData($column, $rowData);
 			$compositeKey = (string)$rowData['row_id'] . ',' . (string)$rowData['column_id'];
 			if ($cellMapperCache[$columnType]->hasMultipleValues()) {
 				if (array_key_exists($compositeKey, $rowValues)) {

--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -27,14 +27,14 @@ class RowCellMapperSuper extends QBMapper {
 	}
 
 	/**
-	 * Format a row cell entity to API response array
+	 * Format a row cell raw value from DB to API response array
 	 *
-	 * @param T $cell
+	 * @param array<string, mixed> $row
 	 * @return TOutgoing
 	 */
-	public function formatEntity(Column $column, RowCellSuper $cell) {
+	public function formatRowData(Column $column, array $row) {
 		/** @var TOutgoing $value */
-		$value = $cell->getValue();
+		$value = $row['value'];
 		return $value;
 	}
 	/*

--- a/lib/Db/RowCellNumberMapper.php
+++ b/lib/Db/RowCellNumberMapper.php
@@ -20,17 +20,17 @@ class RowCellNumberMapper extends RowCellMapperSuper {
 		parent::__construct($db, $this->table, RowCellNumber::class);
 	}
 
-	public function formatEntity(Column $column, RowCellSuper $cell) {
-		$value = $cell->getValue();
+	public function formatRowData(Column $column, array $row) {
+		$value = $row['value'];
 		if ($value === '') {
 			return null;
 		}
 		$decimals = $column->getNumberDecimals() ?? 0;
 		if ($decimals === 0) {
 			return (int)$value;
-		} else {
-			return round(floatval($value), $decimals);
 		}
+
+		return round(floatval($value), $decimals);
 	}
 
 	public function applyDataToEntity(Column $column, RowCellSuper $cell, $data): void {

--- a/lib/Db/RowCellSelectionMapper.php
+++ b/lib/Db/RowCellSelectionMapper.php
@@ -29,8 +29,8 @@ class RowCellSelectionMapper extends RowCellMapperSuper {
 		$cell->setValue($this->valueToJsonDbValue($column, $data));
 	}
 
-	public function formatEntity(Column $column, RowCellSuper $cell) {
-		return json_decode($cell->getValue());
+	public function formatRowData(Column $column, array $row) {
+		return json_decode($row['value']);
 	}
 
 	private function valueToJsonDbValue(Column $column, $value): string {

--- a/lib/Db/RowCellSuper.php
+++ b/lib/Db/RowCellSuper.php
@@ -37,28 +37,8 @@ abstract class RowCellSuper extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * Same as Entity::fromRow but ignoring unknown properties
-	 */
-	public static function fromRowData(array $row): RowCellSuper {
-		$instance = new static();
-
-		foreach ($row as $key => $value) {
-			$property = $instance->columnToProperty($key);
-			$setter = 'set' . ucfirst($property);
-			;
-			if (property_exists($instance, $property)) {
-				$instance->$setter($value);
-			}
-		}
-
-		$instance->resetUpdatedFields();
-
-		return $instance;
-	}
-
-	/**
 	 * @param float|null|string $value
-	 * @param int $value_type
+	 * @param int $valueType
 	 */
 	public function jsonSerializePreparation(string|float|null $value, int $valueType = 0): array {
 		return [

--- a/lib/Db/RowCellUsergroupMapper.php
+++ b/lib/Db/RowCellUsergroupMapper.php
@@ -42,18 +42,20 @@ class RowCellUsergroupMapper extends RowCellMapperSuper {
 		$cell->setValueWrapper($data);
 	}
 
-	public function formatEntity(Column $column, RowCellSuper $cell) {
-		$displayName = $cell->getValue();
-		if ($cell->getValueType() === UsergroupType::USER) {
-			$displayName = $this->userManager->getDisplayName($cell->getValue()) ?? $cell->getValue();
-		} elseif ($cell->getValueType() === UsergroupType::CIRCLE) {
-			$displayName = $this->circleHelper->getCircleDisplayName($cell->getValue(), ($this->userSession->getUser()?->getUID() ?: '')) ?: $cell->getValue();
-		} elseif ($cell->getValueType() === UsergroupType::GROUP) {
-			$displayName = $this->groupHelper->getGroupDisplayName($cell->getValue()) ?: $cell->getValue();
+	public function formatRowData(Column $column, array $row) {
+		$value = $row['value'];
+		$valueType = (int)$row['value_type'];
+		$displayName = $value;
+		if ($valueType === UsergroupType::USER) {
+			$displayName = $this->userManager->getDisplayName($value) ?? $value;
+		} elseif ($valueType === UsergroupType::CIRCLE) {
+			$displayName = $this->circleHelper->getCircleDisplayName($value, ($this->userSession->getUser()?->getUID() ?: '')) ?: $value;
+		} elseif ($valueType === UsergroupType::GROUP) {
+			$displayName = $this->groupHelper->getGroupDisplayName($value) ?: $value;
 		}
 		return [
-			'id' => $cell->getValue(),
-			'type' => $cell->getValueType(),
+			'id' => $value,
+			'type' => $valueType,
 			'displayName' => $displayName,
 		];
 	}


### PR DESCRIPTION
I've found that we are creating `Cell` entity just to call few methods of it. We can avoid of doing that and speedup `/row/table/{tableId}` endpoint up to 2x. For a table with 2k rows I've got a latency decrease from 1.15s to 0.568s with my PR.

| :heavy_minus_sign: Before | :heavy_plus_sign: After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/3c87f06b-f179-452c-a4ce-707529116278" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/493c25e5-1f77-4adc-bac2-5f5c32894a8b" /> | 
