### PR TITLE
fix: Listing contexts without user-id

### DIFF
--- a/lib/Command/ListContexts.php
+++ b/lib/Command/ListContexts.php
@@ -49,7 +49,7 @@ class ListContexts extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$userId = trim($input->getArgument('user-id'));
+		$userId = trim($input->getArgument('user-id') ?? '');
 		if ($userId === '') {
 			$userId = null;
 		}


### PR DESCRIPTION
```
# occ tables:contexts:list
An unhandled exception has been thrown:
TypeError: trim(): Argument #1 ($string) must be of type string, null given in /var/www/html/apps-extra/tables/lib/Command/ListContexts.php:52
Stack trace:
#0 /var/www/html/apps-extra/tables/lib/Command/ListContexts.php(52): trim(NULL)
#1 /var/www/html/3rdparty/symfony/console/Command/Command.php(326): OCA\Tables\Command\ListContexts->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /var/www/html/core/Command/Base.php(220): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /var/www/html/3rdparty/symfony/console/Application.php(1078): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /var/www/html/3rdparty/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(OCA\Tables\Command\ListContexts), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/html/3rdparty/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/lib/private/Console/Application.php(187): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/console.php(92): OC\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#8 /var/www/html/occ(33): require_once('/var/www/html/c...')
#9 {main}%   
```