### PR TITLE
Perf: Optimize performance of the get rows endpoints

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Share your tables and views with users and groups within your cloud.
 Have a good time and manage whatever you want.
 
 ]]></description>
-	<version>2.2.1</version>
+	<version>2.3.0-dev.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author>Nextcloud GmbH and Nextcloud contributors</author>
 	<namespace>Tables</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Share your tables and views with users and groups within your cloud.
 Have a good time and manage whatever you want.
 
 ]]></description>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author>Nextcloud GmbH and Nextcloud contributors</author>
 	<namespace>Tables</namespace>
@@ -58,6 +58,7 @@ Have a good time and manage whatever you want.
 		<post-migration>
 			<step>OCA\Tables\Migration\NewDbStructureRepairStep</step>
 			<step>OCA\Tables\Migration\DbRowSleeveSequence</step>
+			<step>OCA\Tables\Migration\CacheSleeveCells</step>
 		</post-migration>
 	</repair-steps>
 	<commands>

--- a/lib/Db/ColumnMapper.php
+++ b/lib/Db/ColumnMapper.php
@@ -91,7 +91,7 @@ class ColumnMapper extends QBMapper {
 
 	/**
 	 * @param integer $tableId
-	 * @return array
+	 * @return Column[]
 	 * @throws Exception
 	 */
 	public function findAllByTable(int $tableId): array {
@@ -116,7 +116,7 @@ class ColumnMapper extends QBMapper {
 
 	/**
 	 * @param integer $tableID
-	 * @return array
+	 * @return int[]
 	 * @throws Exception
 	 */
 	public function findAllIdsByTable(int $tableID): array {

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -28,9 +28,9 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class Row2Mapper {
-	use TTransactional;
-
 	private const DB_CHUNK_SIZE = 1_000;
+
+	use TTransactional;
 
 	private RowSleeveMapper $rowSleeveMapper;
 	private ?string $userId;
@@ -124,10 +124,6 @@ class Row2Mapper {
 		return $rowSleeve->getTableId();
 	}
 
-	public function setUserId(string $userId): void {
-		$this->userId = $userId;
-	}
-
 	/**
 	 * @return int[]
 	 * @throws InternalError
@@ -203,14 +199,27 @@ class Row2Mapper {
 			return [];
 		}
 
-		$allRows = [];
-		foreach (array_chunk($rowIds, self::DB_CHUNK_SIZE) as $rowIdChunk) {
-			$allRows[] = $this->getRowsChunk($rowIdChunk, $columnIds);
+		$columnTypesCount = count($this->columnsHelper->columns);
+		if ($columnTypesCount === 0) {
+			return [];
 		}
-		return array_merge(...$allRows);
+
+		$columnsCount = count($columnIds);
+		$maxParamsPerType = floor(self::DB_CHUNK_SIZE / $columnTypesCount) ;
+		$calculatedChunkSize = (int)($maxParamsPerType - $columnsCount);
+		$chunkSize = max(1, $calculatedChunkSize);
+
+		$rowIdChunks = array_chunk($rowIds, $chunkSize);
+		$chunks = [];
+		foreach ($rowIdChunks as $chunkedRowIds) {
+			$chunks[] = $this->getRowsChunk($chunkedRowIds, $columnIds);
+		}
+
+		return array_merge(...$chunks);
 	}
 
 	/**
+	 * Builds and executes the UNION ALL query for a specific chunk of rows.
 	 * @param array $rowIds
 	 * @param array $columnIds
 	 * @return Row2[]

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -10,6 +10,8 @@ namespace OCA\Tables\Db;
 use DateTime;
 use DateTimeImmutable;
 use OCA\Tables\Constants\UsergroupType;
+use OCA\Tables\Db\RowLoader\CachedRowLoader;
+use OCA\Tables\Db\RowLoader\NormalizedRowLoader;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Helper\ColumnsHelper;
@@ -18,18 +20,12 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\Exception;
-use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\Server;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
 class Row2Mapper {
-	private const DB_CHUNK_SIZE = 1_000;
-
 	use TTransactional;
 
 	private RowSleeveMapper $rowSleeveMapper;
@@ -40,8 +36,15 @@ class Row2Mapper {
 	protected ColumnMapper $columnMapper;
 
 	private ColumnsHelper $columnsHelper;
+	/**
+	 * @var array<RowLoader\RowLoader::LOADER_*, RowLoader\RowLoader>
+	 */
+	private array $rowLoaders;
 
-	public function __construct(?string $userId, IDBConnection $db, LoggerInterface $logger, UserHelper $userHelper, RowSleeveMapper $rowSleeveMapper, ColumnsHelper $columnsHelper, ColumnMapper $columnMapper) {
+	public function __construct(?string $userId, IDBConnection $db, LoggerInterface $logger, UserHelper $userHelper, RowSleeveMapper $rowSleeveMapper, ColumnsHelper $columnsHelper, ColumnMapper $columnMapper,
+		NormalizedRowLoader $normalizedRowLoader,
+		CachedRowLoader $cachedRowLoader,
+	) {
 		$this->rowSleeveMapper = $rowSleeveMapper;
 		$this->userId = $userId;
 		$this->db = $db;
@@ -49,6 +52,10 @@ class Row2Mapper {
 		$this->userHelper = $userHelper;
 		$this->columnsHelper = $columnsHelper;
 		$this->columnMapper = $columnMapper;
+		$this->rowLoaders = [
+			RowLoader\RowLoader::LOADER_NORMALIZED => $normalizedRowLoader,
+			RowLoader\RowLoader::LOADER_CACHED => $cachedRowLoader,
+		];
 	}
 
 	/**
@@ -60,7 +67,7 @@ class Row2Mapper {
 		$this->db->beginTransaction();
 		try {
 			foreach ($this->columnsHelper->columns as $columnType) {
-				$this->getCellMapperFromType($columnType)->deleteAllForRow($row->getId());
+				$this->columnsHelper->getCellMapperFromType($columnType)->deleteAllForRow($row->getId());
 			}
 			$this->rowSleeveMapper->deleteById($row->getId());
 			$this->db->commit();
@@ -124,6 +131,10 @@ class Row2Mapper {
 		return $rowSleeve->getTableId();
 	}
 
+	public function setUserId(string $userId): void {
+		$this->userId = $userId;
+	}
+
 	/**
 	 * @return int[]
 	 * @throws InternalError
@@ -178,7 +189,7 @@ class Row2Mapper {
 			$wantedRowIdsArray = $this->getWantedRowIds($userId, $tableId, $filter, $sort, $limit, $offset);
 
 			// Get rows without SQL sorting
-			$rows = $this->getRows($wantedRowIdsArray, $showColumnIds);
+			$rows = $this->getRows($wantedRowIdsArray, $showColumnIds, RowLoader\RowLoader::LOADER_CACHED);
 
 			// Sort rows in PHP to preserve the order from getWantedRowIds
 			return $this->sortRowsByIds($rows, $wantedRowIdsArray);
@@ -191,92 +202,26 @@ class Row2Mapper {
 	/**
 	 * @param array $rowIds
 	 * @param array $columnIds
+	 * @param RowLoader\RowLoader::LOADER_* $loader
 	 * @return Row2[]
 	 * @throws InternalError
 	 */
-	private function getRows(array $rowIds, array $columnIds): array {
+	private function getRows(array $rowIds, array $columnIds, string $loader = RowLoader\RowLoader::LOADER_NORMALIZED): array {
 		if (empty($rowIds) || empty($columnIds)) {
 			return [];
 		}
 
-		$columnTypesCount = count($this->columnsHelper->columns);
-		if ($columnTypesCount === 0) {
-			return [];
+		$columns = $mappers = [];
+		foreach ($columnIds as $columnId) {
+			$columns[$columnId] = $this->columnMapper->find($columnId);
+			$mappers[$columnId] = $this->getCellMapper($columns[$columnId]);
 		}
 
-		$columnsCount = count($columnIds);
-		$maxParamsPerType = floor(self::DB_CHUNK_SIZE / $columnTypesCount) ;
-		$calculatedChunkSize = (int)($maxParamsPerType - $columnsCount);
-		$chunkSize = max(1, $calculatedChunkSize);
-
-		$rowIdChunks = array_chunk($rowIds, $chunkSize);
-		$chunks = [];
-		foreach ($rowIdChunks as $chunkedRowIds) {
-			$chunks[] = $this->getRowsChunk($chunkedRowIds, $columnIds);
+		$rows = [];
+		foreach ($this->rowLoaders[$loader]->getRows($rowIds, $columns, $mappers) as $row) {
+			$rows[] = $row;
 		}
-
-		return array_merge(...$chunks);
-	}
-
-	/**
-	 * Builds and executes the UNION ALL query for a specific chunk of rows.
-	 * @param array $rowIds
-	 * @param array $columnIds
-	 * @return Row2[]
-	 * @throws InternalError
-	 */
-	private function getRowsChunk(array $rowIds, array $columnIds): array {
-		$qb = $this->db->getQueryBuilder();
-
-		$qbSqlForColumnTypes = null;
-		foreach ($this->columnsHelper->columns as $columnType) {
-			$qbTmp = $this->db->getQueryBuilder();
-			$qbTmp->select('row_id', 'column_id', 'last_edit_at', 'last_edit_by')
-				->selectAlias($qb->expr()->castColumn('value', IQueryBuilder::PARAM_STR), 'value');
-
-			// This is not ideal but I cannot think of a good way to abstract this away into the mapper right now
-			// Ideally we dynamically construct this query depending on what additional selects the column type requires
-			// however the union requires us to match the exact number of selects for each column type
-			if ($columnType === Column::TYPE_USERGROUP) {
-				$qbTmp->selectAlias($qb->expr()->castColumn('value_type', IQueryBuilder::PARAM_STR), 'value_type');
-			} else {
-				$qbTmp->selectAlias($qbTmp->createFunction('NULL'), 'value_type');
-			}
-
-			$qbTmp
-				->from('tables_row_cells_' . $columnType)
-				->where($qb->expr()->in('column_id', $qb->createNamedParameter($columnIds, IQueryBuilder::PARAM_INT_ARRAY, ':columnIds')))
-				->andWhere($qb->expr()->in('row_id', $qb->createNamedParameter($rowIds, IQueryBuilder::PARAM_INT_ARRAY, ':rowsIds')));
-
-			if ($qbSqlForColumnTypes) {
-				$qbSqlForColumnTypes .= ' UNION ALL ' . $qbTmp->getSQL() . ' ';
-			} else {
-				$qbSqlForColumnTypes = '(' . $qbTmp->getSQL();
-			}
-		}
-		$qbSqlForColumnTypes .= ')';
-
-		$qb->select('row_id', 'column_id', 'created_by', 'created_at', 't1.last_edit_by', 't1.last_edit_at', 'value', 'table_id')
-			// Also should be more generic (see above)
-			->addSelect('value_type')
-			->from($qb->createFunction($qbSqlForColumnTypes), 't1')
-			->innerJoin('t1', 'tables_row_sleeves', 'rs', 'rs.id = t1.row_id');
-
-		try {
-			$result = $qb->executeQuery();
-		} catch (Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
-		}
-
-		try {
-			$sleeves = $this->rowSleeveMapper->findMultiple($rowIds);
-		} catch (Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
-		}
-
-		return $this->parseEntities($result, $sleeves);
+		return $rows;
 	}
 
 	/**
@@ -666,61 +611,6 @@ class Row2Mapper {
 	}
 
 	/**
-	 * @param IResult $result
-	 * @param RowSleeve[] $sleeves
-	 * @return Row2[]
-	 * @throws InternalError
-	 */
-	private function parseEntities(IResult $result, array $sleeves): array {
-		$rows = [];
-		foreach ($sleeves as $sleeve) {
-			$rows[$sleeve->getId()] = new Row2();
-			$rows[$sleeve->getId()]->setId($sleeve->getId());
-			$rows[$sleeve->getId()]->setCreatedBy($sleeve->getCreatedBy());
-			$rows[$sleeve->getId()]->setCreatedAt($sleeve->getCreatedAt());
-			$rows[$sleeve->getId()]->setLastEditBy($sleeve->getLastEditBy());
-			$rows[$sleeve->getId()]->setLastEditAt($sleeve->getLastEditAt());
-			$rows[$sleeve->getId()]->setTableId($sleeve->getTableId());
-		}
-
-		$rowValues = [];
-		$keyToColumnId = [];
-		$keyToRowId = [];
-		$cellMapperCache = [];
-
-		while ($rowData = $result->fetch()) {
-			if (!isset($rowData['row_id'], $rows[$rowData['row_id']])) {
-				break;
-			}
-
-			$column = $this->columnMapper->find($rowData['column_id']);
-			$columnType = $column->getType();
-			if (!isset($cellMapperCache[$columnType])) {
-				$cellMapperCache[$columnType] = $this->getCellMapperFromType($columnType);
-			}
-			$value = $cellMapperCache[$columnType]->formatRowData($column, $rowData);
-			$compositeKey = (string)$rowData['row_id'] . ',' . (string)$rowData['column_id'];
-			if ($cellMapperCache[$columnType]->hasMultipleValues()) {
-				if (array_key_exists($compositeKey, $rowValues)) {
-					$rowValues[$compositeKey][] = $value;
-				} else {
-					$rowValues[$compositeKey] = [$value];
-				}
-			} else {
-				$rowValues[$compositeKey] = $value;
-			}
-			$keyToColumnId[$compositeKey] = $rowData['column_id'];
-			$keyToRowId[$compositeKey] = $rowData['row_id'];
-		}
-
-		foreach ($rowValues as $compositeKey => $value) {
-			$rows[$keyToRowId[$compositeKey]]->addCell($keyToColumnId[$compositeKey], $value);
-		}
-
-		return array_values($rows);
-	}
-
-	/**
 	 * @throws InternalError
 	 */
 	public function isRowInViewPresent(int $rowId, View $view, string $userId): bool {
@@ -748,9 +638,12 @@ class Row2Mapper {
 		}
 
 		// write all cells to its db-table
+		$cachedCells = [];
 		foreach ($row->getData() as $cell) {
-			$this->insertCell($rowSleeve->getId(), $cell['columnId'], $cell['value'], $rowSleeve->getLastEditAt(), $rowSleeve->getLastEditBy());
+			$cachedCells[$cell['columnId']] = $this->insertCell($rowSleeve->getId(), $cell['columnId'], $cell['value'], $rowSleeve->getLastEditAt(), $rowSleeve->getLastEditBy());
 		}
+		$rowSleeve->setCachedCellsArray($cachedCells);
+		$this->rowSleeveMapper->update($rowSleeve);
 
 		return $row;
 	}
@@ -784,9 +677,12 @@ class Row2Mapper {
 		$this->columnMapper->preloadColumns(array_column($changedCells, 'columnId'));
 
 		// write all changed cells to its db-table
+		$cachedCells = $sleeve->getCachedCellsArray();
 		foreach ($changedCells as $cell) {
-			$this->insertOrUpdateCell($sleeve->getId(), $cell['columnId'], $cell['value']);
+			$cachedCells[$cell['columnId']] = $this->insertOrUpdateCell($sleeve->getId(), $cell['columnId'], $cell['value']);
 		}
+		$sleeve->setCachedCellsArray($cachedCells);
+		$this->rowSleeveMapper->update($sleeve);
 
 		return $row;
 	}
@@ -838,9 +734,11 @@ class Row2Mapper {
 	/**
 	 * Insert a cell to its specific db-table
 	 *
+	 * @return array<string, mixed> normalized cell data
+	 *
 	 * @throws InternalError
 	 */
-	private function insertCell(int $rowId, int $columnId, $value, ?string $lastEditAt = null, ?string $lastEditBy = null): void {
+	private function insertCell(int $rowId, int $columnId, $value, ?string $lastEditAt = null, ?string $lastEditBy = null): array {
 		try {
 			$column = $this->columnMapper->find($columnId);
 		} catch (DoesNotExistException $e) {
@@ -850,7 +748,7 @@ class Row2Mapper {
 
 		// insert new cell
 		$cellMapper = $this->getCellMapper($column);
-
+		$cachedCell = [];
 		try {
 			$cellClassName = 'OCA\Tables\Db\RowCell' . ucfirst($column->getType());
 			if ($cellMapper->hasMultipleValues()) {
@@ -862,6 +760,7 @@ class Row2Mapper {
 					$this->updateMetaData($cell, false, $lastEditAt, $lastEditBy);
 					$cellMapper->applyDataToEntity($column, $cell, $val);
 					$cellMapper->insert($cell);
+					$cachedCell[] = $cellMapper->toArray($cell);
 				}
 			} else {
 				/** @var RowCellSuper $cell */
@@ -871,11 +770,14 @@ class Row2Mapper {
 				$this->updateMetaData($cell, false, $lastEditAt, $lastEditBy);
 				$cellMapper->applyDataToEntity($column, $cell, $value);
 				$cellMapper->insert($cell);
+				$cachedCell = $cellMapper->toArray($cell);
 			}
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError('Failed to insert column: ' . $e->getMessage(), 0, $e);
 		}
+
+		return $cachedCell;
 	}
 
 	/**
@@ -883,53 +785,51 @@ class Row2Mapper {
 	 * @param RowCellMapperSuper $mapper
 	 * @param mixed $value the value should be parsed to the correct format within the row service
 	 * @param Column $column
+	 *
+	 * @return array<string, mixed> normalized cell data
 	 * @throws InternalError
 	 */
-	private function updateCell(RowCellSuper $cell, RowCellMapperSuper $mapper, $value, Column $column): void {
-		$this->getCellMapper($column)->applyDataToEntity($column, $cell, $value);
+	private function updateCell(RowCellSuper $cell, RowCellMapperSuper $mapper, $value, Column $column): array {
+		$cellMapper = $this->getCellMapper($column);
+		$cellMapper->applyDataToEntity($column, $cell, $value);
 		$this->updateMetaData($cell);
 		$mapper->updateWrapper($cell);
+
+		return $cellMapper->toArray($cell);
 	}
 
 	/**
+	 * @return array<string, mixed> normalized cell data
 	 * @throws InternalError
 	 */
-	private function insertOrUpdateCell(int $rowId, int $columnId, $value): void {
+	private function insertOrUpdateCell(int $rowId, int $columnId, $value): array {
 		$column = $this->columnMapper->find($columnId);
 		$cellMapper = $this->getCellMapper($column);
+		$cachedCell = [];
 		try {
 			if ($cellMapper->hasMultipleValues()) {
-				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value) {
+				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value, &$cachedCell) {
 					// For a usergroup field with mutiple values, each is inserted as a new cell
 					// we need to delete all previous cells for this row and column, otherwise we get duplicates
 					$cellMapper->deleteAllForColumnAndRow($columnId, $rowId);
-					$this->insertCell($rowId, $columnId, $value);
+					$cachedCell = $this->insertCell($rowId, $columnId, $value);
 				}, $this->db);
 			} else {
 				$cell = $cellMapper->findByRowAndColumn($rowId, $columnId);
-				$this->updateCell($cell, $cellMapper, $value, $column);
+				$cachedCell = $this->updateCell($cell, $cellMapper, $value, $column);
 			}
 		} catch (DoesNotExistException) {
-			$this->insertCell($rowId, $columnId, $value);
+			$cachedCell = $this->insertCell($rowId, $columnId, $value);
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), $e->getCode(), $e);
 		}
+
+		return $cachedCell;
 	}
 
 	private function getCellMapper(Column $column): RowCellMapperSuper {
-		return $this->getCellMapperFromType($column->getType());
-	}
-
-	private function getCellMapperFromType(string $columnType): RowCellMapperSuper {
-		$cellMapperClassName = 'OCA\Tables\Db\RowCell' . ucfirst($columnType) . 'Mapper';
-		/** @var RowCellMapperSuper $cellMapper */
-		try {
-			return Server::get($cellMapperClassName);
-		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
-		}
+		return $this->columnsHelper->getCellMapperFromType($column->getType());
 	}
 
 	/**

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -668,7 +668,6 @@ class Row2Mapper {
 		try {
 			$sleeve = $this->rowSleeveMapper->find($row->getId());
 			$this->updateMetaData($sleeve);
-			$this->rowSleeveMapper->update($sleeve);
 		} catch (DoesNotExistException|MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());

--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -49,6 +49,10 @@ class RowCellMapperSuper extends QBMapper {
 		$cell->setValue($data);
 	}
 
+	public function toArray(RowCellSuper $cell): array {
+		return ['value' => $cell->getValue()];
+	}
+
 	public function getDbParamType() {
 		return IQueryBuilder::PARAM_STR;
 	}
@@ -111,6 +115,21 @@ class RowCellMapperSuper extends QBMapper {
 			->where($qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('column_id', $qb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT)));
 		return $this->findEntity($qb);
+	}
+
+	/**
+	 * @throws MultipleObjectsReturnedException
+	 * @throws DoesNotExistException
+	 * @throws Exception
+	 * @return RowCellSuper[]
+	 */
+	public function findManyByRowAndColumn(int $rowId, int $columnId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->tableName)
+			->where($qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('column_id', $qb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT)));
+		return $this->findEntities($qb);
 	}
 
 	/**

--- a/lib/Db/RowCellMapperSuper.php
+++ b/lib/Db/RowCellMapperSuper.php
@@ -133,6 +133,18 @@ class RowCellMapperSuper extends QBMapper {
 	}
 
 	/**
+	 * @throws Exception
+	 * @return RowCellSuper[]
+	 */
+	public function findAllForRow(int $rowId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->tableName)
+			->where($qb->expr()->eq('row_id', $qb->createNamedParameter($rowId, IQueryBuilder::PARAM_INT)));
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * @throws MultipleObjectsReturnedException
 	 * @throws DoesNotExistException
 	 * @throws Exception

--- a/lib/Db/RowCellUsergroupMapper.php
+++ b/lib/Db/RowCellUsergroupMapper.php
@@ -60,6 +60,13 @@ class RowCellUsergroupMapper extends RowCellMapperSuper {
 		];
 	}
 
+	public function toArray(RowCellSuper $cell): array {
+		return [
+			'value' => $cell->getValue(),
+			'value_type' => $cell->getValueType(),
+		];
+	}
+
 	public function hasMultipleValues(): bool {
 		return true;
 	}

--- a/lib/Db/RowLoader/CachedRowLoader.php
+++ b/lib/Db/RowLoader/CachedRowLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Db/RowLoader/CachedRowLoader.php
+++ b/lib/Db/RowLoader/CachedRowLoader.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Db\RowLoader;
+
+use OCA\Tables\Db\Column;
+use OCA\Tables\Db\Row2;
+use OCA\Tables\Db\RowCellMapperSuper;
+use OCA\Tables\Db\RowSleeveMapper;
+use OCA\Tables\Errors\InternalError;
+use OCP\DB\Exception;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Loads rows using `tables_row_sleeves.cached_cells` column
+ */
+class CachedRowLoader implements RowLoader {
+	public function __construct(
+		private RowSleeveMapper $rowSleeveMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getRows(array $rowIds, array $columns, array $mappers): iterable {
+		foreach (array_chunk($rowIds, self::MAX_DB_PARAMETERS) as $chunkedRowIds) {
+			yield from $this->getRowsChunk($chunkedRowIds, $columns, $mappers);
+		}
+	}
+
+	/**
+	 * @param array $rowIds
+	 * @param array<int, Column> $columns Column per columnId
+	 * @param array<int, RowCellMapperSuper> $mappers Mapper per columnId
+	 * @return Row2[]
+	 * @throws InternalError
+	 */
+	private function getRowsChunk(array $rowIds, array $columns, array $mappers): array {
+		try {
+			$sleeves = $this->rowSleeveMapper->findMultiple($rowIds);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), $e->getCode(), $e);
+		}
+
+		return $this->parseResult($sleeves, $columns, $mappers);
+	}
+
+	/**
+	 * @param list<array<string, mixed>> $sleeves
+	 * @param array<int, Column> $columns Column per columnId
+	 * @param array<int, RowCellMapperSuper> $mappers Mapper per columnId
+	 * @return Row2[]
+	 */
+	private function parseResult(array $sleeves, array $columns, $mappers): array {
+		$rows = [];
+		foreach ($sleeves as $sleeve) {
+			$id = (int)$sleeve['id'];
+			$row = new Row2();
+			$row->setId($id);
+			$row->setCreatedBy($sleeve['created_by']);
+			$row->setCreatedAt($sleeve['created_at']);
+			$row->setLastEditBy($sleeve['last_edit_by']);
+			$row->setLastEditAt($sleeve['last_edit_at']);
+			$row->setTableId((int)$sleeve['table_id']);
+
+			$cachedCells = json_decode($sleeve['cached_cells'] ?? '{}', true);
+			foreach ($columns as $columnId => $column) {
+				if (empty($cachedCells[$columnId])) {
+					continue;
+				}
+
+				$cellMapper = $mappers[$columnId];
+				if ($cellMapper->hasMultipleValues()) {
+					$value = array_map(static fn ($rowData) => $cellMapper->formatRowData($column, $rowData),
+						$cachedCells[$columnId]);
+				} else {
+					$value = $cellMapper->formatRowData($column, $cachedCells[$columnId]);
+				}
+
+				$row->addCell($columnId, $value);
+			}
+
+			$rows[] = $row;
+		}
+
+		return $rows;
+	}
+}

--- a/lib/Db/RowLoader/NormalizedRowLoader.php
+++ b/lib/Db/RowLoader/NormalizedRowLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Db/RowLoader/NormalizedRowLoader.php
+++ b/lib/Db/RowLoader/NormalizedRowLoader.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Db\RowLoader;
+
+use OCA\Tables\Db\Column;
+use OCA\Tables\Db\Row2;
+use OCA\Tables\Db\RowCellMapperSuper;
+use OCA\Tables\Db\RowSleeveMapper;
+use OCA\Tables\Errors\InternalError;
+use OCA\Tables\Helper\ColumnsHelper;
+use OCP\DB\Exception;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Loads rows using EAV structure (`tables_row_cells_*` tables)
+ */
+class NormalizedRowLoader implements RowLoader {
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly RowSleeveMapper $rowSleeveMapper,
+		private readonly ColumnsHelper $columnsHelper,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	public function getRows(array $rowIds, array $columns, array $mappers): iterable {
+		$maxParametersPerType = (int)floor(self::MAX_DB_PARAMETERS / count($this->columnsHelper->columns));
+		$chunkSize = max(1, $maxParametersPerType - count($columns));
+
+		foreach (array_chunk($rowIds, $chunkSize) as $chunkedRowIds) {
+			yield from $this->getRowsChunk($chunkedRowIds, $columns, $mappers);
+		}
+	}
+
+	/**
+	 * Builds and executes the UNION ALL query for a specific chunk of rows.
+	 * @param array $rowIds
+	 * @param array<int, Column> $columns Column per columnId
+	 * @param array<int, RowCellMapperSuper> $mappers Mapper per columnId
+	 * @return Row2[]
+	 * @throws InternalError
+	 */
+	private function getRowsChunk(array $rowIds, array $columns, array $mappers): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$subqueries = [];
+		foreach ($this->columnsHelper->columns as $columnType) {
+			$qbValues = $this->db->getQueryBuilder();
+			$qbValues->select('row_id', 'column_id', 'last_edit_at', 'last_edit_by')
+				->selectAlias($qb->expr()->castColumn('value', IQueryBuilder::PARAM_STR), 'value');
+
+			// This is not ideal but I cannot think of a good way to abstract this away into the mapper right now
+			// Ideally we dynamically construct this query depending on what additional selects the column type requires
+			// however the union requires us to match the exact number of selects for each column type
+			if ($columnType === Column::TYPE_USERGROUP) {
+				$qbValues->selectAlias($qb->expr()->castColumn('value_type', IQueryBuilder::PARAM_STR), 'value_type');
+			} else {
+				$qbValues->selectAlias($qbValues->createFunction('NULL'), 'value_type');
+			}
+
+			$qbValues
+				->from('tables_row_cells_' . $columnType)
+				->where($qb->expr()->in('column_id', $qb->createNamedParameter(array_keys($columns), IQueryBuilder::PARAM_INT_ARRAY, ':columnIds')))
+				->andWhere($qb->expr()->in('row_id', $qb->createNamedParameter($rowIds, IQueryBuilder::PARAM_INT_ARRAY, ':rowsIds')));
+
+			$subqueries[] = $qbValues->getSQL();
+		}
+
+		$qb->select('row_id', 'column_id', 'created_by', 'created_at', 't1.last_edit_by', 't1.last_edit_at', 'value', 'table_id')
+			// Also should be more generic (see above)
+			->addSelect('value_type')
+			->from($qb->createFunction('(' . implode(' UNION ALL ', $subqueries) . ')'), 't1')
+			->innerJoin('t1', 'tables_row_sleeves', 'rs', 'rs.id = t1.row_id');
+
+		try {
+			$result = $qb->executeQuery();
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), $e->getCode(), $e);
+		}
+
+		try {
+			$sleeves = $this->rowSleeveMapper->findMultiple($rowIds);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), $e->getCode(), $e);
+		}
+
+		return $this->parseResult($result, $sleeves, $columns, $mappers);
+	}
+
+	/**
+	 * @param IResult $result
+	 * @param list<array<string, mixed>> $sleeves
+	 * @param array<int, Column> $columns Column per columnId
+	 * @param array<int, RowCellMapperSuper> $mappers Mapper per columnId
+	 * @return Row2[]
+	 * @throws InternalError
+	 */
+	private function parseResult(IResult $result, array $sleeves, array $columns, array $mappers): array {
+		$rows = [];
+		foreach ($sleeves as $sleeve) {
+			$id = (int)$sleeve['id'];
+			$rows[$id] = new Row2();
+			$rows[$id]->setId($id);
+			$rows[$id]->setCreatedBy($sleeve['created_by']);
+			$rows[$id]->setCreatedAt($sleeve['created_at']);
+			$rows[$id]->setLastEditBy($sleeve['last_edit_by']);
+			$rows[$id]->setLastEditAt($sleeve['last_edit_at']);
+			$rows[$id]->setTableId((int)$sleeve['table_id']);
+		}
+
+		$rowValues = [];
+		$keyToColumnId = [];
+		$keyToRowId = [];
+
+		while ($rowData = $result->fetch()) {
+			if (!isset($rowData['row_id'], $rows[$rowData['row_id']])) {
+				break;
+			}
+
+			$column = $columns[$rowData['column_id']];
+			$cellMapper = $mappers[$rowData['column_id']];
+			$value = $cellMapper->formatRowData($column, $rowData);
+			$compositeKey = (string)$rowData['row_id'] . ',' . (string)$rowData['column_id'];
+			if ($cellMapper->hasMultipleValues()) {
+				if (array_key_exists($compositeKey, $rowValues)) {
+					$rowValues[$compositeKey][] = $value;
+				} else {
+					$rowValues[$compositeKey] = [$value];
+				}
+			} else {
+				$rowValues[$compositeKey] = $value;
+			}
+			$keyToColumnId[$compositeKey] = $rowData['column_id'];
+			$keyToRowId[$compositeKey] = $rowData['row_id'];
+		}
+
+		foreach ($rowValues as $compositeKey => $value) {
+			$rows[$keyToRowId[$compositeKey]]->addCell($keyToColumnId[$compositeKey], $value);
+		}
+
+		return array_values($rows);
+	}
+}

--- a/lib/Db/RowLoader/RowLoader.php
+++ b/lib/Db/RowLoader/RowLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Db/RowLoader/RowLoader.php
+++ b/lib/Db/RowLoader/RowLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Db\RowLoader;
+
+use OCA\Tables\Db\Column;
+use OCA\Tables\Db\Row2;
+use OCA\Tables\Db\RowCellMapperSuper;
+use OCA\Tables\Errors\InternalError;
+
+interface RowLoader {
+	public const LOADER_CACHED = 'cached';
+	public const LOADER_NORMALIZED = 'normalized';
+
+	public const MAX_DB_PARAMETERS = 1_000;
+
+	/**
+	 * @param array $rowIds
+	 * @param array<int, Column> $columns Column per columnId
+	 * @param array<int, RowCellMapperSuper> $mappers Mapper per columnId
+	 * @return iterable<Row2>
+	 * @throws InternalError
+	 */
+	public function getRows(array $rowIds, array $columns, array $mappers): iterable;
+}

--- a/lib/Db/RowSleeve.php
+++ b/lib/Db/RowSleeve.php
@@ -14,6 +14,8 @@ use OCP\AppFramework\Db\Entity;
  * @psalm-suppress PropertyNotSetInConstructor
  * @method getTableId(): ?int
  * @method setTableId(int $columnId)
+ * @method getCachedCells(): string
+ * @method setCachedCells(string $cachedCells)
  * @method getCreatedBy(): string
  * @method setCreatedBy(string $createdBy)
  * @method getCreatedAt(): string
@@ -25,6 +27,7 @@ use OCP\AppFramework\Db\Entity;
  */
 class RowSleeve extends Entity implements JsonSerializable {
 	protected ?int $tableId = null;
+	protected ?string $cachedCells = null;
 	protected ?string $createdBy = null;
 	protected ?string $createdAt = null;
 	protected ?string $lastEditBy = null;
@@ -33,12 +36,25 @@ class RowSleeve extends Entity implements JsonSerializable {
 	public function __construct() {
 		$this->addType('id', 'integer');
 		$this->addType('tableId', 'integer');
+		$this->addType('cachedCells', 'string');
+	}
+
+	/**
+	 * @return array<int, mixed> Indexed by column ID
+	 */
+	public function getCachedCellsArray(): array {
+		return json_decode($this->cachedCells, true) ?: [];
+	}
+
+	public function setCachedCellsArray(array $array):void {
+		$this->setCachedCells(json_encode($array));
 	}
 
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
 			'tableId' => $this->tableId,
+			'cachedCells' => $this->cachedCells,
 			'createdBy' => $this->createdBy,
 			'createdAt' => $this->createdAt,
 			'lastEditBy' => $this->lastEditBy,

--- a/lib/Db/RowSleeveMapper.php
+++ b/lib/Db/RowSleeveMapper.php
@@ -40,7 +40,7 @@ class RowSleeveMapper extends QBMapper {
 
 	/**
 	 * @param int[] $ids
-	 * @return RowSleeve[]
+	 * @return list<array<string, mixed>> Raw data from DB for the best performance
 	 * @throws Exception
 	 */
 	public function findMultiple(array $ids): array {
@@ -49,6 +49,7 @@ class RowSleeveMapper extends QBMapper {
 		$qb->select(
 			$sleeveAlias . '.id',
 			$sleeveAlias . '.table_id',
+			$sleeveAlias . '.cached_cells',
 			$sleeveAlias . '.created_by',
 			$sleeveAlias . '.created_at',
 			$sleeveAlias . '.last_edit_by',
@@ -56,7 +57,8 @@ class RowSleeveMapper extends QBMapper {
 		)
 			->from($this->table, $sleeveAlias)
 			->where($qb->expr()->in($sleeveAlias . '.id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)));
-		return $this->findEntities($qb);
+
+		return $qb->executeQuery()->fetchAll();
 	}
 
 	/**

--- a/lib/Helper/ColumnsHelper.php
+++ b/lib/Helper/ColumnsHelper.php
@@ -9,11 +9,15 @@ namespace OCA\Tables\Helper;
 
 use OCA\Tables\Constants\UsergroupType;
 use OCA\Tables\Db\Column;
+use OCA\Tables\Db\RowCellMapperSuper;
+use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Service\ColumnTypes\IColumnTypeBusiness;
 use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 class ColumnsHelper {
-
 	public array $columns = [
 		Column::TYPE_TEXT,
 		Column::TYPE_NUMBER,
@@ -28,9 +32,15 @@ class ColumnsHelper {
 	 */
 	private array $columnBusinesses = [];
 
+	/**
+	 * @var array<string, RowCellMapperSuper>
+	 */
+	private array $cellMappers = [];
+
 	public function __construct(
-		private UserHelper $userHelper,
-		private CircleHelper $circleHelper,
+		private readonly UserHelper $userHelper,
+		private readonly CircleHelper $circleHelper,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -103,5 +113,22 @@ class ColumnsHelper {
 		$columnBusiness = Server::get($businessClassName);
 
 		return $this->columnBusinesses[$cacheKey] = $columnBusiness;
+	}
+
+	public function getCellMapperFromType(string $columnType): RowCellMapperSuper {
+		if (isset($this->cellMappers[$columnType])) {
+			return $this->cellMappers[$columnType];
+		}
+
+		$cellMapperClassName = 'OCA\Tables\Db\RowCell' . ucfirst($columnType) . 'Mapper';
+		/** @var RowCellMapperSuper $cellMapper */
+		try {
+			$cellMapper = Server::get($cellMapperClassName);
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), previous: $e);
+		}
+
+		return $this->cellMappers[$columnType] = $cellMapper;
 	}
 }

--- a/lib/Migration/CacheSleeveCells.php
+++ b/lib/Migration/CacheSleeveCells.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Migration;
+
+use OCA\Tables\Db\ColumnMapper;
+use OCA\Tables\Db\RowSleeveMapper;
+use OCA\Tables\Helper\ColumnsHelper;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+class CacheSleeveCells implements IRepairStep {
+	public function __construct(
+		private IDBConnection $db,
+		private ColumnMapper $columnMapper,
+		private ColumnsHelper $columnsHelper,
+		private RowSleeveMapper $rowSleeveMapper,
+		private IConfig $config,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName() {
+		return 'Caches cells to the row-sleeves table';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function run(IOutput $output) {
+		$cachingSleeveCellsComplete = $this->config->getAppValue('tables', 'cachingSleeveCellsComplete', 'false') === 'true';
+		if ($cachingSleeveCellsComplete) {
+			return;
+		}
+
+		foreach ($this->getTableIds() as $tableId) {
+			$columns = $this->columnMapper->findAllByTable($tableId);
+
+			while ($rowIds = $this->getPendingRowIds($tableId)) {
+				foreach ($rowIds as $rowId) {
+					$cachedCells = [];
+					foreach ($columns as $column) {
+						$cellMapper = $this->columnsHelper->getCellMapperFromType($column->getType());
+						$cells = $cellMapper->findManyByRowAndColumn($rowId, $column->getId());
+						foreach ($cells as $cell) {
+							if ($cellMapper->hasMultipleValues()) {
+								$cachedCells[$column->getId()][] = $cellMapper->toArray($cell);
+							} else {
+								$cachedCells[$column->getId()] = $cellMapper->toArray($cell);
+							}
+						}
+					}
+
+					$sleeve = $this->rowSleeveMapper->find($rowId);
+					$sleeve->setCachedCellsArray($cachedCells);
+					$this->rowSleeveMapper->update($sleeve);
+				}
+			}
+
+			$this->logger->info('Finished caching cells for table ' . $tableId);
+		}
+
+		$this->config->setAppValue('tables', 'cachingSleeveCellsComplete', 'true');
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function getTableIds(): array {
+		return $this->db->getQueryBuilder()
+			->select('id')
+			->from('tables_tables')
+			->orderBy('id')
+			->setMaxResults(PHP_INT_MAX)
+			->executeQuery()
+			->fetchAll(\PDO::FETCH_COLUMN);
+
+	}
+
+	/**
+	 * @return int[]
+	 */
+	private function getPendingRowIds(int $tableId): array {
+		$qb = $this->db->getQueryBuilder();
+
+		return $qb->select('id')
+			->from('tables_row_sleeves')
+			->where($qb->expr()->isNull('cached_cells'))
+			->andWhere($qb->expr()->eq('table_id', $qb->createNamedParameter($tableId, \PDO::PARAM_INT)))
+			->orderBy('id')
+			->setMaxResults(1000)
+			->executeQuery()
+			->fetchAll(\PDO::FETCH_COLUMN);
+	}
+}

--- a/lib/Migration/CacheSleeveCells.php
+++ b/lib/Migration/CacheSleeveCells.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -81,7 +83,6 @@ class CacheSleeveCells implements IRepairStep {
 			->select('id')
 			->from('tables_tables')
 			->orderBy('id')
-			->setMaxResults(PHP_INT_MAX)
 			->executeQuery()
 			->fetchAll(\PDO::FETCH_COLUMN);
 

--- a/lib/Migration/Version001010Date20251229000000.php
+++ b/lib/Migration/Version001010Date20251229000000.php
@@ -1,0 +1,41 @@
+<?php
+
+/** @noinspection PhpUnused */
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version001010Date20251229000000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws Exception
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('tables_row_sleeves');
+		if (!$table->hasColumn('tables_row_sleeves')) {
+			$table->addColumn('cached_cells', Types::JSON, [
+				'notnull' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version2030Date20260620000000.php
+++ b/lib/Migration/Version2030Date20260620000000.php
@@ -17,7 +17,7 @@ use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version001010Date20251229000000 extends SimpleMigrationStep {
+class Version2030Date20260620000000 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
@@ -30,8 +30,8 @@ class Version001010Date20251229000000 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('tables_row_sleeves');
-		if (!$table->hasColumn('tables_row_sleeves')) {
-			$table->addColumn('cached_cells', Types::JSON, [
+		if (!$table->hasColumn('cached_cells')) {
+			$table->addColumn('cached_cells', Types::TEXT, [
 				'notnull' => false,
 			]);
 		}

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -901,6 +901,7 @@ class RowService extends SuperService {
 			$qb->insert('tables_row_sleeves')
 				->values([
 					'table_id' => $qb->createNamedParameter($table->getId(), IQueryBuilder::PARAM_INT),
+					'cached_cells' => $qb->createNamedParameter(json_encode([])),
 					'created_by' => $qb->createNamedParameter($table->getOwnership()),
 					'created_at' => $qb->createNamedParameter($row['createdAt']),
 					'last_edit_by' => $qb->createNamedParameter($table->getOwnership()),

--- a/lib/UserMigration/TablesMigrator.php
+++ b/lib/UserMigration/TablesMigrator.php
@@ -14,6 +14,7 @@ use OCA\Tables\Db\ContextMapper;
 use OCA\Tables\Db\ContextNodeRelationMapper;
 use OCA\Tables\Db\RowCellDatetime;
 use OCA\Tables\Db\RowCellDatetimeMapper;
+use OCA\Tables\Db\RowCellMapperSuper;
 use OCA\Tables\Db\RowCellNumber;
 use OCA\Tables\Db\RowCellNumberMapper;
 use OCA\Tables\Db\RowCellSelection;
@@ -34,6 +35,7 @@ use OCA\Tables\Service\RowService;
 use OCA\Tables\Service\ShareService;
 use OCA\Tables\Service\TableService;
 use OCA\Tables\Service\ViewService;
+use OCP\DB\Exception;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\UserMigration\IExportDestination;
@@ -41,6 +43,7 @@ use OCP\UserMigration\IImportSource;
 use OCP\UserMigration\IMigrator;
 use OCP\UserMigration\ISizeEstimationMigrator;
 use OCP\UserMigration\TMigratorBasicVersionHandling;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TablesMigrator implements IMigrator, ISizeEstimationMigrator {
@@ -83,6 +86,7 @@ class TablesMigrator implements IMigrator, ISizeEstimationMigrator {
 		protected RowService $rowService,
 		private ContextService $contextService,
 		private ShareService $shareService,
+		protected LoggerInterface $logger,
 	) {
 	}
 
@@ -279,6 +283,8 @@ class TablesMigrator implements IMigrator, ISizeEstimationMigrator {
 				$userId,
 			);
 
+			$this->rebuildCachedCells($rowIdMap);
+
 			$connection->commit();
 		} catch (\Throwable $e) {
 			$connection->rollBack();
@@ -332,6 +338,39 @@ class TablesMigrator implements IMigrator, ISizeEstimationMigrator {
 				$cell->setLastEditAt($cellData['lastEditAt'] ?? null);
 				$mapper->insert($cell);
 			}
+		}
+	}
+
+	private function rebuildCachedCells(array $rowIdMap): void {
+		foreach ($rowIdMap as $newRowId) {
+			$sleeve = $this->rowSleeveMapper->find($newRowId);
+			$cachedCells = [];
+
+			/** @var RowCellMapperSuper[] $cellMappers */
+			$cellMappers = [
+				$this->rowCellTextMapper,
+				$this->rowCellNumberMapper,
+				$this->rowCellDatetimeMapper,
+				$this->rowCellSelectionMapper,
+				$this->rowCellUsergroupMapper,
+			];
+
+			foreach ($cellMappers as $mapper) {
+				try {
+					$cells = $mapper->findAllForRow($newRowId);
+					foreach ($cells as $cell) {
+						$cachedCells[$cell->getColumnId()] = $mapper->toArray($cell);
+					}
+				} catch (Exception $e) {
+					$this->logger->error('Failed to load cells for row during cached_cells rebuild', [
+						'rowId' => $newRowId,
+						'exception' => $e->getMessage(),
+					]);
+				}
+			}
+
+			$sleeve->setCachedCellsArray($cachedCells);
+			$this->rowSleeveMapper->update($sleeve);
 		}
 	}
 

--- a/tests/unit/Database/DatabaseTestCase.php
+++ b/tests/unit/Database/DatabaseTestCase.php
@@ -292,6 +292,7 @@ abstract class DatabaseTestCase extends TestCase {
 
 		if (!empty($cellsData)) {
 			$this->addCellsToRow($rowId, $cellsData, $columnMapping);
+			$this->updateCachedCells($rowId, $cellsData, $columnMapping);
 		}
 
 		return $result;
@@ -346,6 +347,31 @@ abstract class DatabaseTestCase extends TestCase {
 			->setValue('value', $qb->createNamedParameter($value))
 			->setValue('last_edit_at', $qb->createNamedParameter(date('Y-m-d H:i:s')))
 			->setValue('last_edit_by', $qb->createNamedParameter('user1'));
+
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Updates the cached_cells column for a row
+	 */
+	protected function updateCachedCells(int $rowId, array $cellsData, array $columnMapping = []): void {
+		$cachedCells = [];
+		foreach ($cellsData as $columnIdentifier => $value) {
+			// Convert test_ident to actual column ID if mapping is provided
+			if (is_string($columnIdentifier) && isset($columnMapping[$columnIdentifier])) {
+				$columnId = $columnMapping[$columnIdentifier];
+			} else {
+				$columnId = $columnIdentifier;
+			}
+
+			// Format the value as expected by CachedRowLoader (matches cell mapper toArray format)
+			$cachedCells[$columnId] = ['value' => $value];
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('tables_row_sleeves')
+			->set('cached_cells', $qb->createNamedParameter(json_encode($cachedCells)))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($rowId)));
 
 		$qb->executeStatement();
 	}

--- a/tests/unit/Db/Row2MapperTestDependencies.php
+++ b/tests/unit/Db/Row2MapperTestDependencies.php
@@ -12,11 +12,21 @@ namespace OCA\Tables\Tests\Unit\Db;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
 use OCA\Tables\Db\Row2Mapper;
+use OCA\Tables\Db\RowCellDatetimeMapper;
+use OCA\Tables\Db\RowCellNumberMapper;
+use OCA\Tables\Db\RowCellSelectionMapper;
+use OCA\Tables\Db\RowCellTextMapper;
+use OCA\Tables\Db\RowCellUsergroupMapper;
+use OCA\Tables\Db\RowLoader\CachedRowLoader;
+use OCA\Tables\Db\RowLoader\NormalizedRowLoader;
 use OCA\Tables\Db\RowSleeveMapper;
 use OCA\Tables\Helper\CircleHelper;
 use OCA\Tables\Helper\ColumnsHelper;
+use OCA\Tables\Helper\GroupHelper;
 use OCA\Tables\Helper\UserHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -35,6 +45,8 @@ trait Row2MapperTestDependencies {
 	protected ColumnsHelper|MockObject $columnsHelper;
 	protected LoggerInterface|MockObject $logger;
 	protected CircleHelper|MockObject $circleHelper;
+	protected NormalizedRowLoader $normalizedRowLoader;
+	protected CachedRowLoader $cachedRowLoader;
 
 	protected static bool $testDataInitialized = false;
 	protected static int $testTableId;
@@ -56,7 +68,22 @@ trait Row2MapperTestDependencies {
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->rowSleeveMapper = new RowSleeveMapper($this->connectionAdapter, $this->logger);
-		$this->columnsHelper = new ColumnsHelper($this->userHelper, $this->circleHelper);
+		$this->columnsHelper = $this->createMock(ColumnsHelper::class);
+
+		// Mock getCellMapperFromType to return real cell mappers
+		$this->setupCellMappers();
+
+		// Use real loader instances since we have a real database
+		$this->normalizedRowLoader = new NormalizedRowLoader(
+			$this->connectionAdapter,
+			$this->rowSleeveMapper,
+			$this->columnsHelper,
+			$this->logger
+		);
+		$this->cachedRowLoader = new CachedRowLoader(
+			$this->rowSleeveMapper,
+			$this->logger
+		);
 
 		$this->mapper = new Row2Mapper(
 			'test_user',
@@ -65,13 +92,36 @@ trait Row2MapperTestDependencies {
 			$this->userHelper,
 			$this->rowSleeveMapper,
 			$this->columnsHelper,
-			$this->columnMapper
+			$this->columnMapper,
+			$this->normalizedRowLoader,
+			$this->cachedRowLoader
 		);
 
 		if (!self::$testDataInitialized) {
 			$this->initializeTestData();
 			self::$testDataInitialized = true;
 		}
+	}
+
+	/**
+	 * Sets up real cell mappers by mocking getCellMapperFromType
+	 * This is needed because ColumnsHelper uses Server::get() which doesn't work in unit tests
+	 */
+	private function setupCellMappers(): void {
+		$userManager = $this->createMock(IUserManager::class);
+		$userSession = $this->createMock(IUserSession::class);
+
+		$this->columnsHelper->method('getCellMapperFromType')
+			->willReturnCallback(function ($columnType) use ($userManager, $userSession) {
+				return match ($columnType) {
+					Column::TYPE_TEXT => new RowCellTextMapper($this->connectionAdapter),
+					Column::TYPE_NUMBER => new RowCellNumberMapper($this->connectionAdapter),
+					Column::TYPE_DATETIME => new RowCellDatetimeMapper($this->connectionAdapter),
+					Column::TYPE_SELECTION => new RowCellSelectionMapper($this->connectionAdapter),
+					Column::TYPE_USERGROUP => new RowCellUsergroupMapper($this->connectionAdapter, $userManager, $this->circleHelper, $this->createMock(GroupHelper::class), $userSession),
+					default => throw new \InvalidArgumentException("Unknown column type: $columnType"),
+				};
+			});
 	}
 
 	/**

--- a/tests/unit/TablesMigratorTest.php
+++ b/tests/unit/TablesMigratorTest.php
@@ -36,6 +36,7 @@ use OCP\IUser;
 use OCP\UserMigration\IExportDestination;
 use OCP\UserMigration\IImportSource;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\NullOutput;
 
 class TablesMigratorTest extends TestCase {
@@ -60,6 +61,7 @@ class TablesMigratorTest extends TestCase {
 	private $rowService;
 	private $contextService;
 	private $shareService;
+	private $logger;
 
 	protected function setUp(): void {
 		$this->l10n = $this->createMock(IL10N::class);
@@ -82,6 +84,7 @@ class TablesMigratorTest extends TestCase {
 		$this->rowService = $this->createMock(RowService::class);
 		$this->contextService = $this->createMock(ContextService::class);
 		$this->shareService = $this->createMock(ShareService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->migrator = new TablesMigrator(
 			$this->l10n,
@@ -103,7 +106,8 @@ class TablesMigratorTest extends TestCase {
 			$this->columnService,
 			$this->rowService,
 			$this->contextService,
-			$this->shareService
+			$this->shareService,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
This PR built on top of #2238.
Closes #1490.


It fixes loading of the large tables. Right now it is not possible to load a table with 30k rows and 8 columns due to an error:

```
"Previous":{"Exception":"Doctrine\\DBAL\\Exception\\DriverException","Message":
"An exception occurred while executing a query: SQLSTATE[HY000]: 
General error: 7 number of parameters must be between 0 and 65535",
```

PR contains 2 commits: fix itself and performance improvement.

I've measured latency for a various scenarios for `/row/table/{tableId}` endpoint:
| Scenario | master | #2238 | 1st commit from this PR | 2nd commit from this PR |
|--------|--------|--------|--------|--------|
| 8 columns x 2k rows | 0.68s | 0.31s | 0.31s | 0.17s |
| 8 columns x 10k rows | 2.86s | 1.21s | 1.21s | 0.44s |
| 8 columns x 60k rows | :lady_beetle: sql error | :lady_beetle: sql error | 6.97s | 2.27s |


📹 [Video](https://github.com/nextcloud/tables/pull/2242#issuecomment-3806357240) for performance comparison

Next step: move filtering/sorting/pagination to BE side and speedup FE. But this is completely separate topic which will be implemented in upcoming PRs.