### PR TITLE
ci: fix wrong concurrency group

### DIFF
--- a/.github/workflows/php-scoper-dependencies.yml
+++ b/.github/workflows/php-scoper-dependencies.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: openapi-${{ github.head_ref || github.run_id }}
+  group: phpscoper-deps-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
It was responsible for the cancellations like
<img width="1492" height="108" alt="image" src="https://github.com/user-attachments/assets/7f2457e3-d5ce-4100-ae9a-07ccb996111b" /> in opanapi vs phpscoper-dependencies checks.