### PR TITLE
fix: transfer shares on context ownership change

### DIFF
--- a/lib/Db/ContextNavigationMapper.php
+++ b/lib/Db/ContextNavigationMapper.php
@@ -34,6 +34,17 @@ class ContextNavigationMapper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
+	public function deleteByShareIdAndUserId(int $shareId, string $userId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('share_id', $qb->createNamedParameter($shareId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
+			->executeStatement();
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	public function setDisplayModeByShareId(int $shareId, int $displayMode, string $userId): ContextNavigation {
 		$entity = new ContextNavigation();
 		$entity->setShareId($shareId);

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -66,7 +66,7 @@ class ShareMapper extends QBMapper {
 	 *
 	 * @throws Exception
 	 */
-	public function findShareForNode(int $nodeId, string $nodeType, string $receiver, ?string $receiverType = null): Share {
+	public function findShareForNode(int $nodeId, string $nodeType, string $receiver, ?string $receiverType = null): ?Share {
 		// if shared with user
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
@@ -77,16 +77,9 @@ class ShareMapper extends QBMapper {
 		if ($receiverType) {
 			$qb->andWhere($qb->expr()->eq('receiver_type', $qb->createNamedParameter($receiverType, IQueryBuilder::PARAM_STR)));
 		}
-		try {
-			$items = $this->findEntities($qb);
-			if (count($items) > 0) {
-				return $items[0];
-			}
-		} catch (Exception $e) {
-			$this->logger->warning('Exception occurred while executing SQL statement: ' . $e->getMessage());
-		}
 
-		throw new Exception('no shares found as expected');
+		$items = $this->findEntities($qb);
+		return $items[0] ?? null;
 	}
 
 	/**
@@ -230,5 +223,20 @@ class ShareMapper extends QBMapper {
 		}
 		$qb->where($orX);
 		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function changeReceiverForNode(string $nodeType, int $nodeId, string $newReceiver, string $oldReceiver, string $sender): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->table)
+			->set('receiver', $qb->createNamedParameter($newReceiver, IQueryBuilder::PARAM_STR))
+			->where($qb->expr()->eq('node_id', $qb->createNamedParameter($nodeId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('node_type', $qb->createNamedParameter($nodeType, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('sender', $qb->createNamedParameter($sender, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('receiver', $qb->createNamedParameter($oldReceiver, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('receiver_type', $qb->createNamedParameter('user', IQueryBuilder::PARAM_STR)))
+			->executeStatement();
 	}
 }

--- a/lib/Service/ContextService.php
+++ b/lib/Service/ContextService.php
@@ -300,10 +300,20 @@ class ContextService {
 			throw new BadRequestError('User does not exist');
 		}
 
+		$oldOwnerId = $context->getOwnerId();
 		$context->setOwnerId($newOwnerId);
 		$context->setOwnerType($newOwnerType);
 
-		$context = $this->contextMapper->update($context);
+		try {
+			$context = $this->atomic(function () use ($context, $contextId, $newOwnerId, $oldOwnerId) {
+				$context = $this->contextMapper->update($context);
+				$this->shareService->transferSharesForContext($contextId, $newOwnerId, $oldOwnerId);
+				return $context;
+			}, $this->dbc);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to transfer context ownership: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Failed to transfer context ownership: ' . $e->getMessage());
+		}
 
 		$auditEvent = new CriticalActionPerformedEvent(
 			sprintf('Tables application with ID %d was transferred to user %s',

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -554,6 +554,46 @@ class ShareService extends SuperService {
 
 	/**
 	 * @throws InternalError
+	 */
+	public function changeReceiverForNode(string $nodeType, int $nodeId, string $newOwnerUserId, string $userId, string $sender): void {
+		try {
+			$this->mapper->changeReceiverForNode($nodeType, $nodeId, $newOwnerUserId, $userId, $sender);
+		} catch (Exception $e) {
+			$this->logger->warning('Could not update share to change the receiver: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Could not update share to change the receiver');
+		}
+	}
+
+	/**
+	 * @throws InternalError
+	 */
+	public function transferSharesForContext(int $contextId, string $newOwnerId, string $oldOwnerId): void {
+		try {
+			$newOwnerShare = $this->mapper->findShareForNode($contextId, 'context', $newOwnerId, 'user');
+			$oldOwnerSelfShare = $this->mapper->findShareForNode($contextId, 'context', $oldOwnerId, 'user');
+
+			$this->changeSenderForNode('context', $contextId, $newOwnerId, $oldOwnerId);
+
+			if ($newOwnerShare) {
+				if ($oldOwnerSelfShare) {
+					$this->contextNavigationMapper->deleteByShareId($oldOwnerSelfShare->getId());
+					$this->mapper->delete($oldOwnerSelfShare);
+				}
+				return;
+			}
+
+			$this->changeReceiverForNode('context', $contextId, $newOwnerId, $oldOwnerId, $newOwnerId);
+			if ($oldOwnerSelfShare) {
+				$this->contextNavigationMapper->deleteByShareIdAndUserId($oldOwnerSelfShare->getId(), $oldOwnerId);
+			}
+		} catch (Exception $e) {
+			$this->logger->error('Failed to transfer shares for context: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Failed to transfer shares for context');
+		}
+	}
+
+	/**
+	 * @throws InternalError
 	 * @return string[]
 	 */
 	public function findSharedWithUserIds(int $elementId, string $elementType): array {

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -27,9 +27,11 @@ use OCA\Tables\ResponseDefinitions;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\Exception as OcpDbException;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IDBConnection;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
@@ -37,6 +39,7 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type TablesTable from ResponseDefinitions
  */
 class TableService extends SuperService {
+	use TTransactional;
 
 	public function __construct(
 		PermissionsService $permissionsService,
@@ -53,6 +56,7 @@ class TableService extends SuperService {
 		protected IEventDispatcher $eventDispatcher,
 		private ContextService $contextService,
 		protected IAppManager $appManager,
+		private IDBConnection $dbc,
 		protected IL10N $l,
 		protected Defaults $themingDefaults,
 		private ActivityManager $activityManager,
@@ -347,20 +351,16 @@ class TableService extends SuperService {
 		}
 
 		$table->setOwnership($newOwnerUserId);
-		try {
-			$table = $this->mapper->update($table);
-		} catch (OcpDbException $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
-		}
 
-		// change owners of related shares
 		try {
-			$this->shareService->changeSenderForNode('table', $id, $newOwnerUserId, $userId);
-		} catch (InternalError $e) {
-			$this->logger->error('Could not update related shares for a table transfer!');
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			$table = $this->atomic(function () use ($table, $id, $newOwnerUserId, $userId) {
+				$table = $this->mapper->update($table);
+				$this->shareService->changeSenderForNode('table', $id, $newOwnerUserId, $userId);
+				return $table;
+			}, $this->dbc);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to transfer table ownership: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Failed to transfer table ownership: ' . $e->getMessage());
 		}
 
 		$event = new TableOwnershipTransferredEvent(

--- a/src/modules/modals/TransferContext.vue
+++ b/src/modules/modals/TransferContext.vue
@@ -32,6 +32,7 @@ import permissionsMixin from '../../shared/components/ncTable/mixins/permissions
 import NcUserPicker from '../../shared/components/ncUserPicker/NcUserPicker.vue'
 import { mapState, mapActions } from 'pinia'
 import { getCurrentUser } from '@nextcloud/auth'
+import rebuildNavigation from '../../service/rebuild-navigation.js'
 import { useTablesStore } from '../../store/store.js'
 
 export default {
@@ -84,6 +85,8 @@ export default {
 					name: this.context?.name,
 					user: this.newOwnerId,
 				}))
+
+				await rebuildNavigation()
 
 				if (transferId === this.activeContextId) {
 					await this.$router.push('/').catch(err => err)


### PR DESCRIPTION
When transferring a context to a new owner, shares are now correctly updated to match the new ownership.