### PR TITLE
Fix: Fix import when column was adjusted in preview screen

### DIFF
--- a/lib/Dto/Column.php
+++ b/lib/Dto/Column.php
@@ -38,6 +38,11 @@ class Column {
 	}
 
 	public static function createFromArray(array $data): self {
+		$customSettings = $data['customSettings'] ?? null;
+		if (is_array($customSettings)) {
+			$customSettings = json_encode($customSettings);
+		}
+
 		return new self(
 			title: $data['title'] ?? null,
 			type: $data['type'] ?? null,
@@ -63,7 +68,7 @@ class Column {
 			usergroupSelectGroups: $data['usergroupSelectGroups'] ?? null,
 			usergroupSelectTeams: $data['usergroupSelectTeams'] ?? null,
 			showUserStatus: $data['showUserStatus'] ?? null,
-			customSettings: $data['customSettings'] ?? null,
+			customSettings: $customSettings,
 		);
 	}
 


### PR DESCRIPTION
This PR fixes a bug. Here a reproducer:

1. Create e table
2. Start import xlsx file
3. Before actual importing - adjust settings of the created column, e.g. change "single line" type to "multi line"
4. Start importing

Expected result: file imported

Actual result: there is an error

<details><summary>Details</summary>
<p>

```
Technical details

    Remote Address: 172.30.1.1
    Request ID: lu7YdLQLvAKMPV6mHYOD
    Type: Exception
    Code: 0
    Message: OCA\Tables\Dto\Column::__construct(): Argument #25 ($customSettings) must be of type ?string, array given, called in /var/www/html/apps/tables/lib/Dto/Column.php on line 46 in file '/var/www/html/apps/tables/lib/Dto/Column.php' line 11
    File: /var/www/html/lib/private/AppFramework/Http/Dispatcher.php
    Line: 150


Trace

#0 /var/www/html/lib/private/AppFramework/App.php(153): OC\AppFramework\Http\Dispatcher->dispatch(Object(OCA\Tables\Controller\ImportController), 'importUploadInT...')
#1 /var/www/html/lib/private/Route/Router.php(321): OC\AppFramework\App::main('OCA\\Tables\\Cont...', 'importUploadInT...', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#2 /var/www/html/lib/base.php(1061): OC\Route\Router->match('/apps/tables/im...')
#3 /var/www/html/index.php(25): OC::handleRequest()
#4 {main}


Previous

#0 /var/www/html/apps/tables/lib/Dto/Column.php(46): OCA\Tables\Dto\Column->__construct('Notes', 'text', 'long', false, 'This column was...', '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, Array)
#1 /var/www/html/apps/tables/lib/Service/ImportService.php(584): OCA\Tables\Dto\Column::createFromArray(Array)
#2 /var/www/html/apps/tables/lib/Service/ImportService.php(356): OCA\Tables\Service\ImportService->getColumns(Object(OCA\Tables\Vendor\PhpOffice\PhpSpreadsheet\Worksheet\Row), Object(OCA\Tables\Vendor\PhpOffice\PhpSpreadsheet\Worksheet\Row))
#3 /var/www/html/apps/tables/lib/Service/ImportService.php(315): OCA\Tables\Service\ImportService->loop(Object(OCA\Tables\Vendor\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet))
#4 /var/www/html/apps/tables/lib/Controller/ImportController.php(118): OCA\Tables\Service\ImportService->import(36, NULL, '/tmp/php4PehuD', true, Array)
#5 /var/www/html/apps/tables/lib/Controller/Errors.php(23): OCA\Tables\Controller\ImportController->OCA\Tables\Controller\{closure}()
#6 /var/www/html/apps/tables/lib/Controller/ImportController.php(116): OCA\Tables\Controller\ImportController->handleError(Object(Closure))
#7 /var/www/html/lib/private/AppFramework/Http/Dispatcher.php(204): OCA\Tables\Controller\ImportController->importUploadInTable(36, true, '[{"titleRaw":"F...')
#8 /var/www/html/lib/private/AppFramework/Http/Dispatcher.php(118): OC\AppFramework\Http\Dispatcher->executeController(Object(OCA\Tables\Controller\ImportController), 'importUploadInT...')
#9 /var/www/html/lib/private/AppFramework/App.php(153): OC\AppFramework\Http\Dispatcher->dispatch(Object(OCA\Tables\Controller\ImportController), 'importUploadInT...')
#10 /var/www/html/lib/private/Route/Router.php(321): OC\AppFramework\App::main('OCA\\Tables\\Cont...', 'importUploadInT...', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#11 /var/www/html/lib/base.php(1061): OC\Route\Router->match('/apps/tables/im...')
#12 /var/www/html/index.php(25): OC::handleRequest()
#13 {main}
```

</p>
</details> 

This happens because FE send to BE `"customSettings": {},` for adjusted columns