### PR TITLE
fix: menu items are not closed for row actions

### DIFF
--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -32,19 +32,19 @@
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
 				<NcActions type="secondary" :force-name="true" :inline="showFullOptions ? 2 : 0">
-					<NcActionButton @click="exportCsv">
+					<NcActionButton close-after-click @click="exportCsv">
 						<template #icon>
 							<Export :size="20" />
 						</template>
 						{{ t('tables', 'Export CSV') }}
 					</NcActionButton>
-					<NcActionButton v-if="config.canDeleteRows" @click="deleteSelectedRows">
+					<NcActionButton v-if="config.canDeleteRows" close-after-click @click="deleteSelectedRows">
 						<template #icon>
 							<Delete :size="20" />
 						</template>
 						{{ t('tables', 'Delete') }}
 					</NcActionButton>
-					<NcActionButton v-if="!showFullOptions" @click="deselectAllRows">
+					<NcActionButton v-if="!showFullOptions" close-after-click @click="deselectAllRows">
 						<template #icon>
 							<Check :size="20" />
 						</template>


### PR DESCRIPTION
This PR fixes that menu items are not closed for row actions

before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b732be60-42e1-4865-b3eb-3b441afa0cd3" />

after
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3dce13dc-2f94-404a-9cfe-4caa3d29b4ac" />
