### PR TITLE
fix(ImportResults): add default value for updated_rows_count prop

### DIFF
--- a/src/modules/modals/ImportResults.vue
+++ b/src/modules/modals/ImportResults.vue
@@ -76,6 +76,7 @@ export default {
 					matching_columns_count: 0,
 					created_columns_count: 0,
 					inserted_rows_count: 0,
+					updated_rows_count: 0,
 					errors_parsing_count: 0,
 					errors_count: 0,
 				}


### PR DESCRIPTION
Probably overlooked when #1824 was implemented.

Tests for the feature only seem to cover scenarios where `updated_rows_count` is >1 (i.e. provided by the back-end).

Low impact; not worth adding tests for at the moment, but a bug nonetheless.