### PR TITLE
Feature/2237 add column name

### DIFF
--- a/lib/Controller/RowOCSController.php
+++ b/lib/Controller/RowOCSController.php
@@ -77,7 +77,7 @@ class RowOCSController extends AOCSController {
 		}
 
 		try {
-			return new DataResponse($this->rowService->create($tableId, $viewId, $newRowData)->jsonSerialize());
+			return new DataResponse($this->rowService->create($tableId, $viewId, $newRowData)->toResponseArray());
 		} catch (BadRequestError $e) {
 			return $this->handleBadRequestError($e);
 		} catch (NotFoundError $e) {

--- a/lib/Controller/RowOCSController.php
+++ b/lib/Controller/RowOCSController.php
@@ -77,7 +77,7 @@ class RowOCSController extends AOCSController {
 		}
 
 		try {
-			return new DataResponse($this->rowService->create($tableId, $viewId, $newRowData)->toResponseArray());
+			return new DataResponse($this->rowService->create($tableId, $viewId, $newRowData)->jsonSerialize());
 		} catch (BadRequestError $e) {
 			return $this->handleBadRequestError($e);
 		} catch (NotFoundError $e) {

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -158,7 +158,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	protected ?string $lastEditByDisplayName = null;
 	protected ?ViewColumnInformation $viewColumnInformation = null;
 
-	protected const VIRTUAL_PROPERTIES = ['createdByDisplayName', 'lastEditByDisplayName', 'viewColumnInformation'];
+	protected const VIRTUAL_PROPERTIES = ['createdByDisplayName', 'lastEditByDisplayName', 'viewColumnInformation', 'columnName'];
 
 	public function __construct() {
 		$this->addType('id', 'integer');

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -145,7 +145,15 @@ class Row2 implements JsonSerializable {
 	}
 
 	/**
-	 * @psalm-return TablesRow
+	 * @return array{
+	 *   id: int|null,
+	 *   tableId: int|null,
+	 *   createdBy: string|null,
+	 *   createdAt: string|null,
+	 *   lastEditBy: string|null,
+	 *   lastEditAt: string|null,
+	 *   data: list<array<array-key, mixed>>
+	 * }
 	 */
 	public function jsonSerialize(): array {
 		$data = [];

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -23,6 +23,7 @@ class Row2 implements JsonSerializable {
 	private ?string $lastEditBy = null;
 	private ?string $lastEditAt = null;
 	private ?array $data = [];
+	private array $cellMeta = [];
 	private array $changedColumnIds = []; // collect column ids that have changed after $loaded = true
 
 	private bool $loaded = false; // set to true if model is loaded, after that changed column ids will be collected
@@ -134,6 +135,16 @@ class Row2 implements JsonSerializable {
 	}
 
 	/**
+	 * add response-only metadata for a specific column
+	 */
+	public function addCellMeta(int $columnId, array $meta): void {
+		if (!isset($this->cellMeta[$columnId])) {
+			$this->cellMeta[$columnId] = [];
+		}
+		$this->cellMeta[$columnId] = array_merge($this->cellMeta[$columnId], $meta);
+	}
+
+	/**
 	 * @psalm-return TablesRow
 	 */
 	public function jsonSerialize(): array {
@@ -145,6 +156,31 @@ class Row2 implements JsonSerializable {
 			'lastEditBy' => $this->lastEditBy,
 			'lastEditAt' => $this->lastEditAt,
 			'data' => $this->data,
+		];
+	}
+
+	/**
+	 * return merged response-only metadata into the data cells.
+	 */
+	public function toResponseArray(): array {
+		$data = [];
+		foreach ($this->data as $cell) {
+			$colId = $cell['columnId'];
+			$merged = $cell;
+			if (isset($this->cellMeta[$colId])) {
+				$merged = array_merge($merged, $this->cellMeta[$colId]);
+			}
+			$data[] = $merged;
+		}
+
+		return [
+			'id' => $this->id,
+			'tableId' => $this->tableId,
+			'createdBy' => $this->createdBy,
+			'createdAt' => $this->createdAt,
+			'lastEditBy' => $this->lastEditBy,
+			'lastEditAt' => $this->lastEditAt,
+			'data' => $data,
 		];
 	}
 

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -212,8 +212,8 @@ class Row2 implements JsonSerializable {
 	}
 
 	/**
-	* attach columnName as metadata for each cell
-	*/
+	 * attach columnName as metadata for each cell
+	 */
 	public function addColumnNames(array $fullRowData): void {
 		foreach ($fullRowData as $meta) {
 			if (isset($meta['columnId']) && array_key_exists('columnName', $meta)) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -80,7 +80,7 @@ namespace OCA\Tables;
  * 	createdAt: string,
  * 	lastEditBy: string,
  * 	lastEditAt: string,
- *  data: ?array{columnId: int, value: mixed},
+ *  data: ?array{columnId: int, columnName: string, value: mixed},
  * }
  *
  * @psalm-type TablesShare = array{

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -211,21 +211,21 @@ class RowService extends SuperService {
 		$fullRowData = [];
 		$columnNames = [];
 
-		foreach ($columns as $c) {
-			$columnNames[$c->getId()] = $c->getTitle();
+		foreach ($columns as $column) {
+			$columnNames[$column->getId()] = $column->getTitle();
 		}
 
 		$rows = $data instanceof RowDataInput ? iterator_to_array($data) : $data;
 
-		foreach ($rows as $r) {
-			$colId = (int)$r['columnId'];
+		foreach ($rows as $row) {
+			$colId = (int)$row['columnId'];
 			if (!isset($columnNames[$colId])) {
 				continue;
 			}
 
 			$fullRowData[] = [
 				'columnId' => $colId,
-				'value' => $r['value'],
+				'value' => $row['value'],
 				'columnName' => $columnNames[$colId],
 			];
 		}
@@ -242,12 +242,8 @@ class RowService extends SuperService {
 		$row2->setData($data);
 		try {
 			$insertedRow = $this->row2Mapper->insert($row2);
-			// attached columnname to returned row for the response only
-			foreach ($fullRowData as $meta) {
-				if (isset($meta['columnId']) && array_key_exists('columnName', $meta)) {
-					$insertedRow->addCellMeta((int)$meta['columnId'], ['columnName' => $meta['columnName']]);
-				}
-			}
+			// attach columnName to returned row for the response only
+			$insertedRow->addColumnNames($fullRowData);
 
 			$this->eventDispatcher->dispatchTyped(new RowAddedEvent($insertedRow));
 			$this->activityManager->triggerEvent(

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -208,13 +208,13 @@ class RowService extends SuperService {
 			throw new InternalError('Cannot create row without table or view in context');
 		}
 
-		$fullRowData = [];				
+		$fullRowData = [];
 		$columnNames = [];
 
 		foreach ($columns as $c) {
 			$columnNames[$c->getId()] = $c->getTitle();
 		}
-		
+
 		$rows = $data instanceof RowDataInput ? iterator_to_array($data) : $data;
 
 		foreach ($rows as $r) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
   - SPDX-FileCopyrightText: 2021 Florian Steffens
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/Unit/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="unit">
             <directory>./tests/Unit</directory>

--- a/tests/unit/Db/Row2Test.php
+++ b/tests/unit/Db/Row2Test.php
@@ -8,25 +8,25 @@ use OCA\Tables\Db\Row2;
 use PHPUnit\Framework\TestCase;
 
 class Row2Test extends TestCase {
-    public function testToResponseArrayMergesMetaButJsonSerializeDoesNot(): void {
-        $row = new Row2();
-        $row->setTableId(1);
+	public function testToResponseArrayMergesMetaButJsonSerializeDoesNot(): void {
+		$row = new Row2();
+		$row->setTableId(1);
 
-        $row->setData([
-            ['columnId' => 57, 'value' => 'foo'],
-            ['columnId' => 58, 'value' => 'bar'],
-        ]);
+		$row->setData([
+			['columnId' => 57, 'value' => 'foo'],
+			['columnId' => 58, 'value' => 'bar'],
+		]);
 
-        $json = $row->jsonSerialize();
-        $this->assertArrayNotHasKey('columnName', $json['data'][0]);
+		$json = $row->jsonSerialize();
+		$this->assertArrayNotHasKey('columnName', $json['data'][0]);
 
-        $row->addCellMeta(57, ['columnName' => 'Title 57']);
+		$row->addCellMeta(57, ['columnName' => 'Title 57']);
 
-        $resp = $row->toResponseArray();
-        $this->assertArrayHasKey('columnName', $resp['data'][0]);
-        $this->assertSame('Title 57', $resp['data'][0]['columnName']);
+		$resp = $row->toResponseArray();
+		$this->assertArrayHasKey('columnName', $resp['data'][0]);
+		$this->assertSame('Title 57', $resp['data'][0]['columnName']);
 
-        $json2 = $row->jsonSerialize();
-        $this->assertArrayNotHasKey('columnName', $json2['data'][0]);
-    }
+		$json2 = $row->jsonSerialize();
+		$this->assertArrayNotHasKey('columnName', $json2['data'][0]);
+	}
 }

--- a/tests/unit/Db/Row2Test.php
+++ b/tests/unit/Db/Row2Test.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Tests\Unit\Db;
+
+use OCA\Tables\Db\Row2;
+use PHPUnit\Framework\TestCase;
+
+class Row2Test extends TestCase {
+    public function testToResponseArrayMergesMetaButJsonSerializeDoesNot(): void {
+        $row = new Row2();
+        $row->setTableId(1);
+
+        $row->setData([
+            ['columnId' => 57, 'value' => 'foo'],
+            ['columnId' => 58, 'value' => 'bar'],
+        ]);
+
+        $json = $row->jsonSerialize();
+        $this->assertArrayNotHasKey('columnName', $json['data'][0]);
+
+        $row->addCellMeta(57, ['columnName' => 'Title 57']);
+
+        $resp = $row->toResponseArray();
+        $this->assertArrayHasKey('columnName', $resp['data'][0]);
+        $this->assertSame('Title 57', $resp['data'][0]['columnName']);
+
+        $json2 = $row->jsonSerialize();
+        $this->assertArrayNotHasKey('columnName', $json2['data'][0]);
+    }
+}

--- a/tests/unit/Db/Row2Test.php
+++ b/tests/unit/Db/Row2Test.php
@@ -8,7 +8,7 @@ use OCA\Tables\Db\Row2;
 use PHPUnit\Framework\TestCase;
 
 class Row2Test extends TestCase {
-	public function testToResponseArrayMergesMetaButJsonSerializeDoesNot(): void {
+	public function testJsonSerializeMergesCellMetadata(): void {
 		$row = new Row2();
 		$row->setTableId(1);
 
@@ -21,12 +21,8 @@ class Row2Test extends TestCase {
 		$this->assertArrayNotHasKey('columnName', $json['data'][0]);
 
 		$row->addCellMeta(57, ['columnName' => 'Title 57']);
-
-		$resp = $row->toResponseArray();
+		$resp = $row->jsonSerialize();
 		$this->assertArrayHasKey('columnName', $resp['data'][0]);
 		$this->assertSame('Title 57', $resp['data'][0]['columnName']);
-
-		$json2 = $row->jsonSerialize();
-		$this->assertArrayNotHasKey('columnName', $json2['data'][0]);
 	}
 }

--- a/tests/unit/Db/Row2Test.php
+++ b/tests/unit/Db/Row2Test.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 namespace OCA\Tables\Tests\Unit\Db;
 
 use OCA\Tables\Db\Row2;


### PR DESCRIPTION
This PR is a fix for [#1840](https://github.com/nextcloud/tables/issues/1840) and #2237.
# Description:
- User asked for more info of the column name to be also returned in response when user add new row so which each cell belongs to which column.
- Return more clear error message when user calls for non-existing row.

# Issues fixed:
- add new value called columnName to response when saving new row.
- return clear error message when user add none-existing row id.