### PR TITLE
fix: Duplicate sidebar entries due to race condition

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -507,12 +507,12 @@ export const useTablesStore = defineStore('store', {
 			let res
 			try {
 				res = await axios.get(generateOcsUrl('/apps/tables/api/2/tables/' + id))
-				
+
 				const existingTable = this.tables.find(table => table.id === id)
 				if (existingTable) {
 					return existingTable
 				}
-				
+
 				const tables = this.tables
 				tables.push(res.data.ocs.data)
 				this.setTables([...tables])
@@ -536,12 +536,12 @@ export const useTablesStore = defineStore('store', {
 			let res
 			try {
 				res = await axios.get(generateUrl('/apps/tables/view/' + id))
-				
+
 				const existingView = this.views.find(view => view.id === id)
 				if (existingView) {
 					return existingView
 				}
-				
+
 				const views = this.views
 				views.push(res.data)
 				this.setViews([...views])

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -507,6 +507,12 @@ export const useTablesStore = defineStore('store', {
 			let res
 			try {
 				res = await axios.get(generateOcsUrl('/apps/tables/api/2/tables/' + id))
+				
+				const existingTable = this.tables.find(table => table.id === id)
+				if (existingTable) {
+					return existingTable
+				}
+				
 				const tables = this.tables
 				tables.push(res.data.ocs.data)
 				this.setTables([...tables])
@@ -530,6 +536,12 @@ export const useTablesStore = defineStore('store', {
 			let res
 			try {
 				res = await axios.get(generateUrl('/apps/tables/view/' + id))
+				
+				const existingView = this.views.find(view => view.id === id)
+				if (existingView) {
+					return existingView
+				}
+				
 				const views = this.views
 				views.push(res.data)
 				this.setViews([...views])


### PR DESCRIPTION
fixes https://github.com/nextcloud/tables/issues/2336

When an application is created from an existing table, we concurrently triggers `loadTablesFromBE()` and `getAllContexts()`
 using `Promise.all`. Since tables and contexts fetch data and mutate the same frontend arrays, a race condition occurred. `loadTablesFromBE()` and `loadContextTable()` both populate `this.tables`. Now, we explicitly check to avoid this