### PR TITLE
[stable0.9] fix(Column): only accept and work with supported columns

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -15,6 +15,7 @@ use OCA\Tables\Api\V1Api;
 use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Dto\Column as ColumnDto;
+use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
@@ -827,9 +828,10 @@ class Api1Controller extends ApiController {
 	 * @param bool|null $usergroupShowUserStatus Whether to show the user's status, if column type is usergroup
 	 * @param list<int>|null $selectedViewIds View IDs where this column should be added to be presented
 	 *
-	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND|Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
 	 *
 	 * 200: Column created
+	 * 400: Invalid arguments
 	 * 403: No permissions
 	 * 404: Not found
 	 */
@@ -914,6 +916,10 @@ class Api1Controller extends ApiController {
 			$this->logger->info('A not found error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
 			return new DataResponse($message, Http::STATUS_NOT_FOUND);
+		} catch (BadRequestError $e) {
+			$this->logger->info('An invalid request was attempted: ' . $e->getMessage(), ['exception' => $e]);
+			$message = ['message' => $e->getMessage()];
+			return new DataResponse($message, Http::STATUS_BAD_REQUEST);
 		}
 	}
 
@@ -944,9 +950,10 @@ class Api1Controller extends ApiController {
 	 * @param bool|null $usergroupSelectTeams Can select teams, if column type is usergroup
 	 * @param bool|null $usergroupShowUserStatus Whether to show the user's status, if column type is usergroup
 	 *
-	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesColumn, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
 	 *
 	 * 200: Updated column
+	 * 400: Invalid arguments
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -1017,6 +1024,10 @@ class Api1Controller extends ApiController {
 			$this->logger->error('An internal error or exception occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
 			return new DataResponse($message, Http::STATUS_INTERNAL_SERVER_ERROR);
+		} catch (BadRequestError $e) {
+			$this->logger->info('An invalid request was attempted: ' . $e->getMessage(), ['exception' => $e]);
+			$message = ['message' => $e->getMessage()];
+			return new DataResponse($message, Http::STATUS_BAD_REQUEST);
 		}
 	}
 

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -7,10 +7,13 @@
 
 namespace OCA\Tables\Db;
 
+use InvalidArgumentException;
 use JsonSerializable;
 
 use OCA\Tables\Dto\Column as ColumnDto;
+use OCA\Tables\Helper\ColumnsHelper;
 use OCA\Tables\ResponseDefinitions;
+use OCP\Server;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -179,10 +182,13 @@ class Column extends EntitySuper implements JsonSerializable {
 		], true);
 	}
 
+	/**
+	 * @throws InvalidArgumentException
+	 */
 	public static function fromDto(ColumnDto $data): self {
 		$column = new self();
 		$column->setTitle($data->getTitle());
-		$column->setType($data->getType());
+		$column->setType(self::getSupportedType($data));
 		$column->setSubtype($data->getSubtype() ?? '');
 		$column->setMandatory($data->isMandatory() ?? false);
 		$column->setDescription($data->getDescription() ?? '');
@@ -205,6 +211,18 @@ class Column extends EntitySuper implements JsonSerializable {
 		$column->setUsergroupSelectTeams($data->getUsergroupSelectTeams());
 		$column->setShowUserStatus($data->getShowUserStatus());
 		return $column;
+	}
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	private static function getSupportedType(ColumnDto $data): string {
+		$columnsHelper = Server::get(ColumnsHelper::class);
+		$type = (string)$data->getType();
+		if ($columnsHelper->isSupportedColumnType($type)) {
+			return $type;
+		}
+		throw new InvalidArgumentException('Unsupported column type');
 	}
 
 	public function getUsergroupDefaultArray():array {

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -267,6 +267,9 @@ class Row2Mapper {
 
 			// if is normal column
 			if ($sortData['columnId'] >= 0) {
+				if (!$this->columnsHelper->isSupportedColumnType((string)$column->getType())) {
+					continue;
+				}
 				$valueTable = 'tables_row_cells_' . $column->getType();
 				$alias = 'sort' . $i;
 				$qb->leftJoin($sleevesAlias, $valueTable, $alias,
@@ -367,6 +370,9 @@ class Row2Mapper {
 	 * @throws InternalError
 	 */
 	private function getFilterExpression(IQueryBuilder $qb, Column $column, string $operator, string $value): IQueryBuilder {
+		if (!$this->columnsHelper->isSupportedColumnType((string)$column->getType())) {
+			throw new InternalError('Column type is not supported');
+		}
 		$paramType = $this->getColumnDbParamType($column);
 		$value = $this->getCellMapper($column)->filterValueToQueryParam($column, $value);
 

--- a/lib/Helper/ColumnsHelper.php
+++ b/lib/Helper/ColumnsHelper.php
@@ -24,6 +24,10 @@ class ColumnsHelper {
 	) {
 	}
 
+	public function isSupportedColumnType(string $type): bool {
+		return in_array($type, $this->columns, true);
+	}
+
 	public function resolveSearchValue(string $placeholder, string $userId): string {
 		if (str_starts_with($placeholder, '@selection-id-')) {
 			return substr($placeholder, 14);

--- a/openapi.json
+++ b/openapi.json
@@ -3974,6 +3974,24 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid arguments",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4162,6 +4180,24 @@
                     },
                     "500": {
                         "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid arguments",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -2878,6 +2878,17 @@ export interface operations {
                     readonly "application/json": components["schemas"]["Column"];
                 };
             };
+            /** @description Invalid arguments */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
+                };
+            };
             /** @description Current user is not logged in */
             readonly 401: {
                 headers: {
@@ -3072,6 +3083,17 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["Column"];
+                };
+            };
+            /** @description Invalid arguments */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly message: string;
+                    };
                 };
             };
             /** @description Current user is not logged in */


### PR DESCRIPTION
- fail hard when an unsupported column is attempted to be added
- ignore when an unsupported column is part of a filter

on main and stable1.0 we have #2309 and its backport covering the same case