### PR TITLE
refactor: Refactor business column classes

### DIFF
--- a/lib/Helper/ColumnsHelper.php
+++ b/lib/Helper/ColumnsHelper.php
@@ -9,6 +9,8 @@ namespace OCA\Tables\Helper;
 
 use OCA\Tables\Constants\UsergroupType;
 use OCA\Tables\Db\Column;
+use OCA\Tables\Service\ColumnTypes\IColumnTypeBusiness;
+use OCP\Server;
 
 class ColumnsHelper {
 
@@ -19,6 +21,11 @@ class ColumnsHelper {
 		Column::TYPE_SELECTION,
 		Column::TYPE_USERGROUP,
 	];
+
+	/**
+	 * @var array<string, IColumnTypeBusiness>
+	 */
+	private array $columnBusinesses = [];
 
 	public function __construct(
 		private UserHelper $userHelper,
@@ -78,5 +85,19 @@ class ColumnsHelper {
 				return date('Y-m-d', strtotime("-{$days} days")) ?: '';
 			default: return $placeholder;
 		}
+	}
+
+	public function getColumnBusinessObject(Column $column): IColumnTypeBusiness {
+		$cacheKey = implode(':', [$column->getType(), $column->getSubtype()]);
+		if (isset($this->columnBusinesses[$cacheKey])) {
+			return $this->columnBusinesses[$cacheKey];
+		}
+
+		$businessClassName = 'OCA\Tables\Service\ColumnTypes\\';
+		$businessClassName .= ucfirst($column->getType()) . ucfirst($column->getSubtype()) . 'Business';
+		/** @var IColumnTypeBusiness $columnBusiness */
+		$columnBusiness = Server::get($businessClassName);
+
+		return $this->columnBusinesses[$cacheKey] = $columnBusiness;
 	}
 }

--- a/lib/Service/ColumnTypes/DatetimeBusiness.php
+++ b/lib/Service/ColumnTypes/DatetimeBusiness.php
@@ -11,14 +11,14 @@ use DateTime;
 use Exception;
 use OCA\Tables\Db\Column;
 
-class DatetimeBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class DatetimeBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		if ($value === '' || $value === null) {
 			return '';
 		}
@@ -38,15 +38,15 @@ class DatetimeBusiness extends SuperBusiness implements IColumnTypeBusiness {
 			$this->logger->debug('Could not parse format for datetime value', ['exception' => $e]);
 		}
 
-		return json_encode($newDateTime !== '' ? $newDateTime : '');
+		return json_encode($newDateTime);
 	}
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		if ($value === '' || $value === null) {
 			return true;
 		}

--- a/lib/Service/ColumnTypes/DatetimeDateBusiness.php
+++ b/lib/Service/ColumnTypes/DatetimeDateBusiness.php
@@ -9,24 +9,23 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class DatetimeDateBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class DatetimeDateBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		return json_encode($this->isValidDate((string)$value, 'Y-m-d') ? (string)$value : '');
 	}
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return $this->isValidDate((string)$value, 'Y-m-d');
 	}
-
 }

--- a/lib/Service/ColumnTypes/DatetimeTimeBusiness.php
+++ b/lib/Service/ColumnTypes/DatetimeTimeBusiness.php
@@ -9,23 +9,23 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class DatetimeTimeBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class DatetimeTimeBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		return json_encode($this->isValidDate((string)$value, 'H:i') ? $value : '');
 	}
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return $this->isValidDate((string)$value, 'H:i');
 	}
 

--- a/lib/Service/ColumnTypes/IColumnTypeBusiness.php
+++ b/lib/Service/ColumnTypes/IColumnTypeBusiness.php
@@ -20,19 +20,19 @@ interface IColumnTypeBusiness {
 	 * FIXME: Why is this not using Mapper methods which should do the same thing
 	 *
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string value stringify
 	 */
-	public function parseValue($value, ?Column $column): string;
+	public function parseValue($value, Column $column): string;
 
 	/**
-	 * tests if the given value can be parsed to a value of the column type
+	 * Tests if the given value can be parsed to a value of the column type
 	 *
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column): bool;
+	public function canBeParsed($value, Column $column): bool;
 
 	/**
 	 * @throws BadRequestError In case the value is not valid
@@ -44,20 +44,20 @@ interface IColumnTypeBusiness {
 	public function validateValue(mixed $value, Column $column, string $userId, int $tableId, ?int $rowId): void;
 
 	/**
-	 * tests if the given string can be parsed to a value/id of the column type
+	 * Tests if the given string can be parsed to a value/id of the column type
 	 *
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsedDisplayValue($value, ?Column $column): bool;
+	public function canBeParsedDisplayValue($value, Column $column): bool;
 
 	/**
-	 * parses the given string to a value/id of the column type
+	 * Parses the given string to a value/id of the column type
 	 *
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseDisplayValue($value, ?Column $column): string;
+	public function parseDisplayValue($value, Column $column): string;
 }

--- a/lib/Service/ColumnTypes/NumberBusiness.php
+++ b/lib/Service/ColumnTypes/NumberBusiness.php
@@ -9,14 +9,14 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class NumberBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class NumberBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (int|float|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		if ($value === null) {
 			return '';
 		}
@@ -26,10 +26,10 @@ class NumberBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 	/**
 	 * @param mixed $value (int|float|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return !$value || floatval($value);
 	}
 

--- a/lib/Service/ColumnTypes/NumberProgressBusiness.php
+++ b/lib/Service/ColumnTypes/NumberProgressBusiness.php
@@ -9,23 +9,23 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class NumberProgressBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class NumberProgressBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (int|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		return json_encode((int)$value);
 	}
 
 	/**
 	 * @param mixed $value (int|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return !$value || ((int)$value >= 0 && (int)$value <= 100);
 	}
 

--- a/lib/Service/ColumnTypes/NumberStarsBusiness.php
+++ b/lib/Service/ColumnTypes/NumberStarsBusiness.php
@@ -9,23 +9,23 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class NumberStarsBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class NumberStarsBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (null|int|string)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		return json_encode((int)$value);
 	}
 
 	/**
 	 * @param mixed $value (null|int|string)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return !$value || in_array((int)$value, [0,1,2,3,4,5]);
 	}
 

--- a/lib/Service/ColumnTypes/SelectionBusiness.php
+++ b/lib/Service/ColumnTypes/SelectionBusiness.php
@@ -9,19 +9,14 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class SelectionBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class SelectionBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (array|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return '';
-		}
-
+	public function parseValue($value, Column $column): string {
 		$intValue = (int)$value;
 		if (!is_numeric($value) || $intValue != $value) {
 			return '';
@@ -36,12 +31,7 @@ class SelectionBusiness extends SuperBusiness implements IColumnTypeBusiness {
 		return '';
 	}
 
-	public function parseDisplayValue($value, ?Column $column = null): string {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return '';
-		}
-
+	public function parseDisplayValue($value, Column $column): string {
 		foreach ($column->getSelectionOptionsArray() as $option) {
 			if ($option['label'] === $value) {
 				return json_encode($option['id']);
@@ -53,14 +43,10 @@ class SelectionBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 	/**
 	 * @param mixed $value (array|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return false;
-		}
+	public function canBeParsed($value, Column $column): bool {
 		if ($value === null) {
 			return true;
 		}
@@ -79,11 +65,7 @@ class SelectionBusiness extends SuperBusiness implements IColumnTypeBusiness {
 		return false;
 	}
 
-	public function canBeParsedDisplayValue($value, ?Column $column = null): bool {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return false;
-		}
+	public function canBeParsedDisplayValue($value, Column $column): bool {
 		if ($value === null) {
 			return true;
 		}

--- a/lib/Service/ColumnTypes/SelectionCheckBusiness.php
+++ b/lib/Service/ColumnTypes/SelectionCheckBusiness.php
@@ -9,31 +9,30 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class SelectionCheckBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class SelectionCheckBusiness extends SuperBusiness {
 	public const PATTERN_POSITIVE = ['yes', '1', true, 1, 'true', 'TRUE'];
 	public const PATTERN_NEGATIVE = ['no', '0', false, 0, 'false', 'FALSE'];
 
 	/**
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		$found = in_array($value, self::PATTERN_POSITIVE, true);
 		return json_encode($found ? 'true' : 'false');
 	}
 
 	/**
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		if ($value === null) {
 			return true;
 		}
 
 		return in_array($value, self::PATTERN_POSITIVE) || in_array($value, self::PATTERN_NEGATIVE) ;
 	}
-
 }

--- a/lib/Service/ColumnTypes/SelectionMultiBusiness.php
+++ b/lib/Service/ColumnTypes/SelectionMultiBusiness.php
@@ -9,21 +9,16 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class SelectionMultiBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class SelectionMultiBusiness extends SuperBusiness {
 
 	private array $options = [];
 
 	/**
 	 * @param mixed $value (array|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return json_encode([]);
-		}
-
+	public function parseValue($value, Column $column): string {
 		if ($value === null) {
 			return json_encode([]);
 		}
@@ -74,15 +69,10 @@ class SelectionMultiBusiness extends SuperBusiness implements IColumnTypeBusines
 
 	/**
 	 * @param mixed $value (int[]|string|null) Array of option IDs or string with comma seperated labels
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return false;
-		}
-
+	public function canBeParsed($value, Column $column): bool {
 		if ($value === null) {
 			return true;
 		}

--- a/lib/Service/ColumnTypes/SuperBusiness.php
+++ b/lib/Service/ColumnTypes/SuperBusiness.php
@@ -11,7 +11,7 @@ use DateTime;
 use OCA\Tables\Db\Column;
 use Psr\Log\LoggerInterface;
 
-class SuperBusiness {
+class SuperBusiness implements IColumnTypeBusiness {
 
 	protected LoggerInterface $logger;
 
@@ -21,23 +21,23 @@ class SuperBusiness {
 
 	/**
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		return json_encode($value);
 	}
 
-	public function parseDisplayValue($value, ?Column $column = null): string {
+	public function parseDisplayValue($value, Column $column): string {
 		return $this->parseValue($value, $column);
 	}
 
 	/**
 	 * @param mixed $value
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		return true;
 	}
 
@@ -45,7 +45,7 @@ class SuperBusiness {
 		// override this method in the child class when needed
 	}
 
-	public function canBeParsedDisplayValue($value, ?Column $column = null): bool {
+	public function canBeParsedDisplayValue($value, Column $column): bool {
 		return $this->canBeParsed($value, $column);
 	}
 

--- a/lib/Service/ColumnTypes/TextLineBusiness.php
+++ b/lib/Service/ColumnTypes/TextLineBusiness.php
@@ -13,7 +13,7 @@ use OCA\Tables\Errors\BadRequestError;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
-class TextLineBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class TextLineBusiness extends SuperBusiness {
 
 	public function __construct(
 		LoggerInterface $logger,

--- a/lib/Service/ColumnTypes/TextLinkBusiness.php
+++ b/lib/Service/ColumnTypes/TextLinkBusiness.php
@@ -9,14 +9,14 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class TextLinkBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class TextLinkBusiness extends SuperBusiness {
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
+	public function parseValue($value, Column $column): string {
 		if ($value === null) {
 			return '';
 		}
@@ -64,10 +64,10 @@ class TextLinkBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 	/**
 	 * @param mixed $value (string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
+	public function canBeParsed($value, Column $column): bool {
 		if (!$value) {
 			return true;
 		}

--- a/lib/Service/ColumnTypes/TextLongBusiness.php
+++ b/lib/Service/ColumnTypes/TextLongBusiness.php
@@ -7,6 +7,6 @@
 
 namespace OCA\Tables\Service\ColumnTypes;
 
-class TextLongBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class TextLongBusiness extends SuperBusiness {
 
 }

--- a/lib/Service/ColumnTypes/TextRichBusiness.php
+++ b/lib/Service/ColumnTypes/TextRichBusiness.php
@@ -7,6 +7,6 @@
 
 namespace OCA\Tables\Service\ColumnTypes;
 
-class TextRichBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class TextRichBusiness extends SuperBusiness {
 
 }

--- a/lib/Service/ColumnTypes/UsergroupBusiness.php
+++ b/lib/Service/ColumnTypes/UsergroupBusiness.php
@@ -9,7 +9,7 @@ namespace OCA\Tables\Service\ColumnTypes;
 
 use OCA\Tables\Db\Column;
 
-class UsergroupBusiness extends SuperBusiness implements IColumnTypeBusiness {
+class UsergroupBusiness extends SuperBusiness {
 
 	/**
 	 * Parse frontend value (array) and transform for using it in the database (array)
@@ -20,15 +20,10 @@ class UsergroupBusiness extends SuperBusiness implements IColumnTypeBusiness {
 	 * Why not use Mapper::parseValueIncoming
 	 *
 	 * @param mixed $value (array|string|null)
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return string
 	 */
-	public function parseValue($value, ?Column $column = null): string {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return json_encode([]);
-		}
-
+	public function parseValue($value, Column $column): string {
 		if ($value === null) {
 			return json_encode([]);
 		}
@@ -38,15 +33,10 @@ class UsergroupBusiness extends SuperBusiness implements IColumnTypeBusiness {
 
 	/**
 	 * @param mixed $value parsable is json encoded array{id: string, type: int}
-	 * @param Column|null $column
+	 * @param Column $column
 	 * @return bool
 	 */
-	public function canBeParsed($value, ?Column $column = null): bool {
-		if (!$column) {
-			$this->logger->warning('No column given, but expected on ' . __FUNCTION__ . ' within ' . __CLASS__, ['exception' => new \Exception()]);
-			return false;
-		}
-
+	public function canBeParsed($value, Column $column): bool {
 		if ($value === null) {
 			return true;
 		}

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -34,7 +34,6 @@ use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
-use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
@@ -344,7 +343,7 @@ class RowService extends SuperService {
 			$column = $this->getColumnFromColumnsArray($columnId, $columns);
 
 			if ($column) {
-				$columnBusiness = $this->getColumnBusiness($column);
+				$columnBusiness = $this->columnsHelper->getColumnBusinessObject($column);
 				$columnBusiness->validateValue($entry['value'], $column, $this->userId, $tableId, $rowId);
 			}
 
@@ -426,7 +425,7 @@ class RowService extends SuperService {
 
 			if ($hasValue) {
 				try {
-					$columnBusiness = $this->getColumnBusiness($column);
+					$columnBusiness = $this->columnsHelper->getColumnBusinessObject($column);
 					$isValid = $this->isValueValidForMandatoryColumn($value, $column, $columnBusiness);
 					if (!$isValid) {
 						throw new BadRequestError(
@@ -478,7 +477,7 @@ class RowService extends SuperService {
 	 */
 	private function parseValueByColumnType(Column $column, $value = null) {
 		try {
-			$columnBusiness = $this->getColumnBusiness($column);
+			$columnBusiness = $this->columnsHelper->getColumnBusinessObject($column);
 			if ($columnBusiness->canBeParsed($value, $column)) {
 				return json_decode($columnBusiness->parseValue($value, $column), true);
 			}
@@ -836,15 +835,6 @@ class RowService extends SuperService {
 		$row->filterDataByColumns($view->getColumnIds());
 
 		return $row;
-	}
-
-	private function getColumnBusiness(Column $column): IColumnTypeBusiness {
-		$businessClassName = 'OCA\Tables\Service\ColumnTypes\\';
-		$businessClassName .= ucfirst($column->getType()) . ucfirst($column->getSubtype()) . 'Business';
-		/** @var IColumnTypeBusiness $columnBusiness */
-		$columnBusiness = Server::get($businessClassName);
-
-		return $columnBusiness;
 	}
 
 	/**

--- a/tests/unit/Service/ColumnTypes/SelectionBusinessTest.php
+++ b/tests/unit/Service/ColumnTypes/SelectionBusinessTest.php
@@ -114,22 +114,4 @@ class SelectionBusinessTest extends TestCase {
 		$result = $this->selectionBusiness->canBeParsedDisplayValue($value, $this->column);
 		$this->assertEquals($expected, $result);
 	}
-
-	public function withoutColumnProvider(): array {
-		return [
-			'parseValue' => ['parseValue', 1, ''],
-			'parseDisplayValue' => ['parseDisplayValue', 'Option 1', ''],
-			'canBeParsed' => ['canBeParsed', 1, false],
-			'canBeParsedDisplayValue' => ['canBeParsedDisplayValue', 'Option 1', false],
-		];
-	}
-
-	/**
-	 * @dataProvider withoutColumnProvider
-	 */
-	public function testMethodsWithoutColumn(string $method, $value, $expected): void {
-		$result = $this->selectionBusiness->$method($value, null);
-		$this->assertEquals($expected, $result);
-	}
-
 }

--- a/tests/unit/Service/ColumnTypes/TextLinkBusinessTest.php
+++ b/tests/unit/Service/ColumnTypes/TextLinkBusinessTest.php
@@ -13,75 +13,78 @@ use Psr\Log\LoggerInterface;
 
 class TextLinkBusinessTest extends TestCase {
 
-	private TextLinkBusiness $textLink;
+	private TextLinkBusiness $textLinkBusiness;
+	private Column $column;
 
 	public function setUp(): void {
-		$this->textLink = new TextLinkBusiness(
+		$this->textLinkBusiness = new TextLinkBusiness(
 			$this->createMock(LoggerInterface::class)
 		);
+
+		$this->column = $this->createMock(Column::class);
 	}
 
 	public function testCanBeParsed() {
-		self::assertTrue($this->textLink->canBeParsed(null));
-		self::assertTrue($this->textLink->canBeParsed(''));
-		self::assertFalse($this->textLink->canBeParsed('null'));
-		self::assertFalse($this->textLink->canBeParsed('invalidurl'));
+		self::assertTrue($this->textLinkBusiness->canBeParsed(null, $this->column));
+		self::assertTrue($this->textLinkBusiness->canBeParsed('', $this->column));
+		self::assertFalse($this->textLinkBusiness->canBeParsed('null', $this->column));
+		self::assertFalse($this->textLinkBusiness->canBeParsed('invalidurl', $this->column));
 
-		self::assertTrue($this->textLink->canBeParsed('https://nextcloud.com'));
+		self::assertTrue($this->textLinkBusiness->canBeParsed('https://nextcloud.com', $this->column));
 
-		self::assertTrue($this->textLink->canBeParsed('test (https://nextcloud.com)'));
-		self::assertTrue($this->textLink->canBeParsed('https://nextcloud.com (https://nextcloud.com)'));
+		self::assertTrue($this->textLinkBusiness->canBeParsed('test (https://nextcloud.com)', $this->column));
+		self::assertTrue($this->textLinkBusiness->canBeParsed('https://nextcloud.com (https://nextcloud.com)', $this->column));
 
 		$column = new Column();
-		self::assertFalse($this->textLink->canBeParsed(json_encode([
+		self::assertFalse($this->textLinkBusiness->canBeParsed(json_encode([
 			'unknown' => 'https://nextcloud.com'
 		]), $column));
-		self::assertTrue($this->textLink->canBeParsed(json_encode([
+		self::assertTrue($this->textLinkBusiness->canBeParsed(json_encode([
 			'resourceUrl' => 'https://nextcloud.com'
 		]), $column));
-		self::assertTrue($this->textLink->canBeParsed(json_encode([
+		self::assertTrue($this->textLinkBusiness->canBeParsed(json_encode([
 			'value' => 'https://nextcloud.com'
 		]), $column));
 	}
 
 	public function testParseValue() {
-		self::assertEquals('', $this->textLink->parseValue(null));
-		self::assertEquals('', $this->textLink->parseValue(''));
-		self::assertEquals('', $this->textLink->parseValue('null'));
+		self::assertEquals('', $this->textLinkBusiness->parseValue(null, $this->column));
+		self::assertEquals('', $this->textLinkBusiness->parseValue('', $this->column));
+		self::assertEquals('', $this->textLinkBusiness->parseValue('null', $this->column));
 
 		self::assertEquals(json_encode(json_encode([
 			'title' => 'https://nextcloud.com',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',
-		])), $this->textLink->parseValue('https://nextcloud.com'));
+		])), $this->textLinkBusiness->parseValue('https://nextcloud.com', $this->column));
 
 		self::assertEquals(json_encode(json_encode([
 			'title' => 'https://nextcloud.com',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',
-		])), $this->textLink->parseValue('https://nextcloud.com (https://nextcloud.com)'));
+		])), $this->textLinkBusiness->parseValue('https://nextcloud.com (https://nextcloud.com)', $this->column));
 		self::assertEquals(json_encode(json_encode([
 			'title' => 'test',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',
-		])), $this->textLink->parseValue('test (https://nextcloud.com)'));
+		])), $this->textLinkBusiness->parseValue('test (https://nextcloud.com)', $this->column));
 
 		$column = new Column();
-		self::assertEquals('', $this->textLink->parseValue(json_encode([
+		self::assertEquals('', $this->textLinkBusiness->parseValue(json_encode([
 			'unknown' => 'https://nextcloud.com'
 		]), $column));
 		self::assertEquals(json_encode(json_encode([
 			'title' => 'https://nextcloud.com',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',
-		])), $this->textLink->parseValue(json_encode([
+		])), $this->textLinkBusiness->parseValue(json_encode([
 			'resourceUrl' => 'https://nextcloud.com'
 		]), $column));
 		self::assertEquals(json_encode(json_encode([
 			'title' => 'Test link',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',
-		])), $this->textLink->parseValue(json_encode([
+		])), $this->textLinkBusiness->parseValue(json_encode([
 			'title' => 'Test link',
 			'value' => 'https://nextcloud.com',
 			'providerId' => 'url',


### PR DESCRIPTION
1. instanciate a column business in a single place `ColumnsHelper::getColumnBusiness()` instead of duplication:
   - `ImportService::parseValueByColumnType()`
   - `RowService::getColumnBusiness()`
2. memoize column business instance per column type in a factory and per column id in a import to speedup performance a bit
3. `SuperBusiness` now implements `IColumnTypeBusiness`
4. make `$column` non-nullable in a column business classes and remove redundant checks. I can't find any use-case when it can be nullable