### PR TITLE
feat: add relation lookup column type

### DIFF
--- a/lib/Constants/ColumnType.php
+++ b/lib/Constants/ColumnType.php
@@ -16,4 +16,5 @@ enum ColumnType: string {
 	case DATETIME = 'datetime';
 	case PEOPLE = 'usergroup';
 	case RELATION = 'relation';
+	case RELATION_LOOKUP = 'relation_lookup';
 }

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -828,7 +828,8 @@ class Api1Controller extends ApiController {
 	 * Get all relation data for a table
 	 *
 	 * @param int $tableId Table ID
-	 * @return DataResponse<Http::STATUS_OK, array<string, array<string, array{id: int, label: string}>>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesRelationData, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @psalm-return DataResponse<Http::STATUS_OK, list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
 	 * 200: Relation data returned
 	 * 403: No permissions
@@ -838,6 +839,7 @@ class Api1Controller extends ApiController {
 	#[NoCSRFRequired]
 	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function indexTableRelations(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->relationService->getRelationsForTable($tableId));
@@ -860,7 +862,8 @@ class Api1Controller extends ApiController {
 	 * Get all relation data for a view
 	 *
 	 * @param int $viewId View ID
-	 * @return DataResponse<Http::STATUS_OK, array<string, array<string, array{id: int, label: string}>>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesRelationData, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @psalm-return DataResponse<Http::STATUS_OK, list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
 	 * 200: Relation data returned
 	 * 403: No permissions
@@ -870,6 +873,7 @@ class Api1Controller extends ApiController {
 	#[NoCSRFRequired]
 	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function indexViewRelations(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->relationService->getRelationsForView($viewId));
@@ -894,7 +898,7 @@ class Api1Controller extends ApiController {
 	 * @param int|null $tableId Table ID
 	 * @param int|null $viewId View ID
 	 * @param string $title Title
-	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation'|'relation_lookup' $type Column main type
 	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory
@@ -1678,7 +1682,7 @@ class Api1Controller extends ApiController {
 	 *
 	 * @param int $tableId Table ID
 	 * @param string $title Title
-	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation'|'relation_lookup' $type Column main type
 	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -844,7 +844,8 @@ class Api1Controller extends ApiController {
 	 * Get all relation data for a table
 	 *
 	 * @param int $tableId Table ID
-	 * @return DataResponse<Http::STATUS_OK, array<string, array<string, array{id: int, label: string}>>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesRelationData, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @psalm-return DataResponse<Http::STATUS_OK, list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
 	 * 200: Relation data returned
 	 * 403: No permissions
@@ -854,6 +855,7 @@ class Api1Controller extends ApiController {
 	#[NoCSRFRequired]
 	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function indexTableRelations(int $tableId): DataResponse {
 		try {
 			return new DataResponse($this->relationService->getRelationsForTable($tableId));
@@ -876,7 +878,8 @@ class Api1Controller extends ApiController {
 	 * Get all relation data for a view
 	 *
 	 * @param int $viewId View ID
-	 * @return DataResponse<Http::STATUS_OK, array<string, array<string, array{id: int, label: string}>>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesRelationData, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @psalm-return DataResponse<Http::STATUS_OK, list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 *
 	 * 200: Relation data returned
 	 * 403: No permissions
@@ -886,6 +889,7 @@ class Api1Controller extends ApiController {
 	#[NoCSRFRequired]
 	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function indexViewRelations(int $viewId): DataResponse {
 		try {
 			return new DataResponse($this->relationService->getRelationsForView($viewId));
@@ -910,7 +914,7 @@ class Api1Controller extends ApiController {
 	 * @param int|null $tableId Table ID
 	 * @param int|null $viewId View ID
 	 * @param string $title Title
-	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation'|'relation_lookup' $type Column main type
 	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory
@@ -1694,7 +1698,7 @@ class Api1Controller extends ApiController {
 	 *
 	 * @param int $tableId Table ID
 	 * @param string $title Title
-	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation'|'relation_lookup' $type Column main type
 	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -107,6 +107,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	public const TYPE_DATETIME = 'datetime';
 	public const TYPE_USERGROUP = 'usergroup';
 	public const TYPE_RELATION = 'relation';
+	public const TYPE_RELATION_LOOKUP = 'relation_lookup';
 
 	public const SUBTYPE_DATETIME_DATE = 'date';
 	public const SUBTYPE_DATETIME_TIME = 'time';
@@ -350,6 +351,20 @@ class Column extends EntitySuper implements JsonSerializable {
 
 	public function getCustomSettingsArray(): array {
 		return json_decode($this->customSettings, true) ?: [];
+	}
+
+	/**
+	 * @template T
+	 * @param class-string<T> $className
+	 * @return T
+	 * @throws \InvalidArgumentException
+	 */
+	public function getCustomSettingsObject(string $className): mixed {
+		$array = $this->getCustomSettingsArray();
+		if (method_exists($className, 'fromArray')) {
+			return $className::fromArray($array);
+		}
+		throw new \InvalidArgumentException("Class $className must have a fromArray method");
 	}
 
 	/**

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -107,6 +107,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	public const TYPE_DATETIME = 'datetime';
 	public const TYPE_USERGROUP = 'usergroup';
 	public const TYPE_RELATION = 'relation';
+	public const TYPE_RELATION_LOOKUP = 'relation_lookup';
 
 	public const SUBTYPE_DATETIME_DATE = 'date';
 	public const SUBTYPE_DATETIME_TIME = 'time';
@@ -352,6 +353,20 @@ class Column extends EntitySuper implements JsonSerializable {
 
 	public function getCustomSettingsArray(): array {
 		return json_decode((string)$this->customSettings, true) ?: [];
+	}
+
+	/**
+	 * @template T
+	 * @param class-string<T> $className
+	 * @return T
+	 * @throws \InvalidArgumentException
+	 */
+	public function getCustomSettingsObject(string $className): mixed {
+		$array = $this->getCustomSettingsArray();
+		if (method_exists($className, 'fromArray')) {
+			return $className::fromArray($array);
+		}
+		throw new \InvalidArgumentException("Class $className must have a fromArray method");
 	}
 
 	/**

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Db;
 use DateTime;
 use DateTimeImmutable;
 use OCA\Tables\Constants\UsergroupType;
+use OCA\Tables\Dto\RelationLookupSettings;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Helper\ColumnsHelper;
@@ -60,6 +61,9 @@ class Row2Mapper {
 		$this->db->beginTransaction();
 		try {
 			foreach ($this->columnsHelper->columns as $columnType) {
+				if ($this->isVirtualColumn($columnType)) {
+					continue;
+				}
 				$this->getCellMapperFromType($columnType)->deleteAllForRow($row->getId());
 			}
 			$this->rowSleeveMapper->deleteById($row->getId());
@@ -219,6 +223,8 @@ class Row2Mapper {
 	private function getRowsChunk(array $rowIds, array $columnIds): array {
 		$qb = $this->db->getQueryBuilder();
 
+		$columnIds = $this->addRelationColumnIdsForLookupColumns($columnIds);
+
 		$qbSqlForColumnTypes = null;
 		foreach ($this->columnsHelper->columns as $columnType) {
 			$qbTmp = $this->db->getQueryBuilder();
@@ -234,6 +240,9 @@ class Row2Mapper {
 				$qbTmp->selectAlias($qbTmp->createFunction('NULL'), 'value_type');
 			}
 
+			if ($this->isVirtualColumn($columnType)) {
+				continue;
+			}
 			$qbTmp
 				->from('tables_row_cells_' . $columnType)
 				->where($qb->expr()->in('column_id', $qb->createNamedParameter($columnIds, IQueryBuilder::PARAM_INT_ARRAY, ':columnIds')))
@@ -839,6 +848,10 @@ class Row2Mapper {
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
+
 		// insert new cell
 		$cellMapper = $this->getCellMapper($column);
 
@@ -877,6 +890,10 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	private function updateCell(RowCellSuper $cell, RowCellMapperSuper $mapper, $value, Column $column): void {
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
+
 		$this->getCellMapper($column)->applyDataToEntity($column, $cell, $value);
 		$this->updateMetaData($cell);
 		$mapper->updateWrapper($cell);
@@ -887,6 +904,9 @@ class Row2Mapper {
 	 */
 	private function insertOrUpdateCell(int $rowId, int $columnId, $value): void {
 		$column = $this->columnMapper->find($columnId);
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
 		$cellMapper = $this->getCellMapper($column);
 		try {
 			if ($cellMapper->hasMultipleValues()) {
@@ -913,6 +933,9 @@ class Row2Mapper {
 	}
 
 	private function getCellMapperFromType(string $columnType): RowCellMapperSuper {
+		if ($this->isVirtualColumn($columnType)) {
+			throw new InternalError('Virtual columns do not have cell mappers');
+		}
 		$cellMapperClassName = 'OCA\Tables\Db\RowCell' . ucfirst($columnType) . 'Mapper';
 		/** @var RowCellMapperSuper $cellMapper */
 		try {
@@ -934,6 +957,9 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	public function deleteDataForColumn(Column $column): void {
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
 		try {
 			$this->getCellMapper($column)->deleteAllForColumn($column->getId());
 		} catch (Exception $e) {
@@ -1002,6 +1028,9 @@ class Row2Mapper {
 			case Column::TYPE_USERGROUP:
 				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getUsergroupDefault());
 				break;
+			case Column::TYPE_RELATION_LOOKUP:
+				$defaultValue = null;
+				break;
 		}
 		return $defaultValue;
 	}
@@ -1029,4 +1058,26 @@ class Row2Mapper {
 
 		return $sortedRows;
 	}
+
+	public function isVirtualColumn(string $columnType): bool {
+		return $columnType === Column::TYPE_RELATION_LOOKUP;
+	}
+
+	/**
+	 * @param int[] $columnIds
+	 * @return int[]
+	 */
+	public function addRelationColumnIdsForLookupColumns(array $columnIds): array {
+		$allColumns = $this->columnMapper->findAll($columnIds);
+		foreach ($allColumns as $column) {
+			if ($column->getType() !== Column::TYPE_RELATION_LOOKUP) {
+				continue;
+			}
+
+			$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+			$columnIds[] = $settings->relationColumnId;
+		}
+		return array_values(array_unique(array_filter($columnIds)));
+	}
+
 }

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Db;
 use DateTime;
 use DateTimeImmutable;
 use OCA\Tables\Constants\UsergroupType;
+use OCA\Tables\Dto\RelationLookupSettings;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Helper\ColumnsHelper;
@@ -32,15 +33,23 @@ class Row2Mapper {
 
 	private const DB_CHUNK_SIZE = 1_000;
 
-	public function __construct(
-		private ?string $userId,
-		private IDBConnection $db,
-		private LoggerInterface $logger,
-		protected UserHelper $userHelper,
-		private RowSleeveMapper $rowSleeveMapper,
-		private ColumnsHelper $columnsHelper,
-		protected ColumnMapper $columnMapper,
-	) {
+	private RowSleeveMapper $rowSleeveMapper;
+	private ?string $userId;
+	private IDBConnection $db;
+	private LoggerInterface $logger;
+	protected UserHelper $userHelper;
+	protected ColumnMapper $columnMapper;
+
+	private ColumnsHelper $columnsHelper;
+
+	public function __construct(?string $userId, IDBConnection $db, LoggerInterface $logger, UserHelper $userHelper, RowSleeveMapper $rowSleeveMapper, ColumnsHelper $columnsHelper, ColumnMapper $columnMapper) {
+		$this->rowSleeveMapper = $rowSleeveMapper;
+		$this->userId = $userId;
+		$this->db = $db;
+		$this->logger = $logger;
+		$this->userHelper = $userHelper;
+		$this->columnsHelper = $columnsHelper;
+		$this->columnMapper = $columnMapper;
 	}
 
 	/**
@@ -52,6 +61,9 @@ class Row2Mapper {
 		$this->db->beginTransaction();
 		try {
 			foreach ($this->columnsHelper->columns as $columnType) {
+				if ($this->isVirtualColumn($columnType)) {
+					continue;
+				}
 				$this->getCellMapperFromType($columnType)->deleteAllForRow($row->getId());
 			}
 			$this->rowSleeveMapper->deleteById($row->getId());
@@ -59,7 +71,7 @@ class Row2Mapper {
 		} catch (Throwable $e) {
 			$this->db->rollBack();
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new Exception(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new Exception(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		return $row;
@@ -83,12 +95,12 @@ class Row2Mapper {
 		if (count($rows) === 0) {
 			$e = new Exception('Wanted row not found.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new NotFoundError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		$e = new Exception('Too many results for one wanted row.');
 		$this->logger->error($e->getMessage(), ['exception' => $e]);
-		throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 	}
 
 	/**
@@ -99,7 +111,7 @@ class Row2Mapper {
 			$rowSleeve = $this->rowSleeveMapper->findNext($offsetId);
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		} catch (DoesNotExistException) {
 			return null;
 		}
@@ -150,10 +162,10 @@ class Row2Mapper {
 			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
 		}
 
-		return array_map(fn (array $item) => $item['id'], $result->fetchAllAssociative());
+		return array_map(fn (array $item) => $item['id'], $result->fetchAll());
 	}
 
 	/**
@@ -180,7 +192,7 @@ class Row2Mapper {
 			return $this->sortRowsByIds($rows, $wantedRowIdsArray);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -211,6 +223,8 @@ class Row2Mapper {
 	private function getRowsChunk(array $rowIds, array $columnIds): array {
 		$qb = $this->db->getQueryBuilder();
 
+		$columnIds = $this->addRelationColumnIdsForLookupColumns($columnIds);
+
 		$qbSqlForColumnTypes = null;
 		foreach ($this->columnsHelper->columns as $columnType) {
 			$qbTmp = $this->db->getQueryBuilder();
@@ -226,6 +240,9 @@ class Row2Mapper {
 				$qbTmp->selectAlias($qbTmp->createFunction('NULL'), 'value_type');
 			}
 
+			if ($this->isVirtualColumn($columnType)) {
+				continue;
+			}
 			$qbTmp
 				->from('tables_row_cells_' . $columnType)
 				->where($qb->expr()->in('column_id', $qb->createNamedParameter($columnIds, IQueryBuilder::PARAM_INT_ARRAY, ':columnIds')))
@@ -249,14 +266,14 @@ class Row2Mapper {
 			$result = $qb->executeQuery();
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
 		}
 
 		try {
 			$sleeves = $this->rowSleeveMapper->findMultiple($rowIds);
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		return $this->parseEntities($result, $sleeves);
@@ -342,7 +359,7 @@ class Row2Mapper {
 	private function replacePlaceholderValues(array &$filters, string $userId): void {
 		foreach ($filters as &$filterGroup) {
 			foreach ($filterGroup as &$filter) {
-				if (str_starts_with((string)$filter['value'], '@')) {
+				if (str_starts_with($filter['value'], '@')) {
 					$columnId = (int)($filter['columnId'] ?? 0);
 					$column = $columnId > 0 ? $this->columnMapper->find($columnId) : null;
 					$filter['value'] = $this->columnsHelper->resolveSearchValue($filter['value'], $userId, $column);
@@ -397,7 +414,7 @@ class Row2Mapper {
 			} else {
 				$e = new Exception('Needed column (' . $columnId . ') not found.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 			}
 			$filterExpressions[] = $sql;
 		}
@@ -413,7 +430,7 @@ class Row2Mapper {
 			$value = $this->getCellMapper($column)->filterValueToQueryParam($column, $value);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error('Cannot filter, because the column does not exist', ['exception' => $e]);
-			throw new InternalError(static::class . '::' . __FUNCTION__ . ': Cannot filter, because the column does not exist');
+			throw new InternalError(get_class($this) . '::' . __FUNCTION__ . ': Cannot filter, because the column does not exist');
 		}
 
 		// We try to match the requested value against the default before building the query
@@ -433,12 +450,12 @@ class Row2Mapper {
 
 		switch ($operator) {
 			case 'begins-with':
-				$includeDefault = str_starts_with((string)($defaultValue ?? ''), (string)$value);
-				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
+				$includeDefault = str_starts_with((string)($defaultValue ?? ''), $value);
+				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'ends-with':
-				$includeDefault = str_ends_with((string)($defaultValue ?? ''), (string)$value);
-				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
+				$includeDefault = str_ends_with((string)($defaultValue ?? ''), $value);
+				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
 				break;
 			case 'contains':
 				$filterExpressions = [];
@@ -465,18 +482,18 @@ class Row2Mapper {
 					break;
 				}
 
-				$includeDefault = str_contains((string)($defaultValue ?? ''), (string)$value);
+				$includeDefault = str_contains((string)($defaultValue ?? ''), $value);
 				if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
 					$value = str_replace(['"', '\''], '', $value);
 					$filterExpression = $qb2->expr()->orX(
-						$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
-						$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
-						$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
-						$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
+						$qb->expr()->like('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
+						$qb->expr()->like('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
+						$qb->expr()->like('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
+						$qb->expr()->like('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
 					);
 					break;
 				}
-				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'does-not-contain':
 				if (is_array($value) && $column->getType() === Column::TYPE_USERGROUP) {
@@ -510,18 +527,18 @@ class Row2Mapper {
 							$qb->expr()->notIn('sl3.id', $qb->createFunction($qb2->getSQL()))
 						);
 				}
-				$includeDefault = !str_contains((string)($defaultValue ?? ''), (string)$value);
+				$includeDefault = !str_contains((string)($defaultValue ?? ''), $value);
 				if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
 					$value = str_replace(['"', '\''], '', $value);
 					$filterExpression = $qb2->expr()->andX(
-						$this->notILike($qb, 'value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
-						$this->notILike($qb, 'value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
-						$this->notILike($qb, 'value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
-						$this->notILike($qb, 'value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
+						$qb->expr()->notLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
+						$qb->expr()->notLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
+						$qb->expr()->notLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
+						$qb->expr()->notLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
 					);
 					break;
 				}
-				$filterExpression = $this->notILike($qb, 'value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+				$filterExpression = $qb->expr()->notLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'is-equal':
 				$includeDefault = $defaultValue === $value;
@@ -590,28 +607,24 @@ class Row2Mapper {
 		$qb2->select('id');
 		$qb2->from('tables_row_sleeves');
 
-		match ($columnId) {
-			Column::TYPE_META_ID => $qb2->where($this->getSqlOperator($operator, $qb, 'id', (int)$value, IQueryBuilder::PARAM_INT)),
-			Column::TYPE_META_CREATED_BY => $qb2->where($this->getSqlOperator($operator, $qb, 'created_by', $value, IQueryBuilder::PARAM_STR)),
-			Column::TYPE_META_CREATED_AT => $qb2->where($this->getSqlOperator($operator, $qb, 'created_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE)),
-			Column::TYPE_META_UPDATED_BY => $qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_by', $value, IQueryBuilder::PARAM_STR)),
-			Column::TYPE_META_UPDATED_AT => $qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE)),
-			default => $qb2,
-		};
-		return $qb2;
-	}
-
-	/**
-	 * Helper method to use notILike if available, otherwise fall back to not(iLike(...))
-	 */
-	private function notILike(IQueryBuilder $qb, string $column, \OCP\DB\QueryBuilder\IParameter $parameter): string {
-		$expr = $qb->expr();
-		// Nextcloud v35 introduced shortcut method
-		if (method_exists($expr, 'notILike')) {
-			return $expr->notILike($column, $parameter);
+		switch ($columnId) {
+			case Column::TYPE_META_ID:
+				$qb2->where($this->getSqlOperator($operator, $qb, 'id', (int)$value, IQueryBuilder::PARAM_INT));
+				break;
+			case Column::TYPE_META_CREATED_BY:
+				$qb2->where($this->getSqlOperator($operator, $qb, 'created_by', $value, IQueryBuilder::PARAM_STR));
+				break;
+			case Column::TYPE_META_CREATED_AT:
+				$qb2->where($this->getSqlOperator($operator, $qb, 'created_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE));
+				break;
+			case Column::TYPE_META_UPDATED_BY:
+				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_by', $value, IQueryBuilder::PARAM_STR));
+				break;
+			case Column::TYPE_META_UPDATED_AT:
+				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE));
+				break;
 		}
-
-		return 'NOT (' . $expr->iLike($column, $parameter) . ')';
+		return $qb2;
 	}
 
 	/**
@@ -624,20 +637,32 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	private function getSqlOperator(string $operator, IQueryBuilder $qb, string $columnName, $value, $paramType): string {
-		return match ($operator) {
-			'begins-with' => $qb->expr()->iLike($columnName, $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType)),
-			'ends-with' => $qb->expr()->iLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType)),
-			'contains' => $qb->expr()->iLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType)),
-			'does-not-contain' => $this->notILike($qb, $columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType)),
-			'is-equal' => $qb->expr()->eq($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-not-equal' => $qb->expr()->neq($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-greater-than' => $qb->expr()->gt($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-greater-than-or-equal' => $qb->expr()->gte($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-lower-than' => $qb->expr()->lt($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-lower-than-or-equal' => $qb->expr()->lte($columnName, $qb->createNamedParameter($value, $paramType)),
-			'is-empty' => $qb->expr()->isNull($columnName),
-			default => throw new InternalError('Operator ' . $operator . ' is not supported.'),
-		};
+		switch ($operator) {
+			case 'begins-with':
+				return $qb->expr()->like($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
+			case 'ends-with':
+				return $qb->expr()->like($columnName, $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
+			case 'contains':
+				return $qb->expr()->like($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+			case 'does-not-contain':
+				return $qb->expr()->notLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+			case 'is-equal':
+				return $qb->expr()->eq($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-not-equal':
+				return $qb->expr()->neq($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-greater-than':
+				return $qb->expr()->gt($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-greater-than-or-equal':
+				return $qb->expr()->gte($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-lower-than':
+				return $qb->expr()->lt($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-lower-than-or-equal':
+				return $qb->expr()->lte($columnName, $qb->createNamedParameter($value, $paramType));
+			case 'is-empty':
+				return $qb->expr()->isNull($columnName);
+			default:
+				throw new InternalError('Operator ' . $operator . ' is not supported.');
+		}
 	}
 
 	/**
@@ -663,7 +688,7 @@ class Row2Mapper {
 		$keyToRowId = [];
 		$cellMapperCache = [];
 
-		while ($rowData = $result->fetchAssociative()) {
+		while ($rowData = $result->fetch()) {
 			if (!isset($rowData['row_id'], $rows[$rowData['row_id']])) {
 				break;
 			}
@@ -753,7 +778,7 @@ class Row2Mapper {
 			$this->rowSleeveMapper->update($sleeve);
 		} catch (DoesNotExistException|MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		$this->columnMapper->preloadColumns(array_column($changedCells, 'columnId'));
@@ -820,7 +845,11 @@ class Row2Mapper {
 			$column = $this->columnMapper->find($columnId);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error('Can not insert cell, because the given column-id is not known', ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		}
+
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
 		}
 
 		// insert new cell
@@ -861,6 +890,10 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	private function updateCell(RowCellSuper $cell, RowCellMapperSuper $mapper, $value, Column $column): void {
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
+
 		$this->getCellMapper($column)->applyDataToEntity($column, $cell, $value);
 		$this->updateMetaData($cell);
 		$mapper->updateWrapper($cell);
@@ -871,10 +904,13 @@ class Row2Mapper {
 	 */
 	private function insertOrUpdateCell(int $rowId, int $columnId, $value): void {
 		$column = $this->columnMapper->find($columnId);
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
 		$cellMapper = $this->getCellMapper($column);
 		try {
 			if ($cellMapper->hasMultipleValues()) {
-				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value): void {
+				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value) {
 					// For a usergroup field with mutiple values, each is inserted as a new cell
 					// we need to delete all previous cells for this row and column, otherwise we get duplicates
 					$cellMapper->deleteAllForColumnAndRow($columnId, $rowId);
@@ -888,7 +924,7 @@ class Row2Mapper {
 			$this->insertCell($rowId, $columnId, $value);
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -897,13 +933,16 @@ class Row2Mapper {
 	}
 
 	private function getCellMapperFromType(string $columnType): RowCellMapperSuper {
+		if ($this->isVirtualColumn($columnType)) {
+			throw new InternalError('Virtual columns do not have cell mappers');
+		}
 		$cellMapperClassName = 'OCA\Tables\Db\RowCell' . ucfirst($columnType) . 'Mapper';
 		/** @var RowCellMapperSuper $cellMapper */
 		try {
 			return Server::get($cellMapperClassName);
 		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -918,11 +957,14 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	public function deleteDataForColumn(Column $column): void {
+		if ($this->isVirtualColumn($column->getType())) {
+			return;
+		}
 		try {
 			$this->getCellMapper($column)->deleteAllForColumn($column->getId());
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -951,55 +993,45 @@ class Row2Mapper {
 	}
 
 	/**
-	 * @param int[] $tableIds
-	 * @return array<int, int>
-	 */
-	public function countRowsForTables(array $tableIds): array {
-		return $this->rowSleeveMapper->countRowsByTableIds($tableIds);
-	}
-
-	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int
 	 */
 	public function countRowsForView(View $view, string $userId): int {
 		$filter = $view->getFilterArray();
-
-		if (empty($filter)) {
-			return $this->countRowsForTable($view->getTableId());
-		}
-
 		try {
-			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter);
+			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter, $view->getSortArray());
 
-			$qb = $this->db->getQueryBuilder();
-			$qb->select($qb->func()->count('*', 'counter'))
-				->from('tables_row_sleeves', 'sleeves')
-				->where($qb->expr()->eq('table_id', $qb->createNamedParameter($view->getTableId(), IQueryBuilder::PARAM_INT)));
-
-			$this->addFilterToQuery($qb, $filter, $userId);
-
-			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
-			$count = (int)$result->fetchOne();
-			$result->closeCursor();
-			return $count;
-		} catch (InternalError|Exception $e) {
+			$rowIds = $this->getWantedRowIds($userId, $view->getTableId(), $filter);
+		} catch (InternalError $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			return 0;
+			$rowIds = [];
 		}
+		return count($rowIds);
 	}
 
 	private function getFormattedDefaultValue(Column $column) {
 		$defaultValue = null;
-		$defaultValue = match ($column->getType()) {
-			Column::TYPE_SELECTION => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getSelectionDefault()),
-			Column::TYPE_DATETIME => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getDatetimeDefault()),
-			Column::TYPE_NUMBER => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getNumberDefault()),
-			Column::TYPE_TEXT => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getTextDefault()),
-			Column::TYPE_USERGROUP => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getUsergroupDefault()),
-			default => $defaultValue,
-		};
+		switch ($column->getType()) {
+			case Column::TYPE_SELECTION:
+				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getSelectionDefault());
+				break;
+			case Column::TYPE_DATETIME:
+				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getDatetimeDefault());
+				break;
+			case Column::TYPE_NUMBER:
+				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getNumberDefault());
+				break;
+			case Column::TYPE_TEXT:
+				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getTextDefault());
+				break;
+			case Column::TYPE_USERGROUP:
+				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getUsergroupDefault());
+				break;
+			case Column::TYPE_RELATION_LOOKUP:
+				$defaultValue = null;
+				break;
+		}
 		return $defaultValue;
 	}
 
@@ -1026,4 +1058,26 @@ class Row2Mapper {
 
 		return $sortedRows;
 	}
+
+	public function isVirtualColumn(string $columnType): bool {
+		return $columnType === Column::TYPE_RELATION_LOOKUP;
+	}
+
+	/**
+	 * @param int[] $columnIds
+	 * @return int[]
+	 */
+	public function addRelationColumnIdsForLookupColumns(array $columnIds): array {
+		$allColumns = $this->columnMapper->findAll($columnIds);
+		foreach ($allColumns as $column) {
+			if ($column->getType() !== Column::TYPE_RELATION_LOOKUP) {
+				continue;
+			}
+
+			$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+			$columnIds[] = $settings->relationColumnId;
+		}
+		return array_values(array_unique(array_filter($columnIds)));
+	}
+
 }

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -33,23 +33,15 @@ class Row2Mapper {
 
 	private const DB_CHUNK_SIZE = 1_000;
 
-	private RowSleeveMapper $rowSleeveMapper;
-	private ?string $userId;
-	private IDBConnection $db;
-	private LoggerInterface $logger;
-	protected UserHelper $userHelper;
-	protected ColumnMapper $columnMapper;
-
-	private ColumnsHelper $columnsHelper;
-
-	public function __construct(?string $userId, IDBConnection $db, LoggerInterface $logger, UserHelper $userHelper, RowSleeveMapper $rowSleeveMapper, ColumnsHelper $columnsHelper, ColumnMapper $columnMapper) {
-		$this->rowSleeveMapper = $rowSleeveMapper;
-		$this->userId = $userId;
-		$this->db = $db;
-		$this->logger = $logger;
-		$this->userHelper = $userHelper;
-		$this->columnsHelper = $columnsHelper;
-		$this->columnMapper = $columnMapper;
+	public function __construct(
+		private ?string $userId,
+		private IDBConnection $db,
+		private LoggerInterface $logger,
+		protected UserHelper $userHelper,
+		private RowSleeveMapper $rowSleeveMapper,
+		private ColumnsHelper $columnsHelper,
+		protected ColumnMapper $columnMapper,
+	) {
 	}
 
 	/**
@@ -71,7 +63,7 @@ class Row2Mapper {
 		} catch (Throwable $e) {
 			$this->db->rollBack();
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new Exception(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new Exception(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		return $row;
@@ -95,12 +87,12 @@ class Row2Mapper {
 		if (count($rows) === 0) {
 			$e = new Exception('Wanted row not found.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new NotFoundError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		$e = new Exception('Too many results for one wanted row.');
 		$this->logger->error($e->getMessage(), ['exception' => $e]);
-		throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 	}
 
 	/**
@@ -111,7 +103,7 @@ class Row2Mapper {
 			$rowSleeve = $this->rowSleeveMapper->findNext($offsetId);
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		} catch (DoesNotExistException) {
 			return null;
 		}
@@ -162,10 +154,10 @@ class Row2Mapper {
 			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
 		}
 
-		return array_map(fn (array $item) => $item['id'], $result->fetchAll());
+		return array_map(fn (array $item) => $item['id'], $result->fetchAllAssociative());
 	}
 
 	/**
@@ -192,7 +184,7 @@ class Row2Mapper {
 			return $this->sortRowsByIds($rows, $wantedRowIdsArray);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -266,14 +258,14 @@ class Row2Mapper {
 			$result = $qb->executeQuery();
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage(), );
 		}
 
 		try {
 			$sleeves = $this->rowSleeveMapper->findMultiple($rowIds);
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		return $this->parseEntities($result, $sleeves);
@@ -359,7 +351,7 @@ class Row2Mapper {
 	private function replacePlaceholderValues(array &$filters, string $userId): void {
 		foreach ($filters as &$filterGroup) {
 			foreach ($filterGroup as &$filter) {
-				if (str_starts_with($filter['value'], '@')) {
+				if (str_starts_with((string)$filter['value'], '@')) {
 					$columnId = (int)($filter['columnId'] ?? 0);
 					$column = $columnId > 0 ? $this->columnMapper->find($columnId) : null;
 					$filter['value'] = $this->columnsHelper->resolveSearchValue($filter['value'], $userId, $column);
@@ -414,7 +406,7 @@ class Row2Mapper {
 			} else {
 				$e = new Exception('Needed column (' . $columnId . ') not found.');
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+				throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 			}
 			$filterExpressions[] = $sql;
 		}
@@ -430,7 +422,7 @@ class Row2Mapper {
 			$value = $this->getCellMapper($column)->filterValueToQueryParam($column, $value);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error('Cannot filter, because the column does not exist', ['exception' => $e]);
-			throw new InternalError(get_class($this) . '::' . __FUNCTION__ . ': Cannot filter, because the column does not exist');
+			throw new InternalError(static::class . '::' . __FUNCTION__ . ': Cannot filter, because the column does not exist');
 		}
 
 		// We try to match the requested value against the default before building the query
@@ -450,12 +442,12 @@ class Row2Mapper {
 
 		switch ($operator) {
 			case 'begins-with':
-				$includeDefault = str_starts_with((string)($defaultValue ?? ''), $value);
-				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
+				$includeDefault = str_starts_with((string)($defaultValue ?? ''), (string)$value);
+				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'ends-with':
-				$includeDefault = str_ends_with((string)($defaultValue ?? ''), $value);
-				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
+				$includeDefault = str_ends_with((string)($defaultValue ?? ''), (string)$value);
+				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
 				break;
 			case 'contains':
 				$filterExpressions = [];
@@ -482,18 +474,18 @@ class Row2Mapper {
 					break;
 				}
 
-				$includeDefault = str_contains((string)($defaultValue ?? ''), $value);
+				$includeDefault = str_contains((string)($defaultValue ?? ''), (string)$value);
 				if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
 					$value = str_replace(['"', '\''], '', $value);
 					$filterExpression = $qb2->expr()->orX(
-						$qb->expr()->like('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
-						$qb->expr()->like('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
-						$qb->expr()->like('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
-						$qb->expr()->like('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
+						$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
+						$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
+						$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
+						$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
 					);
 					break;
 				}
-				$filterExpression = $qb->expr()->like('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'does-not-contain':
 				if (is_array($value) && $column->getType() === Column::TYPE_USERGROUP) {
@@ -527,18 +519,18 @@ class Row2Mapper {
 							$qb->expr()->notIn('sl3.id', $qb->createFunction($qb2->getSQL()))
 						);
 				}
-				$includeDefault = !str_contains((string)($defaultValue ?? ''), $value);
+				$includeDefault = !str_contains((string)($defaultValue ?? ''), (string)$value);
 				if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
 					$value = str_replace(['"', '\''], '', $value);
 					$filterExpression = $qb2->expr()->andX(
-						$qb->expr()->notLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
-						$qb->expr()->notLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
-						$qb->expr()->notLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
-						$qb->expr()->notLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
+						$this->notILike($qb, 'value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ']')),
+						$this->notILike($qb, 'value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($value) . ',%')),
+						$this->notILike($qb, 'value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ']%')),
+						$this->notILike($qb, 'value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($value) . ',%'))
 					);
 					break;
 				}
-				$filterExpression = $qb->expr()->notLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+				$filterExpression = $this->notILike($qb, 'value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
 			case 'is-equal':
 				$includeDefault = $defaultValue === $value;
@@ -607,24 +599,28 @@ class Row2Mapper {
 		$qb2->select('id');
 		$qb2->from('tables_row_sleeves');
 
-		switch ($columnId) {
-			case Column::TYPE_META_ID:
-				$qb2->where($this->getSqlOperator($operator, $qb, 'id', (int)$value, IQueryBuilder::PARAM_INT));
-				break;
-			case Column::TYPE_META_CREATED_BY:
-				$qb2->where($this->getSqlOperator($operator, $qb, 'created_by', $value, IQueryBuilder::PARAM_STR));
-				break;
-			case Column::TYPE_META_CREATED_AT:
-				$qb2->where($this->getSqlOperator($operator, $qb, 'created_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE));
-				break;
-			case Column::TYPE_META_UPDATED_BY:
-				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_by', $value, IQueryBuilder::PARAM_STR));
-				break;
-			case Column::TYPE_META_UPDATED_AT:
-				$qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE));
-				break;
-		}
+		match ($columnId) {
+			Column::TYPE_META_ID => $qb2->where($this->getSqlOperator($operator, $qb, 'id', (int)$value, IQueryBuilder::PARAM_INT)),
+			Column::TYPE_META_CREATED_BY => $qb2->where($this->getSqlOperator($operator, $qb, 'created_by', $value, IQueryBuilder::PARAM_STR)),
+			Column::TYPE_META_CREATED_AT => $qb2->where($this->getSqlOperator($operator, $qb, 'created_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE)),
+			Column::TYPE_META_UPDATED_BY => $qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_by', $value, IQueryBuilder::PARAM_STR)),
+			Column::TYPE_META_UPDATED_AT => $qb2->where($this->getSqlOperator($operator, $qb, 'last_edit_at', new DateTimeImmutable($value), IQueryBuilder::PARAM_DATE)),
+			default => $qb2,
+		};
 		return $qb2;
+	}
+
+	/**
+	 * Helper method to use notILike if available, otherwise fall back to not(iLike(...))
+	 */
+	private function notILike(IQueryBuilder $qb, string $column, \OCP\DB\QueryBuilder\IParameter $parameter): string {
+		$expr = $qb->expr();
+		// Nextcloud v35 introduced shortcut method
+		if (method_exists($expr, 'notILike')) {
+			return $expr->notILike($column, $parameter);
+		}
+
+		return 'NOT (' . $expr->iLike($column, $parameter) . ')';
 	}
 
 	/**
@@ -637,32 +633,20 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	private function getSqlOperator(string $operator, IQueryBuilder $qb, string $columnName, $value, $paramType): string {
-		switch ($operator) {
-			case 'begins-with':
-				return $qb->expr()->like($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType));
-			case 'ends-with':
-				return $qb->expr()->like($columnName, $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
-			case 'contains':
-				return $qb->expr()->like($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
-			case 'does-not-contain':
-				return $qb->expr()->notLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
-			case 'is-equal':
-				return $qb->expr()->eq($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-not-equal':
-				return $qb->expr()->neq($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-greater-than':
-				return $qb->expr()->gt($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-greater-than-or-equal':
-				return $qb->expr()->gte($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-lower-than':
-				return $qb->expr()->lt($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-lower-than-or-equal':
-				return $qb->expr()->lte($columnName, $qb->createNamedParameter($value, $paramType));
-			case 'is-empty':
-				return $qb->expr()->isNull($columnName);
-			default:
-				throw new InternalError('Operator ' . $operator . ' is not supported.');
-		}
+		return match ($operator) {
+			'begins-with' => $qb->expr()->iLike($columnName, $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType)),
+			'ends-with' => $qb->expr()->iLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value), $paramType)),
+			'contains' => $qb->expr()->iLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType)),
+			'does-not-contain' => $this->notILike($qb, $columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType)),
+			'is-equal' => $qb->expr()->eq($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-not-equal' => $qb->expr()->neq($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-greater-than' => $qb->expr()->gt($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-greater-than-or-equal' => $qb->expr()->gte($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-lower-than' => $qb->expr()->lt($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-lower-than-or-equal' => $qb->expr()->lte($columnName, $qb->createNamedParameter($value, $paramType)),
+			'is-empty' => $qb->expr()->isNull($columnName),
+			default => throw new InternalError('Operator ' . $operator . ' is not supported.'),
+		};
 	}
 
 	/**
@@ -688,16 +672,14 @@ class Row2Mapper {
 		$keyToRowId = [];
 		$cellMapperCache = [];
 
-		while ($rowData = $result->fetch()) {
+		while ($rowData = $result->fetchAssociative()) {
 			if (!isset($rowData['row_id'], $rows[$rowData['row_id']])) {
 				break;
 			}
 
 			$column = $this->columnMapper->find($rowData['column_id']);
 			$columnType = $column->getType();
-			if (!isset($cellMapperCache[$columnType])) {
-				$cellMapperCache[$columnType] = $this->getCellMapperFromType($columnType);
-			}
+			$cellMapperCache[$columnType] ??= $this->getCellMapperFromType($columnType);
 			$value = $cellMapperCache[$columnType]->formatRowData($column, $rowData);
 			$compositeKey = (string)$rowData['row_id'] . ',' . (string)$rowData['column_id'];
 			if ($cellMapperCache[$columnType]->hasMultipleValues()) {
@@ -778,7 +760,7 @@ class Row2Mapper {
 			$this->rowSleeveMapper->update($sleeve);
 		} catch (DoesNotExistException|MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		$this->columnMapper->preloadColumns(array_column($changedCells, 'columnId'));
@@ -845,7 +827,7 @@ class Row2Mapper {
 			$column = $this->columnMapper->find($columnId);
 		} catch (DoesNotExistException $e) {
 			$this->logger->error('Can not insert cell, because the given column-id is not known', ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
 		if ($this->isVirtualColumn($column->getType())) {
@@ -910,7 +892,7 @@ class Row2Mapper {
 		$cellMapper = $this->getCellMapper($column);
 		try {
 			if ($cellMapper->hasMultipleValues()) {
-				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value) {
+				$this->atomic(function () use ($cellMapper, $rowId, $columnId, $value): void {
 					// For a usergroup field with mutiple values, each is inserted as a new cell
 					// we need to delete all previous cells for this row and column, otherwise we get duplicates
 					$cellMapper->deleteAllForColumnAndRow($columnId, $rowId);
@@ -924,7 +906,7 @@ class Row2Mapper {
 			$this->insertCell($rowId, $columnId, $value);
 		} catch (MultipleObjectsReturnedException|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -942,7 +924,7 @@ class Row2Mapper {
 			return Server::get($cellMapperClassName);
 		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -964,7 +946,7 @@ class Row2Mapper {
 			$this->getCellMapper($column)->deleteAllForColumn($column->getId());
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			throw new InternalError(static::class . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 	}
 
@@ -993,45 +975,56 @@ class Row2Mapper {
 	}
 
 	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function countRowsForTables(array $tableIds): array {
+		return $this->rowSleeveMapper->countRowsByTableIds($tableIds);
+	}
+
+	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int
 	 */
 	public function countRowsForView(View $view, string $userId): int {
 		$filter = $view->getFilterArray();
-		try {
-			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter, $view->getSortArray());
 
-			$rowIds = $this->getWantedRowIds($userId, $view->getTableId(), $filter);
-		} catch (InternalError $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			$rowIds = [];
+		if (empty($filter)) {
+			return $this->countRowsForTable($view->getTableId());
 		}
-		return count($rowIds);
+
+		try {
+			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter);
+
+			$qb = $this->db->getQueryBuilder();
+			$qb->select($qb->func()->count('*', 'counter'))
+				->from('tables_row_sleeves', 'sleeves')
+				->where($qb->expr()->eq('table_id', $qb->createNamedParameter($view->getTableId(), IQueryBuilder::PARAM_INT)));
+
+			$this->addFilterToQuery($qb, $filter, $userId);
+
+			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
+			$count = (int)$result->fetchOne();
+			$result->closeCursor();
+			return $count;
+		} catch (InternalError|Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			return 0;
+		}
 	}
 
 	private function getFormattedDefaultValue(Column $column) {
 		$defaultValue = null;
-		switch ($column->getType()) {
-			case Column::TYPE_SELECTION:
-				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getSelectionDefault());
-				break;
-			case Column::TYPE_DATETIME:
-				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getDatetimeDefault());
-				break;
-			case Column::TYPE_NUMBER:
-				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getNumberDefault());
-				break;
-			case Column::TYPE_TEXT:
-				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getTextDefault());
-				break;
-			case Column::TYPE_USERGROUP:
-				$defaultValue = $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getUsergroupDefault());
-				break;
-			case Column::TYPE_RELATION_LOOKUP:
-				$defaultValue = null;
-				break;
-		}
+		$defaultValue = match ($column->getType()) {
+			Column::TYPE_SELECTION => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getSelectionDefault()),
+			Column::TYPE_DATETIME => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getDatetimeDefault()),
+			Column::TYPE_NUMBER => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getNumberDefault()),
+			Column::TYPE_TEXT => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getTextDefault()),
+			Column::TYPE_USERGROUP => $this->getCellMapper($column)->filterValueToQueryParam($column, $column->getUsergroupDefault()),
+			Column::TYPE_RELATION_LOOKUP => null,
+			default => $defaultValue,
+		};
 		return $defaultValue;
 	}
 

--- a/lib/Dto/RelationLookupSettings.php
+++ b/lib/Dto/RelationLookupSettings.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Dto;
+
+readonly class RelationLookupSettings {
+	public function __construct(
+		public int $relationColumnId,
+		public int $targetColumnId,
+	) {
+	}
+
+	public static function fromArray(array $data): self {
+		return new self(
+			relationColumnId: (int)$data['relationColumnId'],
+			targetColumnId: (int)$data['targetColumnId'],
+		);
+	}
+}

--- a/lib/Dto/RelationSettings.php
+++ b/lib/Dto/RelationSettings.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Dto;
+
+readonly class RelationSettings {
+	public function __construct(
+		public string $relationType,
+		public int $targetId,
+		public int $labelColumn,
+	) {
+	}
+
+	public static function fromArray(array $data): self {
+		return new self(
+			relationType: $data['relationType'],
+			targetId: (int)$data['targetId'],
+			labelColumn: (int)$data['labelColumn'],
+		);
+	}
+
+	public function isView(): bool {
+		return $this->relationType === 'view';
+	}
+}

--- a/lib/Helper/ColumnsHelper.php
+++ b/lib/Helper/ColumnsHelper.php
@@ -21,6 +21,7 @@ class ColumnsHelper {
 		Column::TYPE_SELECTION,
 		Column::TYPE_USERGROUP,
 		Column::TYPE_RELATION,
+		Column::TYPE_RELATION_LOOKUP,
 	];
 
 	/**

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -243,6 +243,8 @@ namespace OCA\Tables;
  *     notify-column: bool,
  *     notify-row: bool,
  * }
+ *
+ * @psalm-type TablesRelationData = list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>
  */
 class ResponseDefinitions {
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -238,6 +238,8 @@ namespace OCA\Tables;
  *     notify-column: bool,
  *     notify-row: bool,
  * }
+ *
+ * @psalm-type TablesRelationData = list<array{column: ?TablesColumn, values: list<array{id: int, value: mixed}>}>
  */
 class ResponseDefinitions {
 }

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -655,6 +655,11 @@ class ColumnService extends SuperService {
 		foreach ($titles as $title) {
 			$i++;
 			foreach ($allColumns as $column) {
+				// Skip matching columns with type relation_lookup
+				if ($column->getType() === Column::TYPE_RELATION_LOOKUP) {
+					continue;
+				}
+
 				if ($column->getTitle() === $title) {
 					$result[$i] = $column;
 					$countMatchingColumns++;

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -631,6 +631,11 @@ class ColumnService extends SuperService {
 		foreach ($titles as $title) {
 			$i++;
 			foreach ($allColumns as $column) {
+				// Skip matching columns with type relation_lookup
+				if ($column->getType() === Column::TYPE_RELATION_LOOKUP) {
+					continue;
+				}
+
 				if ($column->getTitle() === $title) {
 					$result[$i] = $column;
 					$countMatchingColumns++;

--- a/lib/Service/ColumnTypes/RelationBusiness.php
+++ b/lib/Service/ColumnTypes/RelationBusiness.php
@@ -12,7 +12,7 @@ use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Service\RelationService;
 use Psr\Log\LoggerInterface;
 
-class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class RelationBusiness extends SuperBusiness {
 
 	public function __construct(
 		LoggerInterface $logger,
@@ -34,7 +34,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 		$relationData = $this->relationService->getRelationData($column);
 		// try to find value by label
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return json_encode(reset($matchingRelation)['id']);
 		}
@@ -63,7 +63,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 		$relationData = $this->relationService->getRelationData($column);
 		// try to find value by label
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return true;
 		}
@@ -83,7 +83,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 		$relationData = $this->relationService->getRelationData($column);
 
 		// Try to find value by label first
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return;
 		}

--- a/lib/Service/ColumnTypes/RelationBusiness.php
+++ b/lib/Service/ColumnTypes/RelationBusiness.php
@@ -12,7 +12,7 @@ use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Service\RelationService;
 use Psr\Log\LoggerInterface;
 
-class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class RelationBusiness extends SuperBusiness {
 
 	public function __construct(
 		LoggerInterface $logger,
@@ -35,7 +35,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 		$relationData = $this->relationService->getRelationData($column);
 		// try to find value by label
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return json_encode(reset($matchingRelation)['id']);
 		}
@@ -64,7 +64,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 		$relationData = $this->relationService->getRelationData($column);
 		// try to find value by label
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return true;
 		}
@@ -84,7 +84,7 @@ class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
 		$relationData = $this->relationService->getRelationData($column);
 
 		// Try to find value by label first
-		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['label'] === $value);
+		$matchingRelation = array_filter($relationData, fn (array $relation) => $relation['value'] === $value);
 		if (!empty($matchingRelation)) {
 			return;
 		}

--- a/lib/Service/ColumnTypes/RelationLookupBusiness.php
+++ b/lib/Service/ColumnTypes/RelationLookupBusiness.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Service\ColumnTypes;
+
+use OCA\Tables\Db\Column;
+
+class RelationLookupBusiness extends SuperBusiness {
+	/**
+	 * @param mixed $value (array|string|null)
+	 * @param Column|null $column
+	 * @return string
+	 */
+	public function parseValue($value, ?Column $column = null): string {
+		// Relation lookup is a virtual column, values come from the related table
+		// No parsing needed for input as this column is read-only
+		return '';
+	}
+
+	/**
+	 * @param mixed $value (array|string|null)
+	 * @param Column|null $column
+	 * @return bool
+	 */
+	public function canBeParsed($value, ?Column $column = null): bool {
+		// Virtual column, cannot be set directly
+		return false;
+	}
+
+	public function validateValue(mixed $value, Column $column, string $userId, int $tableId, ?int $rowId): void {
+		// Virtual column, validation not applicable
+		// Values are derived from the relation column
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param Column $column
+	 * @return bool
+	 */
+	public function canBeParsedDisplayValue($value, Column $column): bool {
+		// Virtual column, display values come from relation data
+		return false;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param Column $column
+	 * @return string
+	 */
+	public function parseDisplayValue($value, Column $column): string {
+		// Virtual column, display values come from relation data
+		return '';
+	}
+}

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -9,13 +9,22 @@ namespace OCA\Tables\Service;
 
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
+use OCA\Tables\Db\Row2;
 use OCA\Tables\Db\Row2Mapper;
 use OCA\Tables\Db\ViewMapper;
+use OCA\Tables\Dto\RelationLookupSettings;
+use OCA\Tables\Dto\RelationSettings;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\ResponseDefinitions;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
+/**
+ * @psalm-import-type TablesColumn from ResponseDefinitions
+ */
 class RelationService {
 	/** @var array<string, array> Cache for relation data */
 	private array $cacheRelationData = [];
@@ -25,7 +34,8 @@ class RelationService {
 		private ViewMapper $viewMapper,
 		private Row2Mapper $row2Mapper,
 		private ColumnService $columnService,
-		private ?string $userId,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -33,7 +43,7 @@ class RelationService {
 	 * Get all relation data for a table
 	 *
 	 * @param int $tableId
-	 * @return array Relation data grouped by column ID
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 * @throws NotFoundError
 	 * @throws PermissionError
@@ -42,18 +52,14 @@ class RelationService {
 		// Check table permissions through ColumnService
 		$columns = $this->columnService->findAllByTable($tableId);
 
-		$relationColumns = array_filter($columns, function ($column) {
-			return $column->getType() === Column::TYPE_RELATION;
-		});
-
-		return $this->getRelationsForColumns($relationColumns);
+		return $this->getRelationsForColumnList($columns);
 	}
 
 	/**
 	 * Get all relation data for a view
 	 *
 	 * @param int $viewId
-	 * @return array Relation data grouped by column ID
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 * @throws NotFoundError
 	 * @throws PermissionError
@@ -62,152 +68,344 @@ class RelationService {
 		// Check view permissions through ColumnService
 		$columns = $this->columnService->findAllByView($viewId);
 
-		$relationColumns = array_filter($columns, function ($column) {
-			return $column->getType() === Column::TYPE_RELATION;
-		});
-
-		return $this->getRelationsForColumns($relationColumns);
-	}
-
-	/**
-	 * Get relation data for specific columns
-	 *
-	 * @param Column[] $relationColumns
-	 * @return array Relation data grouped by column ID
-	 * @throws InternalError
-	 */
-	private function getRelationsForColumns(array $relationColumns): array {
-		// Group columns by their target (relationType + targetId + labelColumn)
-		$result = [];
-		$groupedColumns = $this->groupColumnsByTarget($relationColumns);
-		foreach ($groupedColumns as $target => $columns) {
-			$relationData = $this->getRelationDataForTarget($target, $columns[0]);
-
-			// Assign the same data to all columns with this target
-			foreach ($columns as $column) {
-				$result[$column->getId()] = $relationData;
-			}
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Group relation columns by their target configuration
-	 *
-	 * @param Column[] $columns
-	 * @return array
-	 */
-	private function groupColumnsByTarget(array $columns): array {
-		$groups = [];
-
-		foreach ($columns as $column) {
-			$settings = $column->getCustomSettingsArray();
-			if (empty($settings['relationType']) || empty($settings['targetId']) || empty($settings['labelColumn'])) {
-				continue;
-			}
-
-			$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
-			if (!isset($groups[$target])) {
-				$groups[$target] = [];
-			}
-			$groups[$target][] = $column;
-		}
-
-		return $groups;
+		return $this->getRelationsForColumnList($columns);
 	}
 
 	/**
 	 * Get relation data for a specific column
 	 *
 	 * @param Column $column
-	 * @return array<int, array{id: int, label: string}> Indexed per row id
+	 * @return array<int, array{id: int, value: string}> Indexed per row id
 	 */
 	public function getRelationData(Column $column): array {
 		if ($column->getType() !== Column::TYPE_RELATION) {
 			return [];
 		}
 
-		$settings = $column->getCustomSettingsArray();
-		if (empty($settings['relationType']) || empty($settings['targetId']) || empty($settings['labelColumn'])) {
+		try {
+			return $this->fetchRelationValuesForTarget($column);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->warning('Invalid relation settings for column ' . $column->getId() . ': ' . $e->getMessage());
 			return [];
 		}
-
-		$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
-
-		return $this->getRelationDataForTarget($target, $column);
 	}
 
 	/**
-	 * Get relation data for a specific target
+	 * Get relation data for a list of columns
 	 *
-	 * @param string $target
-	 * @param Column $column
-	 * @return array<int, array{id: int, label: string}> Indexed per row id
+	 * @param Column[] $columns
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 */
-	private function getRelationDataForTarget(string $target, Column $column): array {
-		// Check cache first
-		$cacheKey = $target . '_' . ($this->userId ?? 'anonymous');
+	private function getRelationsForColumnList(array $columns): array {
+		$relationColumns = array_filter($columns, fn (Column $column) => $column->getType() === Column::TYPE_RELATION);
+		$relationData = $this->fetchRelationColumns($relationColumns);
+
+		$lookupColumns = array_filter($columns, fn (Column $column) => $column->getType() === Column::TYPE_RELATION_LOOKUP);
+		$relationLookupData = $this->fetchRelationLookupColumns($lookupColumns);
+
+		return array_map(
+			fn (array $data) => ['column' => null, 'values' => $data],
+			$relationData
+		) + $relationLookupData;
+	}
+
+	/**
+	 * Fetch relation data for relation columns
+	 *
+	 * @param Column[] $columns
+	 * @return array<int, array<int, array{id: int, value: string}>> Relation data, indexed per column ID and row ID
+	 * @throws InternalError
+	 */
+	private function fetchRelationColumns(array $columns): array {
+		$result = [];
+		$fetchedTargets = [];
+
+		foreach ($columns as $column) {
+			try {
+				$settings = $column->getCustomSettingsObject(RelationSettings::class);
+				$targetKey = $this->buildRelationCacheKey($settings->relationType, $settings->targetId, $settings->labelColumn);
+
+				if (!isset($fetchedTargets[$targetKey])) {
+					$fetchedTargets[$targetKey] = $this->fetchRelationValuesForTarget($column);
+				}
+
+				$result[$column->getId()] = $fetchedTargets[$targetKey];
+			} catch (\InvalidArgumentException $e) {
+				$this->logger->warning('Invalid relation settings for column ' . $column->getId() . ': ' . $e->getMessage());
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Fetch relation data for relation lookup columns
+	 *
+	 * @param Column[] $columns
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
+	 * @throws InternalError
+	 */
+	private function fetchRelationLookupColumns(array $columns): array {
+		$result = [];
+
+		// Batch fetch all needed columns to avoid duplicate queries
+		$columnIdsToFetch = $this->collectColumnIdsForLookup($columns);
+		$columnsMap = $this->fetchColumnsByIds($columnIdsToFetch);
+
+		foreach ($columns as $column) {
+			try {
+				$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+				$relationColumn = $columnsMap[$settings->relationColumnId] ?? null;
+				$targetColumn = $columnsMap[$settings->targetColumnId] ?? null;
+
+				if (!$relationColumn || !$targetColumn) {
+					continue;
+				}
+
+				$lookupData = $this->fetchLookupValues($settings, $relationColumn);
+				$result[$column->getId()] = [
+					'column' => $targetColumn->jsonSerialize(),
+					'values' => $lookupData,
+				];
+			} catch (\InvalidArgumentException $e) {
+				$this->logger->warning('Invalid relation lookup settings for column ' . $column->getId() . ': ' . $e->getMessage());
+			}
+		}
+
+		return $result;
+	}
+
+	private function getCurrentUserId(): string {
+		$user = $this->userSession->getUser();
+		return $user ? $user->getUID() : 'anonymous';
+	}
+
+	/**
+	 * Fetch relation values for a specific target
+	 *
+	 * @param Column $column
+	 * @return array<int, array{id: int, value: string}> Indexed per row id
+	 * @throws InternalError
+	 */
+	private function fetchRelationValuesForTarget(Column $column): array {
+		$settings = $column->getCustomSettingsObject(RelationSettings::class);
+
+		$cacheKey = $this->buildRelationCacheKey($settings->relationType, $settings->targetId, $settings->labelColumn);
 		if (isset($this->cacheRelationData[$cacheKey])) {
 			return $this->cacheRelationData[$cacheKey];
 		}
 
-		$settings = $column->getCustomSettingsArray();
-		if (empty($settings[Column::RELATION_TYPE]) || empty($settings[Column::RELATION_TARGET_ID]) || empty($settings[Column::RELATION_LABEL_COLUMN])) {
-			$this->cacheRelationData[$cacheKey] = [];
-			return [];
-		}
-
-		$isView = $settings[Column::RELATION_TYPE] === 'view';
-		$targetId = $settings[Column::RELATION_TARGET_ID] ?? null;
-
 		try {
-			$targetColumn = $this->columnMapper->find($settings[Column::RELATION_LABEL_COLUMN]);
-			if ($isView) {
-				$view = $this->viewMapper->find($targetId);
-				$rows = $this->row2Mapper->findAll(
-					[$targetColumn->getId()],
-					$view->getTableId(),
-					null,
-					null,
-					$view->getFilterArray(),
-					$view->getSortArray(),
-					$this->userId
-				);
-			} else {
-				$rows = $this->row2Mapper->findAll(
-					[$targetColumn->getId()],
-					$targetId,
-					null,
-					null,
-					null,
-					null,
-					$this->userId
-				);
-			}
+			$targetColumn = $this->columnMapper->find($settings->labelColumn);
+			$rows = $this->fetchRowsForTarget($settings, [$settings->labelColumn]);
 		} catch (DoesNotExistException $e) {
 			$this->cacheRelationData[$cacheKey] = [];
 			return [];
 		}
 
+		$result = $this->buildRelationValues($rows, $targetColumn, $settings->labelColumn);
+		$this->cacheRelationData[$cacheKey] = $result;
+
+		return $result;
+	}
+
+	/**
+	 * Build a cache key for relation data
+	 */
+	private function buildRelationCacheKey(string $relationType, int $targetId, int $labelColumn): string {
+		return sprintf('%s_%d_%d_%s', $relationType, $targetId, $labelColumn, $this->getCurrentUserId());
+	}
+
+	/**
+	 * Collect all column IDs needed for lookup processing
+	 *
+	 * @param Column[] $columns
+	 * @return int[]
+	 */
+	private function collectColumnIdsForLookup(array $columns): array {
+		$columnIds = [];
+
+		foreach ($columns as $column) {
+			$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+			$columnIds[] = $settings->targetColumnId;
+			$columnIds[] = $settings->relationColumnId;
+		}
+
+		return array_unique($columnIds);
+	}
+
+	/**
+	 * Fetch multiple columns by their IDs in a single batch
+	 *
+	 * @param int[] $columnIds
+	 * @return array<int, Column>
+	 */
+	private function fetchColumnsByIds(array $columnIds): array {
+		if (empty($columnIds)) {
+			return [];
+		}
+
+		try {
+			$columns = $this->columnMapper->findAll($columnIds);
+			$result = [];
+			foreach ($columns as $column) {
+				$result[$column->getId()] = $column;
+			}
+			return $result;
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to fetch columns: ' . $e->getMessage());
+			return [];
+		}
+	}
+
+	/**
+	 * Fetch lookup values for a relation lookup column
+	 *
+	 * @param RelationLookupSettings $settings
+	 * @param Column $relationColumn
+	 * @return array<int, array{id: int, value: mixed}>
+	 */
+	private function fetchLookupValues(RelationLookupSettings $settings, Column $relationColumn): array {
+		$relationSettings = $relationColumn->getCustomSettingsObject(RelationSettings::class);
+
+		$cacheKey = $this->buildRelationCacheKey($relationSettings->relationType, $relationSettings->targetId, $settings->targetColumnId);
+		if (isset($this->cacheRelationData[$cacheKey])) {
+			return $this->cacheRelationData[$cacheKey];
+		}
+
+		try {
+			// Fetch both relation label column and lookup target column in a single query
+			$rows = $this->fetchRowsForTarget($relationSettings, [$relationSettings->labelColumn, $settings->targetColumnId]);
+			$lookupData = $this->buildLookupValues($rows, $relationSettings->labelColumn, $settings->targetColumnId);
+
+			$this->cacheRelationData[$cacheKey] = $lookupData;
+			return $lookupData;
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Failed to fetch lookup data: ' . $e->getMessage());
+			return [];
+		}
+	}
+
+	/**
+	 * Fetch rows for a relation target
+	 *
+	 * @param RelationSettings $settings
+	 * @param int[] $columnIds
+	 * @return Row2[]
+	 * @throws DoesNotExistException
+	 */
+	private function fetchRowsForTarget(RelationSettings $settings, array $columnIds): array {
+		if ($settings->isView()) {
+			$view = $this->viewMapper->find($settings->targetId);
+			return $this->row2Mapper->findAll(
+				$columnIds,
+				$view->getTableId(),
+				null,
+				null,
+				$view->getFilterArray(),
+				$view->getSortArray(),
+				$this->getCurrentUserId()
+			);
+		}
+
+		return $this->row2Mapper->findAll(
+			$columnIds,
+			$settings->targetId,
+			null,
+			null,
+			null,
+			null,
+			$this->getCurrentUserId()
+		);
+	}
+
+	/**
+	 * Build relation values from rows
+	 *
+	 * @param Row2[] $rows
+	 * @param Column $column
+	 * @param int $labelColumnId
+	 * @return array<int, array{id: int, value: string}>
+	 */
+	private function buildRelationValues(array $rows, Column $column, int $labelColumnId): array {
 		$result = [];
+
 		foreach ($rows as $row) {
 			$data = $row->getData();
-			$displayFieldData = array_filter($data, function ($item) use ($settings) {
-				return $item['columnId'] === (int)$settings[Column::RELATION_LABEL_COLUMN];
-			});
+			$displayFieldData = array_filter($data, fn ($item) => $item['columnId'] === $labelColumnId);
 			$value = reset($displayFieldData)['value'] ?? null;
 
-			// Structure compatible with Row2 format: {id: int, label: string}
 			$rowId = (int)$row->getId();
 			$result[$rowId] = [
 				'id' => $rowId,
-				'label' => (string)$value,
+				'value' => $this->formatValue($column, $value),
 			];
 		}
 
-		$this->cacheRelationData[$cacheKey] = $result;
 		return $result;
+	}
+
+	/**
+	 * Build lookup values from rows containing both relation label and target columns
+	 *
+	 * @param Row2[] $rows
+	 * @param int $relationLabelColumnId
+	 * @param int $targetColumnId
+	 * @return array<int, array{id: int, value: mixed}>
+	 */
+	private function buildLookupValues(array $rows, int $relationLabelColumnId, int $targetColumnId): array {
+		$result = [];
+
+		foreach ($rows as $row) {
+			$data = $row->getData();
+			$rowId = (int)$row->getId();
+
+			// Find the relation label value
+			$relationLabelData = array_filter($data, fn ($item) => $item['columnId'] === $relationLabelColumnId);
+			$relationLabelValue = reset($relationLabelData)['value'] ?? null;
+
+			// Find the target column value
+			$targetData = array_filter($data, fn ($item) => $item['columnId'] === $targetColumnId);
+			$targetValue = reset($targetData)['value'] ?? null;
+
+			// Only include if relation label exists (meaning this row is referenced)
+			if ($relationLabelValue !== null && $relationLabelValue !== '') {
+				$result[$rowId] = [
+					'id' => $rowId,
+					'value' => $targetValue,
+				];
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Format a cell value for display as a relation label.
+	 * Relation lookup only supports text-line and number columns.
+	 */
+	private function formatValue(Column $column, mixed $value): string {
+		if ($value === null || $value === '' || $value === []) {
+			return '';
+		}
+
+		return match ($column->getType()) {
+			Column::TYPE_TEXT => trim(strip_tags((string)$value)),
+			Column::TYPE_NUMBER => $this->formatNumberValue($column, $value),
+			default => (string)$value,
+		};
+	}
+
+	private function formatNumberValue(Column $column, mixed $value): string {
+		if ($value === null || $value === '') {
+			return '';
+		}
+		if (!is_numeric($value)) {
+			return (string)$value;
+		}
+		$decimals = $column->getNumberDecimals() ?? 0;
+		$formatted = number_format((float)$value, $decimals, '.', '');
+		return $column->getNumberPrefix() . $formatted . $column->getNumberSuffix();
 	}
 }

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -9,23 +9,33 @@ namespace OCA\Tables\Service;
 
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
+use OCA\Tables\Db\Row2;
 use OCA\Tables\Db\Row2Mapper;
 use OCA\Tables\Db\ViewMapper;
+use OCA\Tables\Dto\RelationLookupSettings;
+use OCA\Tables\Dto\RelationSettings;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
+use OCA\Tables\ResponseDefinitions;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
+/**
+ * @psalm-import-type TablesColumn from ResponseDefinitions
+ */
 class RelationService {
 	/** @var array<string, array> Cache for relation data */
 	private array $cacheRelationData = [];
 
 	public function __construct(
-		private readonly ColumnMapper $columnMapper,
-		private readonly ViewMapper $viewMapper,
-		private readonly Row2Mapper $row2Mapper,
-		private readonly ColumnService $columnService,
-		private readonly ?string $userId,
+		private ColumnMapper $columnMapper,
+		private ViewMapper $viewMapper,
+		private Row2Mapper $row2Mapper,
+		private ColumnService $columnService,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -33,7 +43,7 @@ class RelationService {
 	 * Get all relation data for a table
 	 *
 	 * @param int $tableId
-	 * @return array Relation data grouped by column ID
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 * @throws NotFoundError
 	 * @throws PermissionError
@@ -42,16 +52,14 @@ class RelationService {
 		// Check table permissions through ColumnService
 		$columns = $this->columnService->findAllByTable($tableId);
 
-		$relationColumns = array_filter($columns, fn ($column) => $column->getType() === Column::TYPE_RELATION);
-
-		return $this->getRelationsForColumns($relationColumns);
+		return $this->getRelationsForColumnList($columns);
 	}
 
 	/**
 	 * Get all relation data for a view
 	 *
 	 * @param int $viewId
-	 * @return array Relation data grouped by column ID
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 * @throws NotFoundError
 	 * @throws PermissionError
@@ -60,148 +68,344 @@ class RelationService {
 		// Check view permissions through ColumnService
 		$columns = $this->columnService->findAllByView($viewId);
 
-		$relationColumns = array_filter($columns, fn ($column) => $column->getType() === Column::TYPE_RELATION);
-
-		return $this->getRelationsForColumns($relationColumns);
-	}
-
-	/**
-	 * Get relation data for specific columns
-	 *
-	 * @param Column[] $relationColumns
-	 * @return array Relation data grouped by column ID
-	 * @throws InternalError
-	 */
-	private function getRelationsForColumns(array $relationColumns): array {
-		// Group columns by their target (relationType + targetId + labelColumn)
-		$result = [];
-		$groupedColumns = $this->groupColumnsByTarget($relationColumns);
-		foreach ($groupedColumns as $target => $columns) {
-			$relationData = $this->getRelationDataForTarget($target, $columns[0]);
-
-			// Assign the same data to all columns with this target
-			foreach ($columns as $column) {
-				$result[$column->getId()] = $relationData;
-			}
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Group relation columns by their target configuration
-	 *
-	 * @param Column[] $columns
-	 * @return array
-	 */
-	private function groupColumnsByTarget(array $columns): array {
-		$groups = [];
-
-		foreach ($columns as $column) {
-			$settings = $column->getCustomSettingsArray();
-			if (empty($settings['relationType']) || empty($settings['targetId']) || empty($settings['labelColumn'])) {
-				continue;
-			}
-
-			$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
-			if (!isset($groups[$target])) {
-				$groups[$target] = [];
-			}
-			$groups[$target][] = $column;
-		}
-
-		return $groups;
+		return $this->getRelationsForColumnList($columns);
 	}
 
 	/**
 	 * Get relation data for a specific column
 	 *
 	 * @param Column $column
-	 * @return array<int, array{id: int, label: string}> Indexed per row id
+	 * @return array<int, array{id: int, value: string}> Indexed per row id
 	 */
 	public function getRelationData(Column $column): array {
 		if ($column->getType() !== Column::TYPE_RELATION) {
 			return [];
 		}
 
-		$settings = $column->getCustomSettingsArray();
-		if (empty($settings['relationType']) || empty($settings['targetId']) || empty($settings['labelColumn'])) {
+		try {
+			return $this->fetchRelationValuesForTarget($column);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->warning('Invalid relation settings for column ' . $column->getId() . ': ' . $e->getMessage());
 			return [];
 		}
-
-		$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
-
-		return $this->getRelationDataForTarget($target, $column);
 	}
 
 	/**
-	 * Get relation data for a specific target
+	 * Get relation data for a list of columns
 	 *
-	 * @param string $target
-	 * @param Column $column
-	 * @return array<int, array{id: int, label: string}> Indexed per row id
+	 * @param Column[] $columns
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
 	 * @throws InternalError
 	 */
-	private function getRelationDataForTarget(string $target, Column $column): array {
-		// Check cache first
-		$cacheKey = $target . '_' . ($this->userId ?? 'anonymous');
+	private function getRelationsForColumnList(array $columns): array {
+		$relationColumns = array_filter($columns, fn (Column $column) => $column->getType() === Column::TYPE_RELATION);
+		$relationData = $this->fetchRelationColumns($relationColumns);
+
+		$lookupColumns = array_filter($columns, fn (Column $column) => $column->getType() === Column::TYPE_RELATION_LOOKUP);
+		$relationLookupData = $this->fetchRelationLookupColumns($lookupColumns);
+
+		return array_map(
+			fn (array $data) => ['column' => null, 'values' => $data],
+			$relationData
+		) + $relationLookupData;
+	}
+
+	/**
+	 * Fetch relation data for relation columns
+	 *
+	 * @param Column[] $columns
+	 * @return array<int, array<int, array{id: int, value: string}>> Relation data, indexed per column ID and row ID
+	 * @throws InternalError
+	 */
+	private function fetchRelationColumns(array $columns): array {
+		$result = [];
+		$fetchedTargets = [];
+
+		foreach ($columns as $column) {
+			try {
+				$settings = $column->getCustomSettingsObject(RelationSettings::class);
+				$targetKey = $this->buildRelationCacheKey($settings->relationType, $settings->targetId, $settings->labelColumn);
+
+				if (!isset($fetchedTargets[$targetKey])) {
+					$fetchedTargets[$targetKey] = $this->fetchRelationValuesForTarget($column);
+				}
+
+				$result[$column->getId()] = $fetchedTargets[$targetKey];
+			} catch (\InvalidArgumentException $e) {
+				$this->logger->warning('Invalid relation settings for column ' . $column->getId() . ': ' . $e->getMessage());
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Fetch relation data for relation lookup columns
+	 *
+	 * @param Column[] $columns
+	 * @return array<int, array{column: ?TablesColumn, values: array<int, array{id: int, value: mixed}>}> Relation data grouped by column ID
+	 * @throws InternalError
+	 */
+	private function fetchRelationLookupColumns(array $columns): array {
+		$result = [];
+
+		// Batch fetch all needed columns to avoid duplicate queries
+		$columnIdsToFetch = $this->collectColumnIdsForLookup($columns);
+		$columnsMap = $this->fetchColumnsByIds($columnIdsToFetch);
+
+		foreach ($columns as $column) {
+			try {
+				$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+				$relationColumn = $columnsMap[$settings->relationColumnId] ?? null;
+				$targetColumn = $columnsMap[$settings->targetColumnId] ?? null;
+
+				if (!$relationColumn || !$targetColumn) {
+					continue;
+				}
+
+				$lookupData = $this->fetchLookupValues($settings, $relationColumn);
+				$result[$column->getId()] = [
+					'column' => $targetColumn->jsonSerialize(),
+					'values' => $lookupData,
+				];
+			} catch (\InvalidArgumentException $e) {
+				$this->logger->warning('Invalid relation lookup settings for column ' . $column->getId() . ': ' . $e->getMessage());
+			}
+		}
+
+		return $result;
+	}
+
+	private function getCurrentUserId(): string {
+		$user = $this->userSession->getUser();
+		return $user ? $user->getUID() : 'anonymous';
+	}
+
+	/**
+	 * Fetch relation values for a specific target
+	 *
+	 * @param Column $column
+	 * @return array<int, array{id: int, value: string}> Indexed per row id
+	 * @throws InternalError
+	 */
+	private function fetchRelationValuesForTarget(Column $column): array {
+		$settings = $column->getCustomSettingsObject(RelationSettings::class);
+
+		$cacheKey = $this->buildRelationCacheKey($settings->relationType, $settings->targetId, $settings->labelColumn);
 		if (isset($this->cacheRelationData[$cacheKey])) {
 			return $this->cacheRelationData[$cacheKey];
 		}
 
-		$settings = $column->getCustomSettingsArray();
-		if (empty($settings[Column::RELATION_TYPE]) || empty($settings[Column::RELATION_TARGET_ID]) || empty($settings[Column::RELATION_LABEL_COLUMN])) {
+		try {
+			$targetColumn = $this->columnMapper->find($settings->labelColumn);
+			$rows = $this->fetchRowsForTarget($settings, [$settings->labelColumn]);
+		} catch (DoesNotExistException $e) {
 			$this->cacheRelationData[$cacheKey] = [];
 			return [];
 		}
 
-		$isView = $settings[Column::RELATION_TYPE] === 'view';
-		$targetId = $settings[Column::RELATION_TARGET_ID] ?? null;
+		$result = $this->buildRelationValues($rows, $targetColumn, $settings->labelColumn);
+		$this->cacheRelationData[$cacheKey] = $result;
+
+		return $result;
+	}
+
+	/**
+	 * Build a cache key for relation data
+	 */
+	private function buildRelationCacheKey(string $relationType, int $targetId, int $labelColumn): string {
+		return sprintf('%s_%d_%d_%s', $relationType, $targetId, $labelColumn, $this->getCurrentUserId());
+	}
+
+	/**
+	 * Collect all column IDs needed for lookup processing
+	 *
+	 * @param Column[] $columns
+	 * @return int[]
+	 */
+	private function collectColumnIdsForLookup(array $columns): array {
+		$columnIds = [];
+
+		foreach ($columns as $column) {
+			$settings = $column->getCustomSettingsObject(RelationLookupSettings::class);
+			$columnIds[] = $settings->targetColumnId;
+			$columnIds[] = $settings->relationColumnId;
+		}
+
+		return array_unique($columnIds);
+	}
+
+	/**
+	 * Fetch multiple columns by their IDs in a single batch
+	 *
+	 * @param int[] $columnIds
+	 * @return array<int, Column>
+	 */
+	private function fetchColumnsByIds(array $columnIds): array {
+		if (empty($columnIds)) {
+			return [];
+		}
 
 		try {
-			$targetColumn = $this->columnMapper->find($settings[Column::RELATION_LABEL_COLUMN]);
-			if ($isView) {
-				$view = $this->viewMapper->find($targetId);
-				$rows = $this->row2Mapper->findAll(
-					[$targetColumn->getId()],
-					$view->getTableId(),
-					null,
-					null,
-					$view->getFilterArray(),
-					$view->getSortArray(),
-					$this->userId
-				);
-			} else {
-				$rows = $this->row2Mapper->findAll(
-					[$targetColumn->getId()],
-					$targetId,
-					null,
-					null,
-					null,
-					null,
-					$this->userId
-				);
+			$columns = $this->columnMapper->findAll($columnIds);
+			$result = [];
+			foreach ($columns as $column) {
+				$result[$column->getId()] = $column;
 			}
-		} catch (DoesNotExistException) {
-			$this->cacheRelationData[$cacheKey] = [];
+			return $result;
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to fetch columns: ' . $e->getMessage());
 			return [];
 		}
+	}
 
+	/**
+	 * Fetch lookup values for a relation lookup column
+	 *
+	 * @param RelationLookupSettings $settings
+	 * @param Column $relationColumn
+	 * @return array<int, array{id: int, value: mixed}>
+	 */
+	private function fetchLookupValues(RelationLookupSettings $settings, Column $relationColumn): array {
+		$relationSettings = $relationColumn->getCustomSettingsObject(RelationSettings::class);
+
+		$cacheKey = $this->buildRelationCacheKey($relationSettings->relationType, $relationSettings->targetId, $settings->targetColumnId);
+		if (isset($this->cacheRelationData[$cacheKey])) {
+			return $this->cacheRelationData[$cacheKey];
+		}
+
+		try {
+			// Fetch both relation label column and lookup target column in a single query
+			$rows = $this->fetchRowsForTarget($relationSettings, [$relationSettings->labelColumn, $settings->targetColumnId]);
+			$lookupData = $this->buildLookupValues($rows, $relationSettings->labelColumn, $settings->targetColumnId);
+
+			$this->cacheRelationData[$cacheKey] = $lookupData;
+			return $lookupData;
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Failed to fetch lookup data: ' . $e->getMessage());
+			return [];
+		}
+	}
+
+	/**
+	 * Fetch rows for a relation target
+	 *
+	 * @param RelationSettings $settings
+	 * @param int[] $columnIds
+	 * @return Row2[]
+	 * @throws DoesNotExistException
+	 */
+	private function fetchRowsForTarget(RelationSettings $settings, array $columnIds): array {
+		if ($settings->isView()) {
+			$view = $this->viewMapper->find($settings->targetId);
+			return $this->row2Mapper->findAll(
+				$columnIds,
+				$view->getTableId(),
+				null,
+				null,
+				$view->getFilterArray(),
+				$view->getSortArray(),
+				$this->getCurrentUserId()
+			);
+		}
+
+		return $this->row2Mapper->findAll(
+			$columnIds,
+			$settings->targetId,
+			null,
+			null,
+			null,
+			null,
+			$this->getCurrentUserId()
+		);
+	}
+
+	/**
+	 * Build relation values from rows
+	 *
+	 * @param Row2[] $rows
+	 * @param Column $column
+	 * @param int $labelColumnId
+	 * @return array<int, array{id: int, value: string}>
+	 */
+	private function buildRelationValues(array $rows, Column $column, int $labelColumnId): array {
 		$result = [];
+
 		foreach ($rows as $row) {
 			$data = $row->getData();
-			$displayFieldData = array_filter($data, fn ($item) => $item['columnId'] === (int)$settings[Column::RELATION_LABEL_COLUMN]);
+			$displayFieldData = array_filter($data, fn ($item) => $item['columnId'] === $labelColumnId);
 			$value = reset($displayFieldData)['value'] ?? null;
 
-			// Structure compatible with Row2 format: {id: int, label: string}
 			$rowId = (int)$row->getId();
 			$result[$rowId] = [
 				'id' => $rowId,
-				'label' => (string)$value,
+				'value' => $this->formatValue($column, $value),
 			];
 		}
 
-		$this->cacheRelationData[$cacheKey] = $result;
 		return $result;
+	}
+
+	/**
+	 * Build lookup values from rows containing both relation label and target columns
+	 *
+	 * @param Row2[] $rows
+	 * @param int $relationLabelColumnId
+	 * @param int $targetColumnId
+	 * @return array<int, array{id: int, value: mixed}>
+	 */
+	private function buildLookupValues(array $rows, int $relationLabelColumnId, int $targetColumnId): array {
+		$result = [];
+
+		foreach ($rows as $row) {
+			$data = $row->getData();
+			$rowId = (int)$row->getId();
+
+			// Find the relation label value
+			$relationLabelData = array_filter($data, fn ($item) => $item['columnId'] === $relationLabelColumnId);
+			$relationLabelValue = reset($relationLabelData)['value'] ?? null;
+
+			// Find the target column value
+			$targetData = array_filter($data, fn ($item) => $item['columnId'] === $targetColumnId);
+			$targetValue = reset($targetData)['value'] ?? null;
+
+			// Only include if relation label exists (meaning this row is referenced)
+			if ($relationLabelValue !== null && $relationLabelValue !== '') {
+				$result[$rowId] = [
+					'id' => $rowId,
+					'value' => $targetValue,
+				];
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Format a cell value for display as a relation label.
+	 * Relation lookup only supports text-line and number columns.
+	 */
+	private function formatValue(Column $column, mixed $value): string {
+		if ($value === null || $value === '' || $value === []) {
+			return '';
+		}
+
+		return match ($column->getType()) {
+			Column::TYPE_TEXT => trim(strip_tags((string)$value)),
+			Column::TYPE_NUMBER => $this->formatNumberValue($column, $value),
+			default => (string)$value,
+		};
+	}
+
+	private function formatNumberValue(Column $column, mixed $value): string {
+		if ($value === null || $value === '') {
+			return '';
+		}
+		if (!is_numeric($value)) {
+			return (string)$value;
+		}
+		$decimals = $column->getNumberDecimals() ?? 0;
+		$formatted = number_format((float)$value, $decimals, '.', '');
+		return $column->getNumberPrefix() . $formatted . $column->getNumberSuffix();
 	}
 }

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -30,12 +30,12 @@ class RelationService {
 	private array $cacheRelationData = [];
 
 	public function __construct(
-		private ColumnMapper $columnMapper,
-		private ViewMapper $viewMapper,
-		private Row2Mapper $row2Mapper,
-		private ColumnService $columnService,
-		private IUserSession $userSession,
-		private LoggerInterface $logger,
+		private readonly ColumnMapper $columnMapper,
+		private readonly ViewMapper $viewMapper,
+		private readonly Row2Mapper $row2Mapper,
+		private readonly ColumnService $columnService,
+		private readonly IUserSession $userSession,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -126,9 +126,7 @@ class RelationService {
 				$settings = $column->getCustomSettingsObject(RelationSettings::class);
 				$targetKey = $this->buildRelationCacheKey($settings->relationType, $settings->targetId, $settings->labelColumn);
 
-				if (!isset($fetchedTargets[$targetKey])) {
-					$fetchedTargets[$targetKey] = $this->fetchRelationValuesForTarget($column);
-				}
+				$fetchedTargets[$targetKey] ??= $this->fetchRelationValuesForTarget($column);
 
 				$result[$column->getId()] = $fetchedTargets[$targetKey];
 			} catch (\InvalidArgumentException $e) {
@@ -199,7 +197,7 @@ class RelationService {
 		try {
 			$targetColumn = $this->columnMapper->find($settings->labelColumn);
 			$rows = $this->fetchRowsForTarget($settings, [$settings->labelColumn]);
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			$this->cacheRelationData[$cacheKey] = [];
 			return [];
 		}

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -393,6 +393,10 @@ class RowService extends SuperService {
 
 			$column = $this->getColumnFromColumnsArray($columnId, $columns);
 
+			if ($column && $this->row2Mapper->isVirtualColumn($column->getType())) {
+				continue;
+			}
+
 			if ($column) {
 				$this->validateColumnValueLimits($column, $entry['value']);
 				$columnBusiness = $this->columnsHelper->getColumnBusinessObject($column);
@@ -938,6 +942,8 @@ class RowService extends SuperService {
 		}
 
 		$columnIds = $view->getColumnIds();
+		$columnIds = $this->row2Mapper->addRelationColumnIdsForLookupColumns($columnIds);
+
 		$row->filterDataByColumns($columnIds);
 		$row->filterDataByAliasByColumns($columnIds);
 

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -393,6 +393,10 @@ class RowService extends SuperService {
 
 			$column = $this->getColumnFromColumnsArray($columnId, $columns);
 
+			if ($column && $this->row2Mapper->isVirtualColumn($column->getType())) {
+				continue;
+			}
+
 			if ($column) {
 				$this->validateColumnValueLimits($column, $entry['value']);
 				$columnBusiness = $this->columnsHelper->getColumnBusinessObject($column);
@@ -919,6 +923,8 @@ class RowService extends SuperService {
 		}
 
 		$columnIds = $view->getColumnIds();
+		$columnIds = $this->row2Mapper->addRelationColumnIdsForLookupColumns($columnIds);
+
 		$row->filterDataByColumns($columnIds);
 		$row->filterDataByAliasByColumns($columnIds);
 

--- a/openapi.json
+++ b/openapi.json
@@ -673,6 +673,45 @@
                     }
                 }
             },
+            "RelationData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": [
+                        "column",
+                        "values"
+                    ],
+                    "properties": {
+                        "column": {
+                            "nullable": true,
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Column"
+                                }
+                            ]
+                        },
+                        "values": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "id",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "value": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "Row": {
                 "type": "object",
                 "required": [
@@ -3848,7 +3887,8 @@
                                             "datetime",
                                             "select",
                                             "usergroup",
-                                            "relation"
+                                            "relation",
+                                            "relation_lookup"
                                         ],
                                         "description": "Column main type"
                                     },
@@ -4282,7 +4322,8 @@
                                             "datetime",
                                             "select",
                                             "usergroup",
-                                            "relation"
+                                            "relation",
+                                            "relation_lookup"
                                         ],
                                         "description": "Column main type"
                                     },
@@ -4916,6 +4957,314 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Column"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/tables/api/1/tables/{tableId}/relations": {
+            "get": {
+                "operationId": "api1-index-table-relations",
+                "summary": "Get all relation data for a table",
+                "description": "This endpoint allows CORS requests",
+                "tags": [
+                    "api1"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "tableId",
+                        "in": "path",
+                        "description": "Table ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Relation data returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/RelationData"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "column",
+                                                    "values"
+                                                ],
+                                                "properties": {
+                                                    "column": {
+                                                        "nullable": true,
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Column"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "value"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "value": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/tables/api/1/views/{viewId}/relations": {
+            "get": {
+                "operationId": "api1-index-view-relations",
+                "summary": "Get all relation data for a view",
+                "description": "This endpoint allows CORS requests",
+                "tags": [
+                    "api1"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "viewId",
+                        "in": "path",
+                        "description": "View ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Relation data returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/RelationData"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "column",
+                                                    "values"
+                                                ],
+                                                "properties": {
+                                                    "column": {
+                                                        "nullable": true,
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Column"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "value"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "value": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -673,6 +673,45 @@
                     }
                 }
             },
+            "RelationData": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": [
+                        "column",
+                        "values"
+                    ],
+                    "properties": {
+                        "column": {
+                            "nullable": true,
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Column"
+                                }
+                            ]
+                        },
+                        "values": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "id",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "value": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "Row": {
                 "type": "object",
                 "required": [
@@ -3870,7 +3909,8 @@
                                             "datetime",
                                             "select",
                                             "usergroup",
-                                            "relation"
+                                            "relation",
+                                            "relation_lookup"
                                         ],
                                         "description": "Column main type"
                                     },
@@ -4304,7 +4344,8 @@
                                             "datetime",
                                             "select",
                                             "usergroup",
-                                            "relation"
+                                            "relation",
+                                            "relation_lookup"
                                         ],
                                         "description": "Column main type"
                                     },
@@ -4938,6 +4979,314 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Column"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/tables/api/1/tables/{tableId}/relations": {
+            "get": {
+                "operationId": "api1-index-table-relations",
+                "summary": "Get all relation data for a table",
+                "description": "This endpoint allows CORS requests",
+                "tags": [
+                    "api1"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "tableId",
+                        "in": "path",
+                        "description": "Table ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Relation data returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/RelationData"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "column",
+                                                    "values"
+                                                ],
+                                                "properties": {
+                                                    "column": {
+                                                        "nullable": true,
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Column"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "value"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "value": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/tables/api/1/views/{viewId}/relations": {
+            "get": {
+                "operationId": "api1-index-view-relations",
+                "summary": "Get all relation data for a view",
+                "description": "This endpoint allows CORS requests",
+                "tags": [
+                    "api1"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "viewId",
+                        "in": "path",
+                        "description": "View ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Relation data returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/RelationData"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "column",
+                                                    "values"
+                                                ],
+                                                "properties": {
+                                                    "column": {
+                                                        "nullable": true,
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Column"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "value"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "value": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/src/modules/main/partials/ColumnFormComponent.vue
+++ b/src/modules/main/partials/ColumnFormComponent.vue
@@ -23,6 +23,7 @@ import DatetimeTimeForm from '../../../shared/components/ncTable/partials/rowTyp
 import TextRichForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue'
 import UsergroupForm from '../../../shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue'
 import RelationForm from '../../../shared/components/ncTable/partials/rowTypePartials/RelationForm.vue'
+import RelationLookupForm from '../../../shared/components/ncTable/partials/rowTypePartials/RelationLookupForm.vue'
 
 export default {
 	name: 'ColumnFormComponent',
@@ -42,6 +43,7 @@ export default {
 		DatetimeTimeForm,
 		UsergroupForm,
 		RelationForm,
+		RelationLookupForm,
 	},
 	props: {
 		column: {
@@ -58,7 +60,7 @@ export default {
 	],
 	data() {
 		return {
-			value_data: this.value,
+			value_data: this.getValueForColumn(),
 		}
 	},
 	computed: {
@@ -79,10 +81,13 @@ export default {
 			this.$emit('update:value', this.value_data)
 		},
 		value() {
-			this.value_data = this.value
+			this.value_data = this.getValueForColumn()
 		},
 	},
 	methods: {
+		getValueForColumn() {
+			return this.column.getValueForForm(this.value)
+		},
 		snakeToCamel(str) {
 			str = str.toLowerCase().replace(/([-_][a-z])/g, group =>
 				group

--- a/src/modules/main/partials/ColumnTypeSelection.vue
+++ b/src/modules/main/partials/ColumnTypeSelection.vue
@@ -20,6 +20,7 @@
 				<DatetimeIcon v-if="props.id === 'datetime'" />
 				<ContactsIcon v-if="props.id === 'usergroup'" />
 				<RelationIcon v-if="props.id === 'relation'" />
+				<RelationIcon v-if="props.id === 'relation_lookup'" />
 				<div class="multiSelectOptionLabel">
 					{{ props.label }}
 				</div>
@@ -35,6 +36,7 @@
 			<DatetimeIcon v-if="props.id === 'datetime'" />
 			<ContactsIcon v-if="props.id === 'usergroup'" />
 			<RelationIcon v-if="props.id === 'relation'" />
+			<RelationIcon v-if="props.id === 'relation_lookup'" />
 			<div class="multiSelectOptionLabel">
 				{{ props.label }}
 			</div>
@@ -94,6 +96,7 @@ export default {
 				{ id: 'datetime', label: t('tables', 'Date and time') },
 				{ id: 'usergroup', label: t('tables', 'Users and groups') },
 				{ id: 'relation', label: t('tables', 'Relation') },
+				{ id: 'relation_lookup', label: t('tables', 'Relation lookup') },
 			],
 		}
 	},

--- a/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
+++ b/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
@@ -215,10 +215,10 @@ export default {
 				// Get relations from DataStore using the column's tableId
 				const dataStore = useDataStore()
 				const columnRelations = dataStore.getRelations(this.selectedColumn.id)
-				Object.values(columnRelations).forEach(item => {
+				Object.entries(columnRelations.values || {}).forEach(([, item]) => {
 					options.push({
 						id: '@relation-id-' + item.id,
-						label: item.label,
+						label: item.value,
 					})
 				})
 

--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -127,6 +127,7 @@ import TextRichForm from '../../shared/components/ncTable/partials/columnTypePar
 import { ColumnTypes } from '../../shared/components/ncTable/mixins/columnHandler.js'
 import UsergroupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/UsergroupForm.vue'
 import RelationForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue'
+import RelationLookupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationLookupForm.vue'
 import { useTablesStore } from '../../store/store.js'
 import { useDataStore } from '../../store/data.js'
 import { mapActions } from 'pinia'
@@ -155,6 +156,7 @@ export default {
 		SelectionMultiForm,
 		UsergroupForm,
 		RelationForm,
+		RelationLookupForm,
 	},
 	props: {
 		showModal: {
@@ -333,6 +335,10 @@ export default {
 				showInfo(t('tables', 'Please select a target.'))
 			} else if (this.column.type === ColumnTypes.Relation && !this.column.customSettings?.labelColumn) {
 				showInfo(t('tables', 'Please select a label for relation selection.'))
+			} else if (this.column.type === ColumnTypes.RelationLookup && !this.column.customSettings?.relationColumnId) {
+				showInfo(t('tables', 'Please select a relation column.'))
+			} else if (this.column.type === ColumnTypes.RelationLookup && !this.column.customSettings?.targetColumnId) {
+				showInfo(t('tables', 'Please select a target column.'))
 			} else {
 				this.column.title = title
 				this.$emit('save', this.prepareSubmitData())
@@ -409,6 +415,9 @@ export default {
 				data.customSettings.relationType = this.column.customSettings.relationType
 				data.customSettings.targetId = this.column.customSettings.targetId
 				data.customSettings.labelColumn = this.column.customSettings.labelColumn
+			} else if (this.column.type === ColumnTypes.RelationLookup) {
+				data.customSettings.relationColumnId = this.column.customSettings.relationColumnId
+				data.customSettings.targetColumnId = this.column.customSettings.targetColumnId
 			}
 			return data
 		},

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -9,15 +9,15 @@
 		data-cy="createRowModal"
 		@closing="actionCancel">
 		<div class="modal__content" @keydown="onKeydown">
-			<div v-for="column in nonMetaColumns" :key="column.id" :data-cy="column.title">
+			<div v-for="column in nonMetaColumns" :key="column.getValueColumnId()" :data-cy="column.title">
 				<ColumnFormComponent
-					v-model:value="row[column.id]"
+					v-model:value="row[column.getValueColumnId()]"
 					:column="column" />
-				<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(row[column.id], column)"
+				<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(row[column.getValueColumnId()], column)"
 					type="error">
 					{{ t('tables', '"{columnTitle}" should not be empty', { columnTitle: column.title }) }}
 				</NcNoteCard>
-				<NcNoteCard v-if="row[column.id] && column.type === 'text-link' && !isValidUrlProtocol(row[column.id])"
+				<NcNoteCard v-if="row[column.getValueColumnId()] && column.type === 'text-link' && !isValidUrlProtocol(row[column.getValueColumnId()])"
 					type="error">
 					{{ t('tables', 'Invalid protocol. Allowed: {allowed}', {allowed: allowedProtocols.join(', ')}) }}
 				</NcNoteCard>
@@ -104,7 +104,7 @@ export default {
 			return this.checkMandatoryFields(this.row)
 		},
 		hasInvalidUrlProtocol() {
-			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.row[col.id]))
+			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.row[col.getValueColumnId()]))
 		},
 		dialogTitle() {
 			return this.isFormMode ? t('tables', 'Fill form') : t('tables', 'Create row')

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -71,6 +71,7 @@ import DatetimeDateForm from '../../shared/components/ncTable/partials/columnTyp
 import DatetimeTimeForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/DatetimeTimeForm.vue'
 import UsergroupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/UsergroupForm.vue'
 import RelationForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue'
+import RelationLookupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationLookupForm.vue'
 import { ColumnTypes } from '../../shared/components/ncTable/mixins/columnHandler.js'
 import moment from '@nextcloud/moment'
 import { mapActions } from 'pinia'
@@ -103,6 +104,7 @@ export default {
 		NcUserBubble,
 		UsergroupForm,
 		RelationForm,
+		RelationLookupForm,
 	},
 	props: {
 		column: {

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -35,15 +35,15 @@
 			</div>
 
 			<div v-if="activeTabId === 'edit' && localRow" class="row">
-				<div v-for="column in nonMetaColumns" :key="column.id">
+				<div v-for="column in nonMetaColumns" :key="column.getValueColumnId()">
 					<ColumnFormComponent
-						v-model:value="localRow[column.id]"
+						v-model:value="localRow[column.getValueColumnId()]"
 						:column="column" />
-					<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(localRow[column.id], column)"
+					<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(localRow[column.getValueColumnId()], column)"
 						type="error">
 						{{ t('tables', '"{columnTitle}" should not be empty', { columnTitle: column.title }) }}
 					</NcNoteCard>
-					<NcNoteCard v-if="localRow[column.id] && column.type === 'text-link' && !isValidUrlProtocol(localRow[column.id])"
+					<NcNoteCard v-if="localRow[column.getValueColumnId()] && column.type === 'text-link' && !isValidUrlProtocol(localRow[column.getValueColumnId()])"
 						type="error">
 						{{ t('tables', 'Invalid protocol. Allowed: {allowed}', {allowed: allowedProtocols.join(', ')}) }}
 					</NcNoteCard>
@@ -162,7 +162,7 @@ export default {
 			return this.checkMandatoryFields(this.localRow)
 		},
 		hasInvalidUrlProtocol() {
-			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.localRow[col.id]))
+			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.localRow[col.getValueColumnId()]))
 		},
 	},
 	watch: {
@@ -196,12 +196,12 @@ export default {
 
 				// Ensure all columns have entries, even if missing from row data
 				this.columns.forEach(column => {
-					if (!(column.id in tmp)) {
+					if (!(column.getValueColumnId() in tmp)) {
 						// For usergroup columns, initialize as empty array
 						if (column.type === 'usergroup') {
-							tmp[column.id] = []
+							tmp[column.getValueColumnId()] = []
 						} else {
-							tmp[column.id] = null
+							tmp[column.getValueColumnId()] = null
 						}
 					}
 				})

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -35,15 +35,15 @@
 			</div>
 
 			<div v-if="activeTabId === 'edit' && localRow" class="row">
-				<div v-for="column in nonMetaColumns" :key="column.id">
+				<div v-for="column in nonMetaColumns" :key="column.getValueColumnId()">
 					<ColumnFormComponent
-						v-model:value="localRow[column.id]"
+						v-model:value="localRow[column.getValueColumnId()]"
 						:column="column" />
-					<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(localRow[column.id], column)"
+					<NcNoteCard v-if="isMandatory(column) && !isValueValidForColumn(localRow[column.getValueColumnId()], column)"
 						type="error">
 						{{ t('tables', '"{columnTitle}" should not be empty', { columnTitle: column.title }) }}
 					</NcNoteCard>
-					<NcNoteCard v-if="localRow[column.id] && column.type === 'text-link' && !isValidUrlProtocol(localRow[column.id])"
+					<NcNoteCard v-if="localRow[column.getValueColumnId()] && column.type === 'text-link' && !isValidUrlProtocol(localRow[column.getValueColumnId()])"
 						type="error">
 						{{ t('tables', 'Invalid protocol. Allowed: {allowed}', {allowed: allowedProtocols.join(', ')}) }}
 					</NcNoteCard>
@@ -162,7 +162,7 @@ export default {
 			return this.checkMandatoryFields(this.localRow)
 		},
 		hasInvalidUrlProtocol() {
-			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.localRow[col.id]))
+			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.localRow[col.getValueColumnId()]))
 		},
 	},
 	watch: {
@@ -198,12 +198,12 @@ export default {
 
 				// Ensure all columns have entries, even if missing from row data
 				this.columns.forEach(column => {
-					if (!(column.id in tmp)) {
+					if (!(column.getValueColumnId() in tmp)) {
 						// For usergroup columns, initialize as empty array
 						if (column.type === 'usergroup') {
-							tmp[column.id] = []
+							tmp[column.getValueColumnId()] = []
 						} else {
-							tmp[column.id] = null
+							tmp[column.getValueColumnId()] = null
 						}
 					}
 				})

--- a/src/modules/modals/ImportPreview.vue
+++ b/src/modules/modals/ImportPreview.vue
@@ -120,7 +120,10 @@ export default {
 				return []
 			}
 
-			const columns = this.existingColumns.map(column => ({
+			// Filter out columns with type relation_lookup
+			const filteredColumns = this.existingColumns.filter(column => column.type !== ColumnTypes.RelationLookup)
+
+			const columns = filteredColumns.map(column => ({
 				id: column.id,
 				label: column.title,
 			}))

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -120,6 +120,7 @@ import {
 import { MetaColumns } from './mixins/metaColumns.js'
 import { MagicFields } from './mixins/magicFields.js'
 import { FilterIds, getFiltersForColumn } from './mixins/filter.js'
+import { ColumnTypes } from './mixins/columnHandler.js'
 
 export default {
 	name: 'NcTable',
@@ -354,7 +355,11 @@ export default {
 					})
 					// if we should search
 					if (searchString) {
-						searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
+						if (column.type === ColumnTypes.RelationLookup) {
+							searchStatus = column.isSearchStringFound(row.data, cell, searchString.toLowerCase())
+						} else {
+							searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
+						}
 					}
 
 					// if filterStatus is null, this result should be ignored

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -120,6 +120,7 @@ import {
 import { MetaColumns } from './mixins/metaColumns.js'
 import { MagicFields } from './mixins/magicFields.js'
 import { FilterIds, getFiltersForColumn } from './mixins/filter.js'
+import { ColumnTypes } from './mixins/columnHandler.js'
 
 export default {
 	name: 'NcTable',
@@ -351,7 +352,11 @@ export default {
 					})
 					// if we should search
 					if (searchString) {
-						searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
+						if (column.type === ColumnTypes.RelationLookup) {
+							searchStatus = column.isSearchStringFound(row.data, cell, searchString.toLowerCase())
+						} else {
+							searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
+						}
 					}
 
 					// if filterStatus is null, this result should be ignored

--- a/src/shared/components/ncTable/mixins/columnClass.js
+++ b/src/shared/components/ncTable/mixins/columnClass.js
@@ -81,6 +81,27 @@ export class AbstractColumn {
 		return value
 	}
 
+	/**
+	 * Get the id of the column whose cell holds this column's value.
+	 * Virtual columns may source their value from another column.
+	 *
+	 * @return {number} The column id to read the cell value from
+	 */
+	getValueColumnId() {
+		return this.id
+	}
+
+	/**
+	 * Get the value for form input.
+	 * Default implementation returns the value as-is.
+	 *
+	 * @param {*} value The raw value
+	 * @return {*} The value for form input
+	 */
+	getValueForForm(value) {
+		return value
+	}
+
 }
 
 export class AbstractUsergroupColumn extends AbstractColumn {

--- a/src/shared/components/ncTable/mixins/columnClass.js
+++ b/src/shared/components/ncTable/mixins/columnClass.js
@@ -82,6 +82,27 @@ export class AbstractColumn {
 		return value
 	}
 
+	/**
+	 * Get the id of the column whose cell holds this column's value.
+	 * Virtual columns may source their value from another column.
+	 *
+	 * @return {number} The column id to read the cell value from
+	 */
+	getValueColumnId() {
+		return this.id
+	}
+
+	/**
+	 * Get the value for form input.
+	 * Default implementation returns the value as-is.
+	 *
+	 * @param {*} value The raw value
+	 * @return {*} The value for form input
+	 */
+	getValueForForm(value) {
+		return value
+	}
+
 }
 
 export class AbstractUsergroupColumn extends AbstractColumn {

--- a/src/shared/components/ncTable/mixins/columnHandler.js
+++ b/src/shared/components/ncTable/mixins/columnHandler.js
@@ -18,6 +18,7 @@ export const ColumnTypes = {
 	Datetime: 'datetime',
 	Usergroup: 'usergroup',
 	Relation: 'relation',
+	RelationLookup: 'relation_lookup',
 }
 
 export function getColumnWidthStyle(column) {

--- a/src/shared/components/ncTable/mixins/columnParser.js
+++ b/src/shared/components/ncTable/mixins/columnParser.js
@@ -18,6 +18,7 @@ import TextLongColumn from './columnsTypes/textLong.js'
 import TextRichColumn from './columnsTypes/textRich.js'
 import UsergroupColumn from './columnsTypes/usergroup.js'
 import RelationColumn from './columnsTypes/relation.js'
+import RelationLookupColumn from './columnsTypes/relationLookup.js'
 
 export function parseCol(col) {
 	const columnType = col.type + (col.subtype === '' ? '' : '-' + col.subtype)
@@ -37,6 +38,7 @@ export function parseCol(col) {
 	case ColumnTypes.DatetimeTime: return new DatetimeTimeColumn(col)
 	case ColumnTypes.Usergroup: return new UsergroupColumn(col)
 	case ColumnTypes.Relation: return new RelationColumn(col)
+	case ColumnTypes.RelationLookup: return new RelationLookupColumn(col)
 	default: throw Error(columnType + ' is not a valid column type!')
 	}
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/relation.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/relation.js
@@ -44,7 +44,7 @@ export default class RelationColumn extends AbstractColumn {
 
 	getValueString(valueObject) {
 		valueObject = valueObject || this.value || null
-		return this.getLabel(valueObject.value)
+		return this.getLabel(valueObject.value) ?? String(valueObject.value)
 	}
 
 	getLabel(rowId) {
@@ -59,9 +59,9 @@ export default class RelationColumn extends AbstractColumn {
 			}
 
 			const columnRelations = dataStore.getRelations(this.id)
-			const option = columnRelations[rowId]
+			const option = columnRelations.values?.[rowId]
 
-			return option ? option.label : undefined
+			return option ? option.value : undefined
 		} catch (error) {
 			console.warn('Failed to get relation label:', error)
 			return ''

--- a/src/shared/components/ncTable/mixins/columnsTypes/relationLookup.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/relationLookup.js
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { AbstractColumn } from '../columnClass.js'
+import { useDataStore } from '../../../../../store/data.js'
+
+export default class RelationLookupColumn extends AbstractColumn {
+
+	constructor(col) {
+		super(col)
+		this.type = 'relation_lookup'
+		this.subtype = ''
+	}
+
+	/**
+	 * Format the value for display
+	 * @param {any} value The value to format
+	 * @return {string} The formatted value
+	 */
+	formatValue(value) {
+		if (value === null || value === undefined) {
+			return ''
+		}
+		// Return the virtual value as is - it comes from the related table
+		return String(value)
+	}
+
+	/**
+	 * Parse the value from input
+	 * @param {any} value The value to parse
+	 * @return {any} The parsed value
+	 */
+	parseValue(value) {
+		// This is a virtual column, no input parsing needed
+		// Values come from related rows via backend
+		return value
+	}
+
+	/**
+	 * The lookup value is sourced from the referenced relation column's cell.
+	 * @return {number} The relation column id to read the cell value from
+	 */
+	getValueColumnId() {
+		return this.customSettings.relationColumnId
+	}
+
+	/**
+	 * Get the value for form input.
+	 * For relation lookup, extracts the value from the relation column id.
+	 *
+	 * @param {*} value The raw value
+	 * @return {*} The value for form input
+	 */
+	getValueForForm(value) {
+		if (this.customSettings?.relationColumnId) {
+			return value?.[this.customSettings.relationColumnId] ?? null
+		}
+		return value
+	}
+
+	getValueString(valueObject) {
+		valueObject = valueObject || this.value || null
+		if (!valueObject || valueObject.value === null || valueObject.value === undefined) {
+			return ''
+		}
+
+		// Check if we have relation data to get the label
+		if (this.customSettings?.targetColumnId) {
+			try {
+				const dataStore = useDataStore()
+				const relationData = dataStore.getRelations(this.id)
+
+				let value = valueObject.value
+				if (typeof value === 'object' && value !== null) {
+					value = value.value
+				}
+
+				if (relationData?.values && value) {
+					// Get the related row data for the current value (which is the relation ID)
+					const relatedRow = relationData.values[value]
+					if (relatedRow) {
+						return relationData.column.getValueString({ value: relatedRow.value }) ?? String(valueObject.value)
+					}
+				}
+			} catch (error) {
+				console.warn('Failed to get relation supplement label:', error)
+			}
+		}
+
+		// Fallback to original behavior
+		return String(valueObject.value)
+	}
+
+	default() {
+		// Virtual columns don't have default values
+		return null
+	}
+
+	/**
+	 * Check if filter matches the cell value
+	 * @param {any} cell The cell to check
+	 * @param {any} filter The filter to apply
+	 * @return {boolean} Whether the filter matches
+	 */
+	isFilterFound(cell, filter) {
+		return false
+	}
+
+	isSearchStringFound(rowData, cell, searchString) {
+		const dataStore = useDataStore()
+		const relationLookup = dataStore.getRelations(this.id)
+		const cellRelationLookup = rowData?.find(item => item.columnId === this.customSettings.relationColumnId)
+		if (!cellRelationLookup) return ''
+
+		let value = ''
+		const relatedRow = relationLookup.values?.[cellRelationLookup.value]
+		if (relatedRow && relationLookup.column) {
+			value = relationLookup.column.isSearchStringFound({ value: relatedRow.value }, searchString)
+		}
+
+		return value
+	}
+
+	sort(mode, nextSorts) {
+		const factor = mode === 'DESC' ? -1 : 1
+		return (rowA, rowB) => {
+			let valueA = rowA.data.find(item => item.columnId === this.id)?.value || ''
+			let valueB = rowB.data.find(item => item.columnId === this.id)?.value || ''
+
+			// Convert to strings for comparison
+			valueA = String(valueA).toLowerCase()
+			valueB = String(valueB).toLowerCase()
+
+			return valueA.localeCompare(valueB, undefined) * factor || super.getNextSortsResult(nextSorts, rowA, rowB)
+		}
+	}
+
+}

--- a/src/shared/components/ncTable/mixins/exportTableMixin.js
+++ b/src/shared/components/ncTable/mixins/exportTableMixin.js
@@ -5,9 +5,11 @@
 import moment from '@nextcloud/moment'
 import Papa from 'papaparse'
 import generalHelper from '../../../mixins/generalHelper.js'
+import { ColumnTypes } from './columnHandler.js'
 import {
 	TYPE_META_ID, TYPE_META_CREATED_BY, TYPE_META_CREATED_AT, TYPE_META_UPDATED_BY, TYPE_META_UPDATED_AT,
 } from '../../../../shared/constants.ts'
+import { useDataStore } from '../../../../store/data.js'
 
 export default {
 
@@ -15,19 +17,59 @@ export default {
 
 	methods: {
 
+		getRelationLookupValue(column, row, dataStore) {
+			const relationColumnId = column.customSettings?.relationColumnId
+			if (!relationColumnId) {
+				return ''
+			}
+
+			const relationCell = row.data?.find(d => d.columnId === relationColumnId)
+			if (!relationCell) {
+				return ''
+			}
+
+			try {
+				const relationLookup = dataStore.getRelations(column.id)
+				if (!relationLookup?.values || !relationCell.value) {
+					return ''
+				}
+
+				const relatedRow = relationLookup.values[relationCell.value]
+				if (!relatedRow || relatedRow.value === null || relatedRow.value === undefined) {
+					return ''
+				}
+
+				try {
+					const valueString = relationLookup.column.getValueString({ value: relatedRow.value })
+					return valueString || ''
+				} catch (error) {
+					console.warn('Failed to get value string for relation lookup:', error)
+					return ''
+				}
+			} catch (error) {
+				console.warn('Failed to get relation lookup value for export:', error)
+				return ''
+			}
+		},
+
 		downloadCsv(rows, columns, fileName) {
 			if (!rows || rows.length === 0) {
 				console.debug('downloadCSV has empty parameter, expected array ob row objects', rows)
 			}
 
+			const dataStore = useDataStore()
 			const data = []
 			rows.forEach(row => {
 				const rowData = { ID: row.id }
 				columns.forEach(column => {
 					// if a normal column
 					if (column.id >= 0) {
-						const set = row.data ? row.data.find(d => d.columnId === column.id) || '' : null
-						rowData[column.title] = set ? column.getValueString(set) : ''
+						if (column.type === ColumnTypes.RelationLookup) {
+							rowData[column.title] = this.getRelationLookupValue(column, row, dataStore)
+						} else {
+							const set = row.data ? row.data.find(d => d.columnId === column.id) || '' : null
+							rowData[column.title] = set ? column.getValueString(set) : ''
+						}
 					} else {
 						// if is a meta data column (id < 0)
 						switch (column.id) {

--- a/src/shared/components/ncTable/partials/TableCell.vue
+++ b/src/shared/components/ncTable/partials/TableCell.vue
@@ -1,0 +1,83 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<component :is="cellComponent"
+		:column="column"
+		:row-id="rowId"
+		:value="value"
+		:element-id="elementId"
+		:is-view="isView"
+		:can-edit="canEdit" />
+</template>
+
+<script>
+import TableCellHtml from './TableCellHtml.vue'
+import TableCellProgress from './TableCellProgress.vue'
+import TableCellLink from './TableCellLink.vue'
+import TableCellNumber from './TableCellNumber.vue'
+import TableCellStars from './TableCellStars.vue'
+import TableCellYesNo from './TableCellYesNo.vue'
+import TableCellDateTime from './TableCellDateTime.vue'
+import TableCellTextLine from './TableCellTextLine.vue'
+import TableCellSelection from './TableCellSelection.vue'
+import TableCellMultiSelection from './TableCellMultiSelection.vue'
+import TableCellRelation from './TableCellRelation.vue'
+import TableCellRelationLookup from './TableCellRelationLookup.vue'
+import TableCellTextRich from './TableCellEditor.vue'
+import TableCellUsergroup from './TableCellUsergroup.vue'
+import { ColumnTypes } from './../mixins/columnHandler.js'
+
+const COMPONENT_BY_COLUMN_TYPE = {
+	[ColumnTypes.TextLine]: TableCellTextLine,
+	[ColumnTypes.TextLink]: TableCellLink,
+	[ColumnTypes.TextRich]: TableCellTextRich,
+	[ColumnTypes.Number]: TableCellNumber,
+	[ColumnTypes.NumberStars]: TableCellStars,
+	[ColumnTypes.NumberProgress]: TableCellProgress,
+	[ColumnTypes.Selection]: TableCellSelection,
+	[ColumnTypes.SelectionMulti]: TableCellMultiSelection,
+	[ColumnTypes.SelectionCheck]: TableCellYesNo,
+	[ColumnTypes.Relation]: TableCellRelation,
+	[ColumnTypes.RelationLookup]: TableCellRelationLookup,
+	[ColumnTypes.Datetime]: TableCellDateTime,
+	[ColumnTypes.DatetimeDate]: TableCellDateTime,
+	[ColumnTypes.DatetimeTime]: TableCellDateTime,
+	[ColumnTypes.Usergroup]: TableCellUsergroup,
+}
+
+export default {
+	name: 'TableCell',
+	props: {
+		column: {
+			type: Object,
+			default: () => {},
+		},
+		rowId: {
+			type: Number,
+			default: null,
+		},
+		value: {
+			required: true,
+		},
+		elementId: {
+			type: Number,
+			default: null,
+		},
+		isView: {
+			type: Boolean,
+			default: true,
+		},
+		canEdit: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	computed: {
+		cellComponent() {
+			return COMPONENT_BY_COLUMN_TYPE[this.column?.type] || TableCellHtml
+		},
+	},
+}
+</script>

--- a/src/shared/components/ncTable/partials/TableCellRelation.vue
+++ b/src/shared/components/ncTable/partials/TableCellRelation.vue
@@ -77,7 +77,7 @@ export default {
 		...mapState(useTablesStore, ['activeTable', 'activeView']),
 		allRelations() {
 			const dataStore = useDataStore()
-			return dataStore.getRelations(this.column.id) || {}
+			return dataStore.getRelations(this.column.id).values || {}
 		},
 		currentOption() {
 			if (!this.value) {
@@ -86,12 +86,13 @@ export default {
 			return this.allRelations[this.value]
 		},
 		relationLabel() {
-			return this.currentOption ? this.currentOption.label : null
+			return this.currentOption ? this.currentOption.value : null
 		},
 		relationOptions() {
 			const activeElement = this.activeView || this.activeTable
-			if (activeElement) {
+			if (activeElement && !this.loading) {
 				return Object.values(this.allRelations || {})
+					.map(relation => ({ id: relation.id, label: relation.value }))
 			}
 			return []
 		},

--- a/src/shared/components/ncTable/partials/TableCellRelation.vue
+++ b/src/shared/components/ncTable/partials/TableCellRelation.vue
@@ -77,7 +77,7 @@ export default {
 		...mapState(useTablesStore, ['activeTable', 'activeView']),
 		allRelations() {
 			const dataStore = useDataStore()
-			return dataStore.getRelations(this.column.id) || {}
+			return dataStore.getRelations(this.column.id).values || {}
 		},
 		currentOption() {
 			if (!this.value) {
@@ -86,12 +86,13 @@ export default {
 			return this.allRelations[this.value]
 		},
 		relationLabel() {
-			return this.currentOption ? this.currentOption.label : null
+			return this.currentOption ? this.currentOption.value : null
 		},
 		relationOptions() {
 			const activeElement = this.activeView || this.activeTable
-			if (activeElement) {
-				return Object.values(this.allRelations || {}).map(option => ({ ...option, id: parseInt(option.id) }))
+			if (activeElement && !this.loading) {
+				return Object.values(this.allRelations || {})
+					.map(relation => ({ id: relation.id, label: relation.value }))
 			}
 			return []
 		},
@@ -124,17 +125,6 @@ export default {
 			this.startEditing()
 			// Stop the event from propagating to avoid immediate click outside
 			event.stopPropagation()
-		},
-
-		startEditing() {
-			if (!this.canEditCell()) {
-				return false
-			}
-			this.isEditing = true
-			this.editValue = this.value ? parseInt(this.value) : null
-			this.$nextTick(() => {
-				this.$refs.editingContainer?.focus()
-			})
 		},
 
 		async saveChanges() {

--- a/src/shared/components/ncTable/partials/TableCellRelationLookup.vue
+++ b/src/shared/components/ncTable/partials/TableCellRelationLookup.vue
@@ -1,0 +1,82 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div>
+		<TableCell
+			v-if="targetColumn"
+			:column="targetColumn"
+			:row-id="rowId"
+			:value="targetValue"
+			:can-edit="false" />
+	</div>
+</template>
+
+<script>
+import { useDataStore } from '../../../../store/data.js'
+
+export default {
+	name: 'TableCellRelationLookup',
+	components: {
+		// Loaded asynchronously to break the circular dependency with TableCell,
+		// which itself resolves TableCellRelationLookup for relation lookup columns.
+		TableCell: () => import('./TableCell.vue'),
+	},
+	props: {
+		column: {
+			type: Object,
+			default: () => {},
+		},
+		rowId: {
+			type: Number,
+			default: null,
+		},
+		value: {
+			required: true,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+		}
+	},
+	computed: {
+		targetColumn() {
+			if (!this.column?.id) {
+				return null
+			}
+			const dataStore = useDataStore()
+			const relationData = dataStore.getRelations(this.column.id)
+			return relationData?.column || null
+		},
+		relationValues() {
+			const dataStore = useDataStore()
+			const relationData = dataStore.getRelations(this.column.id)
+			return relationData?.values || null
+		},
+		targetValue() {
+			if (!this.column?.customSettings?.targetColumnId) {
+				return null
+			}
+
+			let value = this.value
+			if (typeof this.value === 'object' && this.value !== null) {
+				value = this.value.value
+			}
+
+			if (!this.relationValues || !value) {
+				return null
+			}
+
+			// Get the related row data for the current value (which is the relation ID)
+			const relatedRow = this.relationValues[value]
+			if (!relatedRow) {
+				return null
+			}
+
+			return relatedRow.value
+		},
+	},
+}
+</script>

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -20,8 +20,7 @@
 				'frozen-column--last': index === pinnedColumnIndex,
 			}"
 			@click="handleCellClick(col)">
-			<component :is="getTableCell(col)"
-				:column="col"
+			<TableCell :column="col"
 				:row-id="row.id"
 				:value="getCellValue(col)"
 				:element-id="elementId"
@@ -68,19 +67,7 @@ import { NcCheckboxRadioSwitch, NcActions, NcActionButton } from '@nextcloud/vue
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import Pencil from 'vue-material-design-icons/PencilOutline.vue'
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
-import TableCellHtml from './TableCellHtml.vue'
-import TableCellProgress from './TableCellProgress.vue'
-import TableCellLink from './TableCellLink.vue'
-import TableCellNumber from './TableCellNumber.vue'
-import TableCellStars from './TableCellStars.vue'
-import TableCellYesNo from './TableCellYesNo.vue'
-import TableCellDateTime from './TableCellDateTime.vue'
-import TableCellTextLine from './TableCellTextLine.vue'
-import TableCellSelection from './TableCellSelection.vue'
-import TableCellMultiSelection from './TableCellMultiSelection.vue'
-import TableCellRelation from './TableCellRelation.vue'
-import TableCellTextRich from './TableCellEditor.vue'
-import TableCellUsergroup from './TableCellUsergroup.vue'
+import TableCell from './TableCell.vue'
 import { ColumnTypes, getColumnWidthStyle, getFrozenColumnStyle } from './../mixins/columnHandler.js'
 import { translate as t } from '@nextcloud/l10n'
 import {
@@ -91,25 +78,13 @@ import activityMixin from '../../../mixins/activityMixin.js'
 export default {
 	name: 'TableRow',
 	components: {
-		TableCellYesNo,
-		TableCellStars,
-		TableCellNumber,
-		TableCellLink,
-		TableCellProgress,
-		TableCellHtml,
+		TableCell,
 		NcActions,
 		NcActionButton,
 		ContentCopy,
 		Pencil,
 		TrashCanOutline,
 		NcCheckboxRadioSwitch,
-		TableCellDateTime,
-		TableCellTextLine,
-		TableCellSelection,
-		TableCellMultiSelection,
-		TableCellRelation,
-		TableCellTextRich,
-		TableCellUsergroup,
 	},
 
 	mixins: [activityMixin],
@@ -173,6 +148,7 @@ export default {
 		// to be used to trigger the edit modal instead of inline editing
 		nonInlineEditableColumnTypes() {
 			return [
+				ColumnTypes.RelationLookup,
 			]
 		},
 	},
@@ -184,25 +160,6 @@ export default {
 			// If the column type doesn't support inline editing, trigger the edit modal
 			if (this.nonInlineEditableColumnTypes.includes(column.type) && this.config.canEditRows) {
 				this.$emit('edit-row', this.row.id)
-			}
-		},
-		getTableCell(column) {
-			switch (column.type) {
-			case ColumnTypes.TextLine: return 'TableCellTextLine'
-			case ColumnTypes.TextLink: return 'TableCellLink'
-			case ColumnTypes.TextRich:return 'TableCellTextRich'
-			case ColumnTypes.Number: return 'TableCellNumber'
-			case ColumnTypes.NumberStars: return 'TableCellStars'
-			case ColumnTypes.NumberProgress: return 'TableCellProgress'
-			case ColumnTypes.Selection: return 'TableCellSelection'
-			case ColumnTypes.SelectionMulti: return 'TableCellMultiSelection'
-			case ColumnTypes.SelectionCheck: return 'TableCellYesNo'
-			case ColumnTypes.Relation: return 'TableCellRelation'
-			case ColumnTypes.Datetime: return 'TableCellDateTime'
-			case ColumnTypes.DatetimeDate: return 'TableCellDateTime'
-			case ColumnTypes.DatetimeTime: return 'TableCellDateTime'
-			case ColumnTypes.Usergroup: return 'TableCellUsergroup'
-			default: return 'TableCellHtml'
 			}
 		},
 		getCell(columnId) {
@@ -236,7 +193,7 @@ export default {
 			}
 
 			// lets see if we have a value
-			const cell = this.getCell(column.id)
+			const cell = this.getCell(column.getValueColumnId())
 			let value
 
 			if (cell) {

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -148,6 +148,7 @@ export default {
 		// to be used to trigger the edit modal instead of inline editing
 		nonInlineEditableColumnTypes() {
 			return [
+				ColumnTypes.RelationLookup,
 			]
 		},
 	},
@@ -193,7 +194,7 @@ export default {
 			}
 
 			// lets see if we have a value
-			const cell = this.getCell(column.id)
+			const cell = this.getCell(column.getValueColumnId())
 			let value
 
 			if (cell) {

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationLookupForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationLookupForm.vue
@@ -1,0 +1,158 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div style="width: 100%">
+		<div class="row space-T">
+			<div class="fix-col-4 title">
+				{{ t('tables', 'Relation Column') }}
+			</div>
+			<div class="fix-col-4">
+				<NcSelect v-model="customSettings.relationColumnId"
+					:options="relationColumns"
+					:reduce="(option) => option.id"
+					:loading="loadingRelationColumns"
+					:aria-label-combobox="t('tables', 'Select relation column')"
+					required
+					@input="onRelationColumnChange" />
+			</div>
+		</div>
+
+		<div class="row space-T">
+			<div class="fix-col-4 title">
+				{{ t('tables', 'Target Column') }}
+			</div>
+			<div class="fix-col-4">
+				<NcSelect v-model="customSettings.targetColumnId"
+					:options="targetColumns"
+					:reduce="(option) => option.id"
+					:loading="loadingTargetColumns"
+					:aria-label-combobox="t('tables', 'Select target column')"
+					required
+					@input="onTargetColumnChange" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+import { translate as t } from '@nextcloud/l10n'
+import { mapState } from 'pinia'
+import { useTablesStore } from '../../../../../../store/store.js'
+import { useDataStore } from '../../../../../../store/data.js'
+import { ColumnTypes } from '../../../mixins/columnHandler.js'
+
+export default {
+	name: 'RelationLookupForm',
+	components: {
+		NcSelect,
+	},
+	props: {
+		column: {
+			type: Object,
+			required: true,
+		},
+	},
+	emits: [
+		'update:customSettings',
+	],
+	data() {
+		return {
+			customSettings: {
+				relationColumnId: this.column.customSettings.relationColumnId ?? null,
+				targetColumnId: this.column.customSettings.targetColumnId ?? null,
+			},
+			relationColumns: [],
+			targetColumns: [],
+			loadingRelationColumns: false,
+			loadingTargetColumns: false,
+		}
+	},
+	computed: {
+		...mapState(useTablesStore, ['activeTable', 'views']),
+		selectedRelationColumn() {
+			if (!this.customSettings.relationColumnId) {
+				return null
+			}
+			return this.relationColumns.find(c => c.id === this.customSettings.relationColumnId) || null
+		},
+		selectedTargetColumn() {
+			if (!this.customSettings.targetColumnId) {
+				return null
+			}
+			return this.targetColumns.find(c => c.id === this.customSettings.targetColumnId) || null
+		},
+	},
+	async mounted() {
+		await this.loadRelationColumns()
+		if (this.customSettings.relationColumnId) {
+			await this.loadTargetColumns()
+		}
+		if (!this.column.customSettings?.relationColumnId) {
+			this.updateCustomSettings()
+		}
+	},
+	methods: {
+		t,
+		async loadRelationColumns() {
+			this.loadingRelationColumns = true
+			try {
+				const dataStore = useDataStore()
+				const columns = await dataStore.getColumns(null, this.activeTable?.id)
+
+				this.relationColumns = columns
+					.filter(column => column.type === ColumnTypes.Relation)
+					.map(column => ({
+						id: column.id,
+						label: column.title,
+						column,
+					}))
+			} finally {
+				this.loadingRelationColumns = false
+			}
+		},
+		async loadTargetColumns() {
+			if (!this.selectedRelationColumn?.column?.customSettings) {
+				this.targetColumns = []
+				return
+			}
+
+			this.loadingTargetColumns = true
+			try {
+				const dataStore = useDataStore()
+				const relationSettings = this.selectedRelationColumn.column.customSettings
+				if (relationSettings.relationType === 'view') {
+					const view = this.views.find(view => view.id === relationSettings.targetId)
+					await dataStore.loadColumnsFromBE({ view, tableId: null })
+				} else {
+					await dataStore.loadColumnsFromBE({ view: null, tableId: relationSettings.targetId })
+				}
+
+				const columns = dataStore.getColumns(relationSettings.relationType === 'view', relationSettings.targetId)
+
+				this.targetColumns = columns
+					.filter(column => column.type !== ColumnTypes.RelationLookup)
+					.map(column => ({
+						id: column.id,
+						label: column.title,
+					}))
+			} finally {
+				this.loadingTargetColumns = false
+			}
+		},
+		async onRelationColumnChange() {
+			this.customSettings.targetColumnId = null
+			await this.loadTargetColumns()
+			this.updateCustomSettings()
+		},
+		onTargetColumnChange() {
+			this.updateCustomSettings()
+		},
+		updateCustomSettings() {
+			this.$emit('update:customSettings', { ...this.customSettings })
+		},
+	},
+}
+</script>

--- a/src/shared/components/ncTable/partials/rowTypePartials/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RelationForm.vue
@@ -60,9 +60,10 @@ export default {
 		relationOptions() {
 			const dataStore = useDataStore()
 			const activeElement = this.activeView || this.activeTable
-			if (activeElement) {
-				const columnRelations = dataStore.getRelations(this.column.id)
-				return Object.values(columnRelations)
+			if (activeElement && !this.loading) {
+				const columnRelations = dataStore.getRelations(this.column.id).values
+				return Object.values(columnRelations || {})
+					.map(relation => ({ id: relation.id, label: relation.value }))
 			}
 			return []
 		},

--- a/src/shared/components/ncTable/partials/rowTypePartials/RelationLookupForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RelationLookupForm.vue
@@ -1,0 +1,31 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<RowFormWrapper :title="column.title" :mandatory="column.mandatory" :description="column.description" :readonly="column.readonly">
+		<TableCellRelationLookup :column="column" :value="value" />
+	</RowFormWrapper>
+</template>
+
+<script>
+import RowFormWrapper from './RowFormWrapper.vue'
+import TableCellRelationLookup from '../TableCellRelationLookup.vue'
+
+export default {
+	name: 'RelationLookupForm',
+	components: {
+		RowFormWrapper,
+		TableCellRelationLookup,
+	},
+	props: {
+		column: {
+			type: Object,
+			required: true,
+		},
+		value: {
+			required: true,
+		},
+	},
+}
+</script>

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -227,6 +227,7 @@ export const useDataStore = defineStore('data', {
 			}
 
 			Object.entries(res.data).forEach(([columnId, relations]) => {
+				relations.column = relations.column ? parseCol(relations.column) : null
 				this.relations[columnId] = relations
 			})
 			this.relationsLoading[stateId] = false

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -239,6 +239,7 @@ export const useDataStore = defineStore('data', {
 			}
 
 			Object.entries(res.data).forEach(([columnId, relations]) => {
+				relations.column = relations.column ? parseCol(relations.column) : null
 				this.relations[columnId] = relations
 			})
 			this.relationsLoading[stateId] = false

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -332,6 +332,46 @@ export type paths = {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/index.php/apps/tables/api/1/tables/{tableId}/relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Get all relation data for a table
+         * @description This endpoint allows CORS requests
+         */
+        readonly get: operations["api1-index-table-relations"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/index.php/apps/tables/api/1/views/{viewId}/relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Get all relation data for a view
+         * @description This endpoint allows CORS requests
+         */
+        readonly get: operations["api1-index-view-relations"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/index.php/apps/tables/api/1/tables/{tableId}/rows/simple": {
         readonly parameters: {
             readonly query?: never;
@@ -1263,6 +1303,14 @@ export type components = {
                 };
             };
         };
+        readonly RelationData: readonly {
+            readonly column: components["schemas"]["Column"] | null;
+            readonly values: readonly {
+                /** Format: int64 */
+                readonly id: number;
+                readonly value: Record<string, never>;
+            }[];
+        }[];
         readonly Row: {
             /** Format: int64 */
             readonly id: number;
@@ -2932,7 +2980,7 @@ export interface operations {
                      * @description Column main type
                      * @enum {string}
                      */
-                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation";
+                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation" | "relation_lookup";
                     /** @description Column sub type */
                     readonly subtype?: string | null;
                     /** @description Is the column mandatory */
@@ -3194,7 +3242,7 @@ export interface operations {
                      * @description Column main type
                      * @enum {string}
                      */
-                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation";
+                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation" | "relation_lookup";
                     /** @description Column sub type */
                     readonly subtype?: string | null;
                     /** @description Is the column mandatory */
@@ -3581,6 +3629,152 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["Column"];
+                };
+            };
+            /** @description Current user is not logged in */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+        };
+    };
+    readonly "api1-index-table-relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Table ID */
+                readonly tableId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Relation data returned */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RelationData"] | readonly {
+                        readonly column: components["schemas"]["Column"] | null;
+                        readonly values: readonly {
+                            /** Format: int64 */
+                            readonly id: number;
+                            readonly value: Record<string, never>;
+                        }[];
+                    }[];
+                };
+            };
+            /** @description Current user is not logged in */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+        };
+    };
+    readonly "api1-index-view-relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description View ID */
+                readonly viewId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Relation data returned */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RelationData"] | readonly {
+                        readonly column: components["schemas"]["Column"] | null;
+                        readonly values: readonly {
+                            /** Format: int64 */
+                            readonly id: number;
+                            readonly value: Record<string, never>;
+                        }[];
+                    }[];
                 };
             };
             /** @description Current user is not logged in */

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -332,6 +332,46 @@ export type paths = {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/index.php/apps/tables/api/1/tables/{tableId}/relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Get all relation data for a table
+         * @description This endpoint allows CORS requests
+         */
+        readonly get: operations["api1-index-table-relations"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/index.php/apps/tables/api/1/views/{viewId}/relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Get all relation data for a view
+         * @description This endpoint allows CORS requests
+         */
+        readonly get: operations["api1-index-view-relations"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/index.php/apps/tables/api/1/tables/{tableId}/rows/simple": {
         readonly parameters: {
             readonly query?: never;
@@ -1160,6 +1200,14 @@ export type components = {
                 };
             };
         };
+        readonly RelationData: readonly {
+            readonly column: components["schemas"]["Column"] | null;
+            readonly values: readonly {
+                /** Format: int64 */
+                readonly id: number;
+                readonly value: Record<string, never>;
+            }[];
+        }[];
         readonly Row: {
             /** Format: int64 */
             readonly id: number;
@@ -2823,7 +2871,7 @@ export interface operations {
                      * @description Column main type
                      * @enum {string}
                      */
-                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation";
+                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation" | "relation_lookup";
                     /** @description Column sub type */
                     readonly subtype?: string | null;
                     /** @description Is the column mandatory */
@@ -3085,7 +3133,7 @@ export interface operations {
                      * @description Column main type
                      * @enum {string}
                      */
-                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation";
+                    readonly type: "text" | "number" | "datetime" | "select" | "usergroup" | "relation" | "relation_lookup";
                     /** @description Column sub type */
                     readonly subtype?: string | null;
                     /** @description Is the column mandatory */
@@ -3472,6 +3520,152 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["Column"];
+                };
+            };
+            /** @description Current user is not logged in */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+        };
+    };
+    readonly "api1-index-table-relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description Table ID */
+                readonly tableId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Relation data returned */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RelationData"] | readonly {
+                        readonly column: components["schemas"]["Column"] | null;
+                        readonly values: readonly {
+                            /** Format: int64 */
+                            readonly id: number;
+                            readonly value: Record<string, never>;
+                        }[];
+                    }[];
+                };
+            };
+            /** @description Current user is not logged in */
+            readonly 401: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
+        };
+    };
+    readonly "api1-index-view-relations": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                /** @description View ID */
+                readonly viewId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Relation data returned */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RelationData"] | readonly {
+                        readonly column: components["schemas"]["Column"] | null;
+                        readonly values: readonly {
+                            /** Format: int64 */
+                            readonly id: number;
+                            readonly value: Record<string, never>;
+                        }[];
+                    }[];
                 };
             };
             /** @description Current user is not logged in */

--- a/src/views/ContentReferenceWidget.vue
+++ b/src/views/ContentReferenceWidget.vue
@@ -19,7 +19,7 @@
 		<div v-if="rows && rows.length > 0" class="nc-table">
 			<NcTable
 				:rows="filteredRows"
-				:columns="richObject.columns"
+				:columns="parsedColumns"
 				:element-id="richObject.id"
 				:is-view="Boolean(richObject.type)"
 				v-bind="tablePermissions"
@@ -28,7 +28,7 @@
 				@delete-row="deleteRow" />
 		</div>
 		<CreateRow
-			:columns="richObject.columns"
+			:columns="parsedColumns"
 			:is-view="Boolean(richObject.type)"
 			:element-id="richObject.id"
 			:show-modal="showCopyRow"
@@ -54,6 +54,8 @@ import { useResizeObserver } from '@vueuse/core'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { useTablesStore } from '../store/store.js'
 import { useDataStore } from '../store/data.js'
+import { parseCol } from '../shared/components/ncTable/mixins/columnParser.js'
+import { AbstractColumn } from '../shared/components/ncTable/mixins/columnClass.js'
 
 export default {
 
@@ -95,6 +97,10 @@ export default {
 	},
 
 	computed: {
+		parsedColumns() {
+			if (!this.richObject?.columns) return []
+			return this.richObject.columns.map(col => (col instanceof AbstractColumn || col.id < 0) ? col : parseCol(col))
+		},
 		tablePermissions() {
 			return {
 				canCreateRows: this.canCreateRowInElement(this.richObject),
@@ -186,7 +192,7 @@ export default {
 			const { default: CreateRow } = await import('../modules/modals/CreateRow.vue')
 			spawnDialog(CreateRow, {
 				showModal: true,
-				columns: this.richObject.columns,
+				columns: this.parsedColumns,
 				isView: Boolean(this.richObject.type),
 				elementId: this.richObject.id,
 			}, async () => {
@@ -200,7 +206,7 @@ export default {
 			const { default: EditRow } = await import('../modules/modals/EditRow.vue')
 			spawnDialog(EditRow, {
 				showModal: true,
-				columns: this.richObject.columns,
+				columns: this.parsedColumns,
 				row: this.getRow(rowId),
 				isView: Boolean(this.richObject.type),
 				element: this.richObject,

--- a/tests/integration/features/APIv1.feature
+++ b/tests/integration/features/APIv1.feature
@@ -700,6 +700,65 @@ Feature: APIv1
     When user "participant2" fetches relations for table "secret-orders"
     Then the reported status is "404"
 
+  @api1 @relation @relation-lookup
+  Scenario: Create a relation lookup column and fetch relations for a table
+    Given table "Products" with emoji "📦" exists for user "participant1" as "products"
+    Then column "name" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then column "category" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then row exists with following values
+      | name     | Apple  |
+      | category | Fruit  |
+    Then row exists with following values
+      | name     | Banana |
+      | category | Berry  |
+    Given table "Orders" with emoji "🛒" exists for user "participant1" as "orders"
+    Then relation column "product" exists on table "orders" pointing to table "products" using label column "name"
+    Then relation lookup column "product category" exists on table "orders" for relation column "product" using target column "category"
+    When user "participant1" fetches relations for table "orders"
+    Then the reported status is "200"
+    Then the relations response contains 2 entries for column "product"
+    Then the relations response for column "product" has an entry with label "Apple"
+    Then the relations response for column "product" has an entry with label "Banana"
+    Then the relations response contains 2 entries for column "product category"
+    Then the relations response for column "product category" has an entry with value "Fruit"
+    Then the relations response for column "product category" has an entry with value "Berry"
+
+  @api1 @relation @relation-lookup
+  Scenario: Create a relation lookup column for a relation pointing to a view
+    Given table "Fruits" with emoji "🍎" exists for user "participant1" as "fruits"
+    Then column "name" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then column "color" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then row exists with following values
+      | name  | Apple  |
+      | color | Red    |
+    Then row exists with following values
+      | name  | Banana |
+      | color | Yellow |
+    When user "participant1" create view "Fruit View" with emoji "👁" for "fruits" as "fruit-view"
+    Given table "Baskets" with emoji "🧺" exists for user "participant1" as "baskets"
+    Then relation column "fruit" exists on table "baskets" pointing to view "fruit-view" using label column "name"
+    Then relation lookup column "fruit color" exists on table "baskets" for relation column "fruit" using target column "color"
+    When user "participant1" fetches relations for table "baskets"
+    Then the reported status is "200"
+    Then the relations response contains 2 entries for column "fruit"
+    Then the relations response for column "fruit" has an entry with label "Apple"
+    Then the relations response for column "fruit" has an entry with label "Banana"
+    Then the relations response contains 2 entries for column "fruit color"
+    Then the relations response for column "fruit color" has an entry with value "Red"
+    Then the relations response for column "fruit color" has an entry with value "Yellow"
+
   @api1 @columns @rows
   Scenario: Column technicalName is returned and dataByAlias maps alias to row values
     Given table "Alias test" with emoji "🔖" exists for user "participant1" as "base1"

--- a/tests/integration/features/APIv1.feature
+++ b/tests/integration/features/APIv1.feature
@@ -747,6 +747,65 @@ Feature: APIv1
     When user "participant2" fetches relations for table "secret-orders"
     Then the reported status is "404"
 
+  @api1 @relation @relation-lookup
+  Scenario: Create a relation lookup column and fetch relations for a table
+    Given table "Products" with emoji "📦" exists for user "participant1" as "products"
+    Then column "name" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then column "category" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then row exists with following values
+      | name     | Apple  |
+      | category | Fruit  |
+    Then row exists with following values
+      | name     | Banana |
+      | category | Berry  |
+    Given table "Orders" with emoji "🛒" exists for user "participant1" as "orders"
+    Then relation column "product" exists on table "orders" pointing to table "products" using label column "name"
+    Then relation lookup column "product category" exists on table "orders" for relation column "product" using target column "category"
+    When user "participant1" fetches relations for table "orders"
+    Then the reported status is "200"
+    Then the relations response contains 2 entries for column "product"
+    Then the relations response for column "product" has an entry with label "Apple"
+    Then the relations response for column "product" has an entry with label "Banana"
+    Then the relations response contains 2 entries for column "product category"
+    Then the relations response for column "product category" has an entry with value "Fruit"
+    Then the relations response for column "product category" has an entry with value "Berry"
+
+  @api1 @relation @relation-lookup
+  Scenario: Create a relation lookup column for a relation pointing to a view
+    Given table "Fruits" with emoji "🍎" exists for user "participant1" as "fruits"
+    Then column "name" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then column "color" exists with following properties
+      | type      | text |
+      | subtype   | line |
+      | mandatory | 0    |
+    Then row exists with following values
+      | name  | Apple  |
+      | color | Red    |
+    Then row exists with following values
+      | name  | Banana |
+      | color | Yellow |
+    When user "participant1" create view "Fruit View" with emoji "👁" for "fruits" as "fruit-view"
+    Given table "Baskets" with emoji "🧺" exists for user "participant1" as "baskets"
+    Then relation column "fruit" exists on table "baskets" pointing to view "fruit-view" using label column "name"
+    Then relation lookup column "fruit color" exists on table "baskets" for relation column "fruit" using target column "color"
+    When user "participant1" fetches relations for table "baskets"
+    Then the reported status is "200"
+    Then the relations response contains 2 entries for column "fruit"
+    Then the relations response for column "fruit" has an entry with label "Apple"
+    Then the relations response for column "fruit" has an entry with label "Banana"
+    Then the relations response contains 2 entries for column "fruit color"
+    Then the relations response for column "fruit color" has an entry with value "Red"
+    Then the relations response for column "fruit color" has an entry with value "Yellow"
+
   @api1 @columns @rows
   Scenario: Column technicalName is returned and dataByAlias maps alias to row values
     Given table "Alias test" with emoji "🔖" exists for user "participant1" as "base1"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2667,6 +2667,74 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @Then relation lookup column :title exists on table :tableName for relation column :relationColumnName using target column :targetColumnName
+	 */
+	public function createRelationLookupColumn(string $title, string $tableName, string $relationColumnName, string $targetColumnName): void {
+		$relationColumnId = (int)$this->collectionManager->getByAlias('column', $relationColumnName)['id'];
+		$targetColumnId = (int)$this->collectionManager->getByAlias('column', $targetColumnName)['id'];
+
+		$props = [
+			'title' => $title,
+			'type' => 'relation_lookup',
+			'mandatory' => 0,
+			'customSettings' => [
+				'relationColumnId' => $relationColumnId,
+				'targetColumnId' => $targetColumnId,
+			],
+		];
+
+		$this->sendRequest(
+			'POST',
+			'/apps/tables/api/1/tables/' . $this->tableIds[$tableName] . '/columns',
+			$props
+		);
+
+		$newColumn = $this->getDataFromResponse($this->response);
+		$this->columnId = $newColumn['id'];
+
+		Assert::assertEquals(200, $this->response->getStatusCode());
+		Assert::assertEquals($title, $newColumn['title']);
+		Assert::assertEquals('relation_lookup', $newColumn['type']);
+
+		$this->collectionManager->register($newColumn, 'column', $newColumn['id'], $title);
+	}
+
+	/**
+	 * @Then relation lookup column :title exists on table :tableName for relation column :relationColumnName using target column :targetColumnName added to view :viewName
+	 */
+	public function createRelationLookupColumnAddedToView(string $title, string $tableName, string $relationColumnName, string $targetColumnName, string $viewName): void {
+		$relationColumnId = (int)$this->collectionManager->getByAlias('column', $relationColumnName)['id'];
+		$targetColumnId = (int)$this->collectionManager->getByAlias('column', $targetColumnName)['id'];
+		$viewId = $this->viewIds[$viewName];
+
+		$props = [
+			'title' => $title,
+			'type' => 'relation_lookup',
+			'mandatory' => 0,
+			'selectedViewIds' => [$viewId],
+			'customSettings' => [
+				'relationColumnId' => $relationColumnId,
+				'targetColumnId' => $targetColumnId,
+			],
+		];
+
+		$this->sendRequest(
+			'POST',
+			'/apps/tables/api/1/tables/' . $this->tableIds[$tableName] . '/columns',
+			$props
+		);
+
+		$newColumn = $this->getDataFromResponse($this->response);
+		$this->columnId = $newColumn['id'];
+
+		Assert::assertEquals(200, $this->response->getStatusCode());
+		Assert::assertEquals($title, $newColumn['title']);
+		Assert::assertEquals('relation_lookup', $newColumn['type']);
+
+		$this->collectionManager->register($newColumn, 'column', $newColumn['id'], $title);
+	}
+
+	/**
 	 * @When user :user fetches relations for table :tableName
 	 */
 	public function userFetchesRelationsForTable(string $user, string $tableName): void {
@@ -2701,7 +2769,7 @@ class FeatureContext implements Context {
 		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
 		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
 		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" (id=' . $columnId . ') not found in relations response');
-		Assert::assertCount($count, $this->relationsData[$columnId], 'Expected ' . $count . ' entries for column "' . $columnName . '"');
+		Assert::assertCount($count, $this->relationsData[$columnId]['values'], 'Expected ' . $count . ' entries for column "' . $columnName . '"');
 	}
 
 	/**
@@ -2711,8 +2779,19 @@ class FeatureContext implements Context {
 		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
 		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
 		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" not found in relations response');
-		$labels = array_column($this->relationsData[$columnId], 'label');
+		$labels = array_column($this->relationsData[$columnId]['values'], 'value');
 		Assert::assertContains($label, $labels, 'Label "' . $label . '" not found in relations for column "' . $columnName . '"');
+	}
+
+	/**
+	 * @Then the relations response for column :columnName has an entry with value :value
+	 */
+	public function theRelationsResponseForColumnHasEntryWithValue(string $columnName, string $value): void {
+		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
+		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
+		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" not found in relations response');
+		$values = array_column($this->relationsData[$columnId]['values'], 'value');
+		Assert::assertContains($value, $values, 'Value "' . $value . '" not found in relations for column "' . $columnName . '"');
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2673,6 +2673,74 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @Then relation lookup column :title exists on table :tableName for relation column :relationColumnName using target column :targetColumnName
+	 */
+	public function createRelationLookupColumn(string $title, string $tableName, string $relationColumnName, string $targetColumnName): void {
+		$relationColumnId = (int)$this->collectionManager->getByAlias('column', $relationColumnName)['id'];
+		$targetColumnId = (int)$this->collectionManager->getByAlias('column', $targetColumnName)['id'];
+
+		$props = [
+			'title' => $title,
+			'type' => 'relation_lookup',
+			'mandatory' => 0,
+			'customSettings' => [
+				'relationColumnId' => $relationColumnId,
+				'targetColumnId' => $targetColumnId,
+			],
+		];
+
+		$this->sendRequest(
+			'POST',
+			'/apps/tables/api/1/tables/' . $this->tableIds[$tableName] . '/columns',
+			$props
+		);
+
+		$newColumn = $this->getDataFromResponse($this->response);
+		$this->columnId = $newColumn['id'];
+
+		Assert::assertEquals(200, $this->response->getStatusCode());
+		Assert::assertEquals($title, $newColumn['title']);
+		Assert::assertEquals('relation_lookup', $newColumn['type']);
+
+		$this->collectionManager->register($newColumn, 'column', $newColumn['id'], $title);
+	}
+
+	/**
+	 * @Then relation lookup column :title exists on table :tableName for relation column :relationColumnName using target column :targetColumnName added to view :viewName
+	 */
+	public function createRelationLookupColumnAddedToView(string $title, string $tableName, string $relationColumnName, string $targetColumnName, string $viewName): void {
+		$relationColumnId = (int)$this->collectionManager->getByAlias('column', $relationColumnName)['id'];
+		$targetColumnId = (int)$this->collectionManager->getByAlias('column', $targetColumnName)['id'];
+		$viewId = $this->viewIds[$viewName];
+
+		$props = [
+			'title' => $title,
+			'type' => 'relation_lookup',
+			'mandatory' => 0,
+			'selectedViewIds' => [$viewId],
+			'customSettings' => [
+				'relationColumnId' => $relationColumnId,
+				'targetColumnId' => $targetColumnId,
+			],
+		];
+
+		$this->sendRequest(
+			'POST',
+			'/apps/tables/api/1/tables/' . $this->tableIds[$tableName] . '/columns',
+			$props
+		);
+
+		$newColumn = $this->getDataFromResponse($this->response);
+		$this->columnId = $newColumn['id'];
+
+		Assert::assertEquals(200, $this->response->getStatusCode());
+		Assert::assertEquals($title, $newColumn['title']);
+		Assert::assertEquals('relation_lookup', $newColumn['type']);
+
+		$this->collectionManager->register($newColumn, 'column', $newColumn['id'], $title);
+	}
+
+	/**
 	 * @When user :user fetches relations for table :tableName
 	 */
 	public function userFetchesRelationsForTable(string $user, string $tableName): void {
@@ -2719,6 +2787,17 @@ class FeatureContext implements Context {
 		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" not found in relations response');
 		$labels = array_column($this->relationsData[$columnId]['values'], 'value');
 		Assert::assertContains($label, $labels, 'Label "' . $label . '" not found in relations for column "' . $columnName . '"');
+	}
+
+	/**
+	 * @Then the relations response for column :columnName has an entry with value :value
+	 */
+	public function theRelationsResponseForColumnHasEntryWithValue(string $columnName, string $value): void {
+		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
+		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
+		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" not found in relations response');
+		$values = array_column($this->relationsData[$columnId]['values'], 'value');
+		Assert::assertContains($value, $values, 'Value "' . $value . '" not found in relations for column "' . $columnName . '"');
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -2707,7 +2707,7 @@ class FeatureContext implements Context {
 		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
 		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
 		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" (id=' . $columnId . ') not found in relations response');
-		Assert::assertCount($count, $this->relationsData[$columnId], 'Expected ' . $count . ' entries for column "' . $columnName . '"');
+		Assert::assertCount($count, $this->relationsData[$columnId]['values'], 'Expected ' . $count . ' entries for column "' . $columnName . '"');
 	}
 
 	/**
@@ -2717,7 +2717,7 @@ class FeatureContext implements Context {
 		Assert::assertNotNull($this->relationsData, 'Relations response was not fetched or returned non-200');
 		$columnId = (int)$this->collectionManager->getByAlias('column', $columnName)['id'];
 		Assert::assertArrayHasKey($columnId, $this->relationsData, 'Column "' . $columnName . '" not found in relations response');
-		$labels = array_column($this->relationsData[$columnId], 'label');
+		$labels = array_column($this->relationsData[$columnId]['values'], 'value');
 		Assert::assertContains($label, $labels, 'Label "' . $label . '" not found in relations for column "' . $columnName . '"');
 	}
 


### PR DESCRIPTION
This is continuation of #2248 that allows to display more column from relation table.
There are 2 tables: `employees` and `vacations`. We can add `vacation.requester` **relation** column that referenced to the row id of the `employee` and display `employee.name`. But what if we need to display more column from the related table? e.g. `employee.department`. That's where **relation lookup** can help: select already existent relation and choose what extra column should be displayed.

## :framed_picture: Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/686c1179-3d11-4dcb-8eb1-bbf64bcb6115" /> <br />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/48d65a04-259c-4c3e-b6f1-5bcfeb8fe388" />

## :spiral_notepad: TODO
- [x] Merge https://github.com/nextcloud/tables/pull/2763 first


