### PR TITLE
fix: it is not possible to clear non-mandatory selects during inline edit

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellMultiSelection.vue
+++ b/src/shared/components/ncTable/partials/TableCellMultiSelection.vue
@@ -20,10 +20,10 @@
 			<NcSelect v-model="editValues"
 				:tag-width="80"
 				:options="getAllNonDeletedOrSelectedOptions"
+				:clearable="!column.mandatory"
 				:multiple="true"
 				:aria-label-combobox="t('tables', 'Options')"
 				:disabled="localLoading || !canEditCell()"
-				:clearable="true"
 				style="width: 100%;" />
 			<div v-if="localLoading" class="loading-indicator">
 				<div class="icon-loading-small icon-loading-inline" />

--- a/src/shared/components/ncTable/partials/TableCellSelection.vue
+++ b/src/shared/components/ncTable/partials/TableCellSelection.vue
@@ -15,6 +15,7 @@
 			@keydown.escape.stop="cancelEdit">
 			<NcSelect v-model="editValue"
 				:options="getAllNonDeletedOptions"
+				:clearable="!column.mandatory"
 				:aria-label-combobox="t('tables', 'Options')"
 				:disabled="localLoading || !canEditCell()"
 				style="width: 100%;" />

--- a/src/shared/components/ncTable/partials/TableCellUsergroup.vue
+++ b/src/shared/components/ncTable/partials/TableCellUsergroup.vue
@@ -21,6 +21,7 @@
 				style="width: 100%;"
 				:loading="loading || localLoading"
 				:options="options"
+				:clearable="!column.mandatory"
 				:placeholder="getPlaceholder()"
 				:searchable="true"
 				:get-option-key="(option) => option.key"

--- a/src/shared/components/ncTable/partials/rowTypePartials/SelectionForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/SelectionForm.vue
@@ -7,6 +7,7 @@
 		<NcSelect
 			v-model="localValue"
 			:options="getAllNonDeletedOptions"
+			:clearable="!column.mandatory"
 			:disabled="column.viewColumnInformation?.readonly"
 			:aria-label-combobox="t('tables', 'Options')" />
 	</RowFormWrapper>

--- a/src/shared/components/ncTable/partials/rowTypePartials/SelectionMultiForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/SelectionMultiForm.vue
@@ -8,6 +8,7 @@
 			v-model="localValues"
 			:tag-width="80"
 			:options="getAllNonDeletedOrSelectedOptions"
+			:clearable="!column.mandatory"
 			:disabled="column.viewColumnInformation?.readonly"
 			:multiple="true"
 			:aria-label-combobox="t('tables', 'Options')" />

--- a/src/shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue
@@ -8,8 +8,11 @@
 			:placeholder="getPlaceholder()" :searchable="true" :get-option-key="(option) => option.key"
 			label="displayName" :aria-label-combobox="getPlaceholder()"
 			:user-select="true"
+			:clearable="!column.mandatory"
 			:disabled="column.viewColumnInformation?.readonly"
-			:close-on-select="false" :multiple="column.usergroupMultipleItems" data-cy="usergroupRowSelect"
+			:close-on-select="false"
+			:multiple="column.usergroupMultipleItems"
+			data-cy="usergroupRowSelect"
 			@search="asyncFind" @input="addItem">
 			<template #noResult>
 				{{ noResultText }}

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -54,7 +54,11 @@
 					</template>
 				</NcButton>
 				<div class="page-number">
-					<NcSelect v-model="pageNumber" :options="allPageNumbersArray" :aria-label-combobox="t('tables', 'Page number')">
+					<NcSelect
+						v-model="pageNumber"
+						:options="allPageNumbersArray"
+						:clearable="false"
+						:aria-label-combobox="t('tables', 'Page number')">
 						<template #selected-option-container="{ option }">
 							<span class="selected-page">
 								{{ option.label }} of {{ totalPages }}
@@ -90,7 +94,7 @@ import { NcButton, useIsMobile, NcSelect } from '@nextcloud/vue'
 import { mapState } from 'pinia'
 import {
 	TYPE_META_ID, TYPE_META_CREATED_BY, TYPE_META_CREATED_AT, TYPE_META_UPDATED_BY, TYPE_META_UPDATED_AT,
-} from '../../../../shared/constants.ts'
+} from '../../../constants.ts'
 import { MetaColumns } from '../mixins/metaColumns.js'
 import { translate as t } from '@nextcloud/l10n'
 import { useTablesStore } from '../../../../store/store.js'
@@ -408,17 +412,6 @@ export default {
 </style>
 
 <style lang="scss" scoped>
-:deep(.vs__clear) {
-	display: none;
-}
-
-:deep(.v-select) {
-	min-width: 95px !important;
-	.vs__dropdown-toggle {
-		background: none;
-	}
-}
-
 :deep(.text-editor__wrapper .paragraph-content:last-child) {
 	margin-bottom: 0!important;
 }
@@ -462,6 +455,10 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
+
+	:deep(.v-select) {
+		min-width: 95px !important;
+	}
 }
 
 :deep(table) {


### PR DESCRIPTION
There is a conflict between `NcSelect` components that are used in pagination footer and inline edit. This PR fixes it for select/multu-select/user-groups column types

Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/79852918-9af3-41db-9fb5-511ee86472f7" />

After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1445d25f-4dc2-4ca1-9164-c5b34bad814d" />

And vise versa for popup edit field: we're displaying clear button even for mandatory columns
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f1cab89b-792e-4efe-afde-2e0364ce0977" />

Related to https://github.com/nextcloud/tables/issues/2054#issuecomment-3761299903