### PR TITLE
feat: update loading shares of table

### DIFF
--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -39,7 +39,7 @@ class ShareController extends Controller {
 
 
 	#[NoAdminRequired]
-	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	public function index(int $tableId): DataResponse {
 		return $this->handleError(function () use ($tableId) {
 			$shares = $this->service->findAll('table', $tableId);
@@ -48,7 +48,7 @@ class ShareController extends Controller {
 	}
 
 	#[NoAdminRequired]
-	#[RequirePermission(permission: Application::PERMISSION_READ, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_VIEW, idParam: 'viewId')]
 	public function indexView(int $viewId): DataResponse {
 		return $this->handleError(function () use ($viewId) {
 			$shares = $this->service->findAll('view', $viewId);

--- a/src/modules/main/sections/Dashboard.vue
+++ b/src/modules/main/sections/Dashboard.vue
@@ -262,11 +262,13 @@ export default {
 		},
 
 		async loadShares() {
-			// load shares for table
-			this.loadingTableShares = true
-			const allTableShares = await this.getSharesForTableFromBE(this.table.id)
-			this.tableShares = allTableShares.filter(s => !isPublicLinkShare(s))
-			this.loadingTableShares = false
+			if (this.canManageElement(this.table)) {
+				// load shares for table
+				this.loadingTableShares = true
+				const allTableShares = await this.getSharesForTableFromBE(this.table.id)
+				this.tableShares = allTableShares.filter(s => !isPublicLinkShare(s))
+				this.loadingTableShares = false
+			}
 
 			// load shares for all views
 			this.loadingViewShares = true


### PR DESCRIPTION
Update access control for viewing table shares and improves the user interface logic to ensure only authorized users can load share information.

* The `index` method in `ShareController.php` now requires `MANAGE` permission instead of `READ` to access table shares, ensuring only users with management rights can view share information.

* The `indexView` method in `ShareController.php` now requires `MANAGE` permission instead of `READ` to access view shares, ensuring only users with management rights can view share information.

* In `Dashboard.vue`, the `loadShares` method now checks if the user can manage the table before loading its shares, preventing unauthorized users from accessing share data.