### PR TITLE
Fix: fix export table to csv with deleted options

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
@@ -44,7 +44,11 @@ export default class SelectionMutliColumn extends AbstractSelectionColumn {
 		// values is an array of option-ids as string
 		const objects = []
 		values?.forEach(id => {
-			objects.push(this.getOptionObject(parseInt(id)))
+			const optionsObject = this.getOptionObject(parseInt(id))
+			// skip options that not exists anymore
+			if (optionsObject) {
+				objects.push(optionsObject)
+			}
 		})
 		return objects
 	}


### PR DESCRIPTION
## Reproducer:
1. Create a table with multi-select column (options: `a, b, c`)
2. Create a row with options `a, c`
3. Delete option `c`
4. Export table to csv

Expected result: table exported to csv without removed option
Actual result: there is an error in the console, csv file not created