### PR TITLE
feat: improve pagination block

### DIFF
--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -43,7 +43,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 <template>
 	<div ref="table" class="NcTable" data-cy="ncTable">
 		<div class="options row" style="padding-right: calc(var(--default-grid-baseline) * 2);">
-			<Options :rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
+			<Options :rows="getSearchedAndFilteredAndSortedRows" :all-rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
 				:selected-rows="localSelectedRows" :show-options="parsedColumns.length !== 0"
 				:view-setting.sync="localViewSetting" :config="config" @create-row="$emit('create-row')"
 				@download-csv="data => downloadCsv(data, parsedColumns, downloadTitle)"
@@ -52,7 +52,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 		</div>
 		<div class="custom-table row">
 			<CustomTable v-if="config.canReadRows || (config.canCreateRows && rows.length > 0)" :columns="parsedColumns"
-				:rows="rows" :is-view="isView" :element-id="elementId" :view-setting.sync="localViewSetting"
+				:rows="getSearchedAndFilteredAndSortedRows" :is-view="isView" :element-id="elementId" :view-setting.sync="localViewSetting"
 				:config="config" @create-row="$emit('create-row')"
 				@edit-row="rowId => $emit('edit-row', rowId)"
 				@create-column="$emit('create-column')"
@@ -103,6 +103,16 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { parseCol } from './mixins/columnParser.js'
 import { AbstractColumn } from './mixins/columnClass.js'
 import { translate as t } from '@nextcloud/l10n'
+import {
+	TYPE_META_CREATED_AT,
+	TYPE_META_CREATED_BY,
+	TYPE_META_ID,
+	TYPE_META_UPDATED_AT,
+	TYPE_META_UPDATED_BY,
+} from '../../constants.ts'
+import { MetaColumns } from './mixins/metaColumns.js'
+import { MagicFields } from './mixins/magicFields.js'
+import { getFiltersForColumn } from './mixins/filter.js'
 
 export default {
 	name: 'NcTable',
@@ -220,6 +230,153 @@ export default {
 			}
 			return this.columns
 		},
+
+		sorting() {
+			return this.viewSetting?.sorting
+		},
+		getSearchedAndFilteredRows() {
+			const debug = false
+			// if we don't have to search and/or filter
+			if (!this.viewSetting?.filter?.length > 0 && !this.viewSetting?.searchString) {
+				// cleanup markers
+				if (this.rows && this.columns) {
+					this.rows.forEach(row => {
+						if (row && row.data) {
+							this.columns.forEach(column => {
+								const cell = row.data.find(item => item && item.columnId === column.id)
+								if (cell === undefined) {
+									return
+								}
+								delete cell.searchStringFound
+								delete cell.filterFound
+							})
+						}
+					})
+				}
+				return this.rows || []
+			}
+
+			const data = [] // array of rows
+			const searchString = this.viewSetting?.searchString
+			// each row
+			if (!this.rows || !this.columns) {
+				return []
+			}
+
+			for (const row of this.rows) {
+				if (!row || !row.data) {
+					continue
+				}
+
+				if (debug) {
+					console.debug('new row ===============================================', row)
+				}
+				let filterStatusRow = null
+				let searchStatusRow = false
+
+				// each column in a row => cell
+				this.columns.forEach(column => {
+					if (debug) {
+						console.debug('new column -------------------', column)
+					}
+					let filterStatus = null
+					let searchStatus = true
+					const filters = getFiltersForColumn(column, this.viewSetting)
+					let cell
+					if (column.id < 0) {
+						cell = { columnId: column.id }
+						switch (column.id) {
+						case TYPE_META_ID:
+							cell.value = row.id
+							break
+						case TYPE_META_CREATED_BY:
+							cell.value = row.createdBy
+							break
+						case TYPE_META_UPDATED_BY:
+							cell.value = row.editedBy
+							break
+						case TYPE_META_CREATED_AT:
+							cell.value = row.createdAt
+							break
+						case TYPE_META_UPDATED_AT:
+							cell.value = row.editedAt
+							break
+						}
+					} else {
+						cell = row.data.find(item => item && item.columnId === column.id)
+					}
+
+					// if we don't have a value for this cell
+					if (cell === undefined) {
+						if (searchString) {
+							searchStatus = false
+						}
+						cell = { columnId: column.id, value: null }
+					}
+					// cleanup possible old markers
+					delete cell.searchStringFound
+					delete cell.filterFound
+
+					// apply filters (if any)
+					filters.forEach(fil => {
+						this.addMagicFieldsValues(fil)
+						if (filterStatus === null || filterStatus === true) {
+							filterStatus = column.isFilterFound(cell, fil)
+						}
+					})
+					// if we should search
+					if (searchString) {
+						console.debug('look for searchString', searchString)
+						searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
+					}
+
+					if (debug) {
+						console.debug('filterStatus for cell', { cell: cell?.value, filterStatusCell: filterStatus, filterStatusRowBefore: filterStatusRow })
+					}
+
+					// if filterStatus is null, this result should be ignored
+					if (filterStatus !== null && (filterStatusRow || filterStatusRow === null)) {
+						filterStatusRow = filterStatus
+					}
+
+					if (debug) {
+						console.debug('new filterStatusRow', filterStatusRow)
+					}
+
+					// filterStatusRow = filterStatus
+					searchStatusRow = searchStatusRow || searchStatus
+				})
+
+				if (debug) {
+					console.debug('if push row', { filterStatusRow, searchStatusRow, result: (filterStatusRow || filterStatusRow === null) && searchStatusRow })
+				}
+				if ((filterStatusRow || filterStatusRow === null) && searchStatusRow) {
+					data.push({ ...row })
+				}
+			}
+			return data
+		},
+		getSearchedAndFilteredAndSortedRows() {
+			const allColumns = this.columns.concat(MetaColumns)
+			const sort = (sortCols) => {
+				const sortColumn = allColumns.find(item => item.id === sortCols?.[0].columnId)
+				const nextSorts = []
+				for (let i = 1; i < sortCols.length; i++) {
+					const sortColumn = allColumns.find(item => item.id === sortCols[i].columnId)
+					nextSorts.push(sortColumn?.sort?.(sortCols[i].mode))
+				}
+				return [...this.getSearchedAndFilteredRows].sort(sortColumn?.sort?.(sortCols[0].mode, nextSorts))
+			}
+
+			// if we have to sort
+			if (this.viewSetting?.presetSorting) {
+				return sort(this.viewSetting.presetSorting)
+			}
+			if (this.viewSetting?.sorting) {
+				return sort(this.viewSetting.sorting)
+			}
+			return this.getSearchedAndFilteredRows
+		},
 	},
 	watch: {
 		localSelectedRows() {
@@ -260,6 +417,14 @@ export default {
 		setSearchString(str) {
 			this.localViewSetting.searchString = str !== '' ? str : null
 			this.localViewSetting = JSON.parse(JSON.stringify(this.localViewSetting))
+		},
+		addMagicFieldsValues(filter) {
+			Object.values(MagicFields).forEach(field => {
+				const newFilterValue = filter.value.replace('@' + field.id, field.replace)
+				if (filter.value !== newFilterValue) {
+					filter.magicValuesEnriched = newFilterValue
+				}
+			})
 		},
 	},
 }

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -8,7 +8,7 @@
 			<thead class="tables-list__thead">
 				<TableHeader :columns="columns"
 					:selected-rows="selectedRows"
-					:rows="getSearchedAndFilteredAndSortedRows"
+					:rows="rows"
 					:view-setting.sync="localViewSetting"
 					:config="config"
 					:pinned-column-id="pinnedColumnId"
@@ -18,6 +18,7 @@
 					@edit-column="col => $emit('edit-column', col)"
 					@delete-column="col => $emit('delete-column', col)"
 					@download-csv="data => $emit('download-csv', data)"
+
 					@select-all-rows="selectAllRows"
 					@pin-column="setPinnedColumn">
 					<template #actions>
@@ -40,70 +41,21 @@
 					:config="config"
 					:element-id="elementId"
 					:is-view="isView"
+
 					:pinned-column-id="pinnedColumnId"
 					:column-widths="columnWidths"
 					@update-row-selection="updateRowSelection"
 					@edit-row="rowId => $emit('edit-row', rowId)" />
 			</transition-group>
 		</table>
-		<div v-if="totalPages > 1" class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">
-			<div class="pagination-items">
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to first page')" @click="pageNumber = 1">
-					<template #icon>
-						<PageFirstIcon :size="20" />
-					</template>
-				</NcButton>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to previous page')" @click="pageNumber--">
-					<template #icon>
-						<ChevronLeftIcon :size="20" />
-					</template>
-				</NcButton>
-				<div class="page-number">
-					<NcSelect
-						v-model="pageNumber"
-						:options="allPageNumbersArray"
-						:clearable="false"
-						:aria-label-combobox="t('tables', 'Page number')">
-						<template #selected-option-container="{ option }">
-							<span class="selected-page">
-								{{ option.label }} of {{ totalPages }}
-							</span>
-						</template>
-					</NcSelect>
-				</div>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to next page')" @click="pageNumber++">
-					<template #icon>
-						<ChevronRightIcon :size="20" />
-					</template>
-				</NcButton>
-				<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to last page')" @click="pageNumber = totalPages">
-					<template #icon>
-						<PageLastIcon :size="20" />
-					</template>
-				</NcButton>
-			</div>
-		</div>
 	</div>
 </template>
 
 <script>
 import TableHeader from '../partials/TableHeader.vue'
-import PageLastIcon from 'vue-material-design-icons/PageLast.vue'
-import PageFirstIcon from 'vue-material-design-icons/PageFirst.vue'
-import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
-import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import TableRow from '../partials/TableRow.vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
-import { MagicFields } from '../mixins/magicFields.js'
-import { NcButton, useIsMobile, NcSelect } from '@nextcloud/vue'
-import { mapState } from 'pinia'
-import {
-	TYPE_META_ID, TYPE_META_CREATED_BY, TYPE_META_CREATED_AT, TYPE_META_UPDATED_BY, TYPE_META_UPDATED_AT,
-} from '../../../constants.ts'
-import { MetaColumns } from '../mixins/metaColumns.js'
 import { translate as t } from '@nextcloud/l10n'
-import { useTablesStore } from '../../../../store/store.js'
-import { getFiltersForColumn } from '../mixins/filter.js'
 
 export default {
 	name: 'CustomTable',
@@ -111,12 +63,6 @@ export default {
 	components: {
 		TableRow,
 		TableHeader,
-		NcButton,
-		PageLastIcon,
-		PageFirstIcon,
-		ChevronLeftIcon,
-		ChevronRightIcon,
-		NcSelect,
 	},
 
 	props: {
@@ -146,12 +92,6 @@ export default {
 		},
 	},
 
-	setup() {
-		return {
-			isMobile: useIsMobile(),
-		}
-	},
-
 	data() {
 		return {
 			selectedRows: [],
@@ -166,164 +106,8 @@ export default {
 	},
 
 	computed: {
-		...mapState(useTablesStore, ['appNavCollapsed']),
-		allPageNumbersArray() {
-			return Array.from(
-				{ length: this.totalPages },
-				(value, index) => 1 + index,
-			)
-		},
 		currentPageRows() {
-			return this.getSearchedAndFilteredAndSortedRows.slice((this.pageNumber - 1) * this.rowsPerPage, ((this.pageNumber - 1) * this.rowsPerPage) + this.rowsPerPage)
-		},
-		totalPages() {
-			return Math.ceil(this.getSearchedAndFilteredAndSortedRows.length / this.rowsPerPage)
-		},
-		sorting() {
-			return this.viewSetting?.sorting
-		},
-		getSearchedAndFilteredRows() {
-			const debug = false
-			// if we don't have to search and/or filter
-			if (!this.viewSetting?.filter?.length > 0 && !this.viewSetting?.searchString) {
-				// cleanup markers
-				if (this.rows && this.columns) {
-					this.rows.forEach(row => {
-						if (row && row.data) {
-							this.columns.forEach(column => {
-								const cell = row.data.find(item => item && item.columnId === column.id)
-								if (cell === undefined) {
-									return
-								}
-								delete cell.searchStringFound
-								delete cell.filterFound
-							})
-						}
-					})
-				}
-				return this.rows || []
-			}
-
-			const data = [] // array of rows
-			const searchString = this.viewSetting?.searchString
-			// each row
-			if (!this.rows || !this.columns) {
-				return []
-			}
-
-			for (const row of this.rows) {
-				if (!row || !row.data) {
-					continue
-				}
-
-				if (debug) {
-					console.debug('new row ===============================================', row)
-				}
-				let filterStatusRow = null
-				let searchStatusRow = false
-
-				// each column in a row => cell
-				this.columns.forEach(column => {
-					if (debug) {
-						console.debug('new column -------------------', column)
-					}
-					let filterStatus = null
-					let searchStatus = true
-					const filters = getFiltersForColumn(column, this.viewSetting)
-					let cell
-					if (column.id < 0) {
-						cell = { columnId: column.id }
-						switch (column.id) {
-						case TYPE_META_ID:
-							cell.value = row.id
-							break
-						case TYPE_META_CREATED_BY:
-							cell.value = row.createdBy
-							break
-						case TYPE_META_UPDATED_BY:
-							cell.value = row.editedBy
-							break
-						case TYPE_META_CREATED_AT:
-							cell.value = row.createdAt
-							break
-						case TYPE_META_UPDATED_AT:
-							cell.value = row.editedAt
-							break
-						}
-					} else {
-						cell = row.data.find(item => item && item.columnId === column.id)
-					}
-
-					// if we don't have a value for this cell
-					if (cell === undefined) {
-						if (searchString) {
-							searchStatus = false
-						}
-						cell = { columnId: column.id, value: null }
-					}
-					// cleanup possible old markers
-					delete cell.searchStringFound
-					delete cell.filterFound
-
-					// apply filters (if any)
-					filters.forEach(fil => {
-						this.addMagicFieldsValues(fil)
-						if (filterStatus === null || filterStatus === true) {
-							filterStatus = column.isFilterFound(cell, fil)
-						}
-					})
-					// if we should search
-					if (searchString) {
-						console.debug('look for searchString', searchString)
-						searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
-					}
-
-					if (debug) {
-						console.debug('filterStatus for cell', { cell: cell?.value, filterStatusCell: filterStatus, filterStatusRowBefore: filterStatusRow })
-					}
-
-					// if filterStatus is null, this result should be ignored
-					if (filterStatus !== null && (filterStatusRow || filterStatusRow === null)) {
-						filterStatusRow = filterStatus
-					}
-
-					if (debug) {
-						console.debug('new filterStatusRow', filterStatusRow)
-					}
-
-					// filterStatusRow = filterStatus
-					searchStatusRow = searchStatusRow || searchStatus
-				})
-
-				if (debug) {
-					console.debug('if push row', { filterStatusRow, searchStatusRow, result: (filterStatusRow || filterStatusRow === null) && searchStatusRow })
-				}
-				if ((filterStatusRow || filterStatusRow === null) && searchStatusRow) {
-					data.push({ ...row })
-				}
-			}
-			return data
-		},
-		getSearchedAndFilteredAndSortedRows() {
-			const allColumns = this.columns.concat(MetaColumns)
-			const sort = (sortCols) => {
-				const sortColumn = allColumns.find(item => item.id === sortCols?.[0].columnId)
-				const nextSorts = []
-				for (let i = 1; i < sortCols.length; i++) {
-					const sortColumn = allColumns.find(item => item.id === sortCols[i].columnId)
-					nextSorts.push(sortColumn?.sort?.(sortCols[i].mode))
-				}
-				return [...this.getSearchedAndFilteredRows].sort(sortColumn?.sort?.(sortCols[0].mode, nextSorts))
-			}
-
-			// if we have to sort
-			if (this.viewSetting?.presetSorting) {
-				return sort(this.viewSetting.presetSorting)
-			}
-			if (this.viewSetting?.sorting) {
-				return sort(this.viewSetting.sorting)
-			}
-			return this.getSearchedAndFilteredRows
+			return this.rows.slice((this.pageNumber - 1) * this.rowsPerPage, ((this.pageNumber - 1) * this.rowsPerPage) + this.rowsPerPage)
 		},
 	},
 
@@ -343,19 +127,15 @@ export default {
 		},
 	},
 
-	updated() {
-		if (this.pageNumber > this.totalPages || this.totalPages === 1) {
-			this.pageNumber = this.totalPages
-		}
-	},
-
 	mounted() {
 		subscribe('tables:selected-rows:deselect', ({ elementId, isView }) => this.deselectAllRows(elementId, isView))
 		subscribe('tables:row:animate', this.enableRowAnimation)
+		subscribe('tables:pagination-changed', this.handlePaginationChanged)
 	},
 	beforeDestroy() {
 		unsubscribe('tables:selected-rows:deselect', ({ elementId, isView }) => this.deselectAllRows(elementId, isView))
 		unsubscribe('tables:row:animate', this.enableRowAnimation)
+		unsubscribe('tables:pagination-changed', this.handlePaginationChanged)
 	},
 
 	methods: {
@@ -374,13 +154,11 @@ export default {
 				this.columnWidths = widths
 			}
 		},
-		addMagicFieldsValues(filter) {
-			Object.values(MagicFields).forEach(field => {
-				const newFilterValue = filter.value.replace('@' + field.id, field.replace)
-				if (filter.value !== newFilterValue) {
-					filter.magicValuesEnriched = newFilterValue
-				}
-			})
+		handlePaginationChanged({ pageNumber, rowsPerPage }) {
+			this.pageNumber = pageNumber
+			if (rowsPerPage) {
+				this.rowsPerPage = rowsPerPage
+			}
 		},
 		deselectAllRows(elementId, isView) {
 			if (parseInt(elementId) === parseInt(this.elementId) && isView === this.isView) {
@@ -390,7 +168,7 @@ export default {
 		selectAllRows(value) {
 			this.selectedRows = []
 			if (value) {
-				this.getSearchedAndFilteredRows.forEach(item => { this.selectedRows.push(item.id) })
+				this.rows.forEach(item => { this.selectedRows.push(item.id) })
 			}
 			this.$emit('update-selected-rows', this.selectedRows)
 		},
@@ -423,12 +201,6 @@ export default {
 }
 </script>
 
-<style>
-.vs__dropdown-menu {
-	min-width: 95px !important;
-}
-</style>
-
 <style lang="scss" scoped>
 :deep(.text-editor__wrapper .paragraph-content:last-child) {
 	margin-bottom: 0!important;
@@ -436,47 +208,6 @@ export default {
 
 :deep(.text-editor__wrapper .ProseMirror > *:first-child) {
 	margin-top: 0!important;
-}
-
-.selected-page{
-	padding-inline-start: 5px;
-
-	display:inline-flex;
-	align-items: center;
-}
-
-.page-number{
-	padding-inline: 5px;
-}
-
-.large-width{
-	width: 100vw !important;
-	inset-inline-start: 0 !important;
-}
-
-.pagination-items{
-	background-color: var(--color-main-background);
-	border-radius: var(--border-radius-large);
-	pointer-events: all;
-
-	display: flex;
-	align-items: center;
-}
-
-.pagination-footer{
-	box-shadow: var(--box-shadow);
-	filter: drop-shadow(0 1px 6px var(--color-box-shadow));
-	padding-bottom: 20px;
-	width: calc(100vw - 316px);
-	pointer-events: none;
-
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	:deep(.v-select) {
-		min-width: 95px !important;
-	}
 }
 
 :deep(table) {

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -4,8 +4,7 @@
 -->
 <template>
 	<div class="options">
-		<div v-if="showOptions && (config.canReadRows || (config.canCreateRows && rows.length > 0))" class="fix-col-4"
-			style="justify-content: space-between;">
+		<div v-if="showOptions && (config.canReadRows || (config.canCreateRows && rows.length > 0))" class="fix-col-4">
 			<div :class="{ 'add-padding-left': isSmallMobile }" class="actionButtonsLeft">
 				<NcButton v-if="!isSmallMobile && config.canCreateRows" :aria-label="t('tables', 'Create row')"
 					:close-after-click="true" type="tertiary" data-cy="createRowBtn" @click="$emit('create-row')">
@@ -25,6 +24,7 @@
 					<SearchForm :columns="columns" :search-string="getSearchString"
 						@set-search-string="str => $emit('set-search-string', str)" />
 				</div>
+				<PaginationBlock :rows="rows" />
 			</div>
 
 			<div v-if="selectedRows.length > 0" class="selected-rows-option">
@@ -52,6 +52,7 @@
 					</NcActionButton>
 				</NcActions>
 			</div>
+			<div v-else class="selected-rows-placeholder" />
 		</div>
 	</div>
 </template>
@@ -65,6 +66,7 @@ import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
 import Export from 'vue-material-design-icons/Export.vue'
 import viewportHelper from '../../../mixins/viewportHelper.js'
 import SearchForm from '../partials/SearchForm.vue'
+import PaginationBlock from './PaginationBlock.vue'
 import { translate as t } from '@nextcloud/l10n'
 
 export default {
@@ -79,6 +81,7 @@ export default {
 		Check,
 		Delete,
 		Export,
+		PaginationBlock,
 	},
 
 	mixins: [viewportHelper],
@@ -89,6 +92,10 @@ export default {
 			default: () => [],
 		},
 		rows: {
+			type: Array,
+			default: () => [],
+		},
+		allRows: {
 			type: Array,
 			default: () => [],
 		},
@@ -154,8 +161,8 @@ export default {
 			this.$emit('download-csv', this.getSelectedRows)
 		},
 		getRowById(rowId) {
-			const index = this.rows.findIndex(row => row.id === rowId)
-			return this.rows[index]
+			const index = this.allRows.findIndex(row => row.id === rowId)
+			return this.allRows[index]
 		},
 		deleteSelectedRows() {
 			this.$emit('delete-selected-rows', this.selectedRows)
@@ -174,6 +181,18 @@ export default {
 	position: sticky;
 	top: 90px;
 	inset-inline-start: 0;
+}
+
+.fix-col-4 {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+}
+
+.selected-rows-placeholder {
+	min-width: fit-content;
+	flex-shrink: 0;
 }
 
 .selected-rows-option {
@@ -196,6 +215,8 @@ export default {
 	display: inline-flex;
 	align-items: center;
 	padding-inline-start: calc(var(--default-grid-baseline) * 1);
+	flex-wrap: wrap;
+	gap: 4px;
 }
 
 :deep(.actionButtonsLeft button) {
@@ -206,5 +227,31 @@ export default {
 	margin-inline-start: calc(var(--default-grid-baseline) * 3);
 	width: auto;
 	min-width: 100px;
+	flex-shrink: 1;
+}
+
+@media only screen and (max-width: 641px) {
+	.fix-col-4 {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.actionButtonsLeft {
+		justify-content: center;
+	}
+
+	.selected-rows-option {
+		justify-content: center;
+		margin-top: 8px;
+	}
+}
+
+@media only screen and (max-width: 480px) {
+	.searchAndFilter {
+		margin-inline-start: calc(var(--default-grid-baseline) * 1);
+		min-width: 80px;
+		order: -1;
+		flex: 1 1 auto;
+	}
 }
 </style>

--- a/src/shared/components/ncTable/sections/PaginationBlock.vue
+++ b/src/shared/components/ncTable/sections/PaginationBlock.vue
@@ -1,0 +1,215 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="pagination-block">
+		<div class="pagination-items">
+			<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to first page')" @click="pageNumber = 1">
+				<template #icon>
+					<PageFirstIcon :size="20" />
+				</template>
+			</NcButton>
+			<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber <= 1" :aria-label="t('tables', 'Go to previous page')" @click="pageNumber--">
+				<template #icon>
+					<ChevronLeftIcon :size="20" />
+				</template>
+			</NcButton>
+			<div class="page-number page-input">
+				<span class="page-label">{{ t('tables', 'Page') }}</span>
+				<NcTextField
+					v-model.number="pageNumber"
+					type="number"
+					:aria-label="t('tables', 'Page number')"
+					:min="1"
+					:max="totalPages" />
+				<span class="page-of">/ {{ totalPages }}</span>
+			</div>
+			<div class="page-number">
+				<NcSelect v-model="rowsPerPage"
+					:options="[25, 50, 75, 100, 125, 150, 175, 200]"
+					:clearable="false"
+					:aria-label-combobox="t('tables', 'Per page')" />
+			</div>
+			<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to next page')" @click="pageNumber++">
+				<template #icon>
+					<ChevronRightIcon :size="20" />
+				</template>
+			</NcButton>
+			<NcButton type="tertiary" :disabled="totalPages === 1 || pageNumber >= totalPages" :aria-label="t('tables', 'Go to last page')" @click="pageNumber = totalPages">
+				<template #icon>
+					<PageLastIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import PageLastIcon from 'vue-material-design-icons/PageLast.vue'
+import PageFirstIcon from 'vue-material-design-icons/PageFirst.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
+import { NcButton, NcSelect, NcTextField } from '@nextcloud/vue'
+import { translate as t } from '@nextcloud/l10n'
+import { emit } from '@nextcloud/event-bus'
+
+export default {
+	name: 'PaginationBlock',
+
+	components: {
+		NcButton,
+		PageLastIcon,
+		PageFirstIcon,
+		ChevronLeftIcon,
+		ChevronRightIcon,
+		NcSelect,
+		NcTextField,
+	},
+
+	props: {
+		rows: {
+			type: Array,
+			default: () => [],
+		},
+	},
+
+	data() {
+		return {
+			pageNumber: 1,
+			rowsPerPage: 100,
+		}
+	},
+
+	computed: {
+		totalPages() {
+			return Math.max(1, Math.ceil(this.rows.length / this.rowsPerPage))
+		},
+	},
+
+	watch: {
+		pageNumber() {
+			this.validatePageInput()
+			emit('tables:pagination-changed', { pageNumber: this.pageNumber, rowsPerPage: this.rowsPerPage })
+		},
+		rowsPerPage() {
+			this.validatePageInput()
+			emit('tables:pagination-changed', { pageNumber: this.pageNumber, rowsPerPage: this.rowsPerPage })
+		},
+		rows() {
+			this.validatePageInput()
+		},
+	},
+
+	methods: {
+		t,
+		validatePageInput() {
+			// Ensure page number is within valid range
+			if (this.pageNumber < 1) {
+				this.pageNumber = 1
+			} else if (this.pageNumber > this.totalPages) {
+				this.pageNumber = this.totalPages
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.selected-page{
+	padding-inline-start: 5px;
+	display: inline-flex;
+	align-items: center;
+}
+
+.page-of {
+	font-size: 14px;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+}
+
+.page-input {
+	padding-inline: 5px;
+	box-sizing: border-box;
+	height: 36px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+
+	.page-label {
+		font-size: 14px;
+		color: var(--color-text-maxcontrast);
+		white-space: nowrap;
+	}
+
+	:deep(.input-field) {
+		width: 50px;
+		margin: 0;
+	}
+
+	:deep(.input-field__main-wrapper) {
+		height: 34px;
+	}
+
+	:deep(.input-field__input) {
+		height: 32px;
+		min-height: 32px;
+		padding: 0 4px;
+		text-align: center;
+	}
+}
+
+.page-number{
+	padding-inline: 5px;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	height: 36px;
+}
+
+.pagination-items{
+	background-color: var(--color-main-background);
+	border-radius: var(--border-radius-large);
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	flex-wrap: wrap;
+	justify-content: center;
+	margin-top: 8px;
+	padding: 4px;
+	gap: 4px;
+
+	:deep(.button-vue) {
+		height: 36px;
+		min-height: 36px;
+		width: 36px;
+		min-width: 36px;
+	}
+}
+
+.pagination-block{
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	max-width: 100%;
+
+	:deep(.v-select) {
+		min-width: 120px !important;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	.pagination-items {
+		gap: 1px;
+		padding: 2px;
+	}
+
+	.page-number {
+		padding-inline: 2px;
+	}
+
+	.page-input :deep(.input-field) {
+		width: 40px;
+	}
+}
+</style>

--- a/src/views/ContentReferenceWidget.vue
+++ b/src/views/ContentReferenceWidget.vue
@@ -11,6 +11,7 @@
 			</h2>
 			<Options
 				:config="tablePermissions"
+				:rows="filteredRows"
 				:show-options="true"
 				@create-row="createRow"
 				@set-search-string="search" />
@@ -264,11 +265,6 @@ export default {
 				:where(.sticky) {
 					background: transparent !important;
 				}
-			}
-
-			:where(.pagination-footer) {
-				width: unset !important;
-				inset-inline-start: unset !important;
 			}
 		}
 


### PR DESCRIPTION
Current pagination block has few drawbacks:
- it is not possible to tune how many items per page to display
- block located in the very bottom of the page on the left side. So it is very inconvenient for wide table with multiple rows (you need to scroll all the time)
- pagination not visible in the embedded views (closes #2073)

<details><summary> :mag:  Screenshoots</summary>
<p>

Initial view  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f7e474c3-29a5-4069-bf26-f331a7a3584f" />

Large table scrolled to the bottom  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b850375b-c9ca-4e0a-b8cc-8516e86cbd1e" />

Large table scrolled to the right with few rows selected  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/16178f65-6231-40d1-b40a-e4f9990ddfa8" />

Embedded table into collective  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0e5a8582-0229-44d3-8646-b1d0efcbf0e2" />
</p>
</details> 

So, this PR aims to fix all of them.

:warning: Styles are not perfect (I'm not CSS master, sorry :see_no_evil:) but it's better than it now. Feel free to improve anything or just pushing directly into the branch