### PR TITLE
fix(FileAction): have to use nc/files 4.0 to register file action in >= 33

### DIFF
--- a/.github/workflows/cypress-custom.yml
+++ b/.github/workflows/cypress-custom.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         databases: [ 'mysql' ]
-        server-versions: [ 'stable31', 'stable32', 'stable33', 'master' ]
+        server-versions: [ 'stable33', 'master' ]
         include:
           - php-versions: 8.2
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,21 +53,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server-versions: ['stable31', 'stable32', 'stable33', 'master']
+        server-versions: ['stable33', 'master']
         php-versions: ['8.2']
         databases: ['mysql']
         include:
-          - server-versions: 'stable31'
+          - server-versions: 'stable33'
             php-versions: '8.4'
             databases: 'pgsql'
-          - server-versions: 'stable31'
+          - server-versions: 'stable33'
             php-versions: '8.4'
             databases: 'sqlite'
           - server-versions: 'master'
-            php-versions: '8.4'
+            php-versions: '8.5'
             databases: 'pgsql'
           - server-versions: 'master'
-            php-versions: '8.4'
+            php-versions: '8.5'
             databases: 'sqlite'
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,7 @@ Have a good time and manage whatever you want.
 		<database>pgsql</database>
 		<database>mysql</database>
 		<database>sqlite</database>
-		<nextcloud min-version="31" max-version="34"/>
+		<nextcloud min-version="33" max-version="34"/>
 	</dependencies>
 	<repair-steps>
 		<pre-migration>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "tables",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "agpl",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
@@ -15,7 +15,7 @@
         "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/dialogs": "^7.2.0",
         "@nextcloud/event-bus": "^3.3.3",
-        "@nextcloud/files": "^3.12.2",
+        "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^3.0.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/moment": "^1.3.5",
@@ -3014,6 +3014,28 @@
         "vue": "^3.2.0"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
+        "cancelable-promise": "^4.3.1",
+        "is-svg": "^6.1.0",
+        "typescript-event-target": "^1.1.1",
+        "webdav": "^5.8.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
     "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/vue": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.4.0.tgz",
@@ -3469,9 +3491,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
-      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
@@ -3481,13 +3503,12 @@
         "@nextcloud/paths": "^3.0.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.3.0",
-        "cancelable-promise": "^4.3.1",
         "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.1",
-        "webdav": "^5.8.0"
+        "typescript-event-target": "^1.1.2",
+        "webdav": "^5.9.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+        "node": "^24.0.0"
       }
     },
     "node_modules/@nextcloud/initial-state": {
@@ -3576,6 +3597,29 @@
       },
       "optionalDependencies": {
         "@nextcloud/files": "^3.12.0"
+      }
+    },
+    "node_modules/@nextcloud/sharing/node_modules/@nextcloud/files": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
+        "cancelable-promise": "^4.3.1",
+        "is-svg": "^6.1.0",
+        "typescript-event-target": "^1.1.1",
+        "webdav": "^5.8.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/stylelint-config": {
@@ -16457,9 +16501,9 @@
       }
     },
     "node_modules/typescript-event-target": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
-      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
+      "integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==",
       "license": "MIT"
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/dialogs": "^7.2.0",
     "@nextcloud/event-bus": "^3.3.3",
-    "@nextcloud/files": "^3.12.2",
+    "@nextcloud/files": "^4.0.0",
     "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/moment": "^1.3.5",
@@ -72,9 +72,9 @@
     "@vue/tsconfig": "^0.5.1",
     "cypress": "^13.6.4",
     "cypress-downloadfile": "^1.2.4",
+    "cypress-vite": "^1.8.0",
     "openapi-typescript": "^7.10.1",
     "typescript": "^5.3.3",
-    "cypress-vite": "^1.8.0",
     "vite": "^7.3.1"
   },
   "optionalDependencies": {

--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { FileAction, registerFileAction } from '@nextcloud/files'
+import { registerFileAction } from '@nextcloud/files'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 // eslint-disable-next-line import/no-unresolved
 import tablesIcon from '@mdi/svg/svg/table-large.svg?raw'
@@ -16,7 +16,7 @@ const validMimeTypes = [
 	'application/vnd.ms-excel',
 ]
 
-const fileAction = new FileAction({
+registerFileAction({
 	id: 'import-to-tables',
 	displayName: () => t('tables', 'Import into Tables'),
 	iconSvgInline: () => tablesIcon,
@@ -38,5 +38,3 @@ const fileAction = new FileAction({
 		return null
 	},
 })
-
-registerFileAction(fileAction)


### PR DESCRIPTION
The previous libraries version in 3.x is not compatible anymore, hence we have to cut ties.

To reproduce: 
1. have Tables enabled
2. Go to Files
3. Upload a CSV file
4. Open file actions
5. Find **Import into Tables** 

<img width="259" height="103" alt="Screenshot_20260212_153615" src="https://github.com/user-attachments/assets/4f16eb25-73b5-4660-ac55-2f032aaac6d5" />

:warning: Drops support in 2.x (unreleased) for NC <= 32.