### PR TITLE
Fix: Properly handle an exception threw by `find` method

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -353,7 +353,11 @@ class Row2Mapper {
 		$filterExpressions = [];
 		foreach ($filterGroup as $filter) {
 			$columnId = $filter['columnId'];
-			$column = $columnId > 0 ? $this->columnMapper->find($columnId) : null;
+			try {
+				$column = $columnId > 0 ? $this->columnMapper->find($columnId) : null;
+			} catch (DoesNotExistException) {
+				$column = null;
+			}
 			// Fail if the filter is for a column that is not in the list and no meta column
 			if ($column === null && $columnId > 0) {
 				throw new InternalError('No column found to build filter with for id ' . $columnId);


### PR DESCRIPTION
`ColumnMapper::find()` not returns `null` but can throw an `DoesNotExistException`. Let's adjust code to properly handle this scenario.

To be consistent with [`addSortQueryForMultipleSleeveFinder`](https://github.com/nextcloud/tables/blob/main/lib/Db/Row2Mapper.php#L283) or other methods.