### PR TITLE
Add possibility filter select/multiselect columns with dropdown

### DIFF
--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -112,7 +112,7 @@ import {
 } from '../../constants.ts'
 import { MetaColumns } from './mixins/metaColumns.js'
 import { MagicFields } from './mixins/magicFields.js'
-import { getFiltersForColumn } from './mixins/filter.js'
+import { FilterIds, getFiltersForColumn } from './mixins/filter.js'
 
 export default {
 	name: 'NcTable',
@@ -235,7 +235,6 @@ export default {
 			return this.viewSetting?.sorting
 		},
 		getSearchedAndFilteredRows() {
-			const debug = false
 			// if we don't have to search and/or filter
 			if (!this.viewSetting?.filter?.length > 0 && !this.viewSetting?.searchString) {
 				// cleanup markers
@@ -267,18 +266,11 @@ export default {
 				if (!row || !row.data) {
 					continue
 				}
-
-				if (debug) {
-					console.debug('new row ===============================================', row)
-				}
 				let filterStatusRow = null
 				let searchStatusRow = false
 
 				// each column in a row => cell
 				this.columns.forEach(column => {
-					if (debug) {
-						console.debug('new column -------------------', column)
-					}
 					let filterStatus = null
 					let searchStatus = true
 					const filters = getFiltersForColumn(column, this.viewSetting)
@@ -326,12 +318,7 @@ export default {
 					})
 					// if we should search
 					if (searchString) {
-						console.debug('look for searchString', searchString)
 						searchStatus = column.isSearchStringFound(cell, searchString.toLowerCase())
-					}
-
-					if (debug) {
-						console.debug('filterStatus for cell', { cell: cell?.value, filterStatusCell: filterStatus, filterStatusRowBefore: filterStatusRow })
 					}
 
 					// if filterStatus is null, this result should be ignored
@@ -339,17 +326,10 @@ export default {
 						filterStatusRow = filterStatus
 					}
 
-					if (debug) {
-						console.debug('new filterStatusRow', filterStatusRow)
-					}
-
 					// filterStatusRow = filterStatus
 					searchStatusRow = searchStatusRow || searchStatus
 				})
 
-				if (debug) {
-					console.debug('if push row', { filterStatusRow, searchStatusRow, result: (filterStatusRow || filterStatusRow === null) && searchStatusRow })
-				}
 				if ((filterStatusRow || filterStatusRow === null) && searchStatusRow) {
 					data.push({ ...row })
 				}
@@ -419,6 +399,10 @@ export default {
 			this.localViewSetting = JSON.parse(JSON.stringify(this.localViewSetting))
 		},
 		addMagicFieldsValues(filter) {
+			if (FilterIds.ContainsItem === filter.operator.id) {
+				return
+			}
+
 			Object.values(MagicFields).forEach(field => {
 				const newFilterValue = filter.value.replace('@' + field.id, field.replace)
 				if (filter.value !== newFilterValue) {

--- a/src/shared/components/ncTable/mixins/columnsTypes/selection.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selection.js
@@ -54,6 +54,7 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const cellLabel = this.getLabel(cell.value)
 		const filterMethod = {
+			[FilterIds.ContainsItem]() { return filterValue.map(option => option.id).includes(cell.value) },
 			[FilterIds.Contains]() { return cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
 			[FilterIds.DoesNotContain]() { return !cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
 			[FilterIds.BeginsWith]() { return cellLabel?.startsWith(filterValue) },

--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
@@ -71,6 +71,13 @@ export default class SelectionMutliColumn extends AbstractSelectionColumn {
 		const valueString = this.getValueString(cell)
 
 		const filterMethod = {
+			[FilterIds.ContainsItem]() {
+				if ((!cell.value || !cell.value.length) && filter.value.length > 0) {
+					return false
+				}
+				const filterOptionIds = filter.value.map(option => option.id)
+				return cell.value.filter(v => filterOptionIds.includes(v)).length > 0
+			},
 			[FilterIds.Contains]() { return valueString?.includes(filterValue) },
 			[FilterIds.DoesNotContain]() { return !valueString?.includes(filterValue) },
 			[FilterIds.IsEqual]() { return valueString === filterValue },

--- a/src/shared/components/ncTable/mixins/filter.js
+++ b/src/shared/components/ncTable/mixins/filter.js
@@ -39,6 +39,7 @@ export function getFilterWithId(id) {
 
 export const FilterIds = {
 	Contains: 'contains',
+	ContainsItem: 'contains-item',
 	DoesNotContain: 'does-not-contain',
 	BeginsWith: 'begins-with',
 	EndsWith: 'ends-with',
@@ -52,6 +53,12 @@ export const FilterIds = {
 }
 
 export const Filters = {
+	ContainsItem: new Filter({
+		id: FilterIds.ContainsItem,
+		label: t('tables', 'Contains items'),
+		goodFor: [ColumnTypes.SelectionMulti, ColumnTypes.Selection],
+		incompatibleWith: [FilterIds.DoesNotContain, FilterIds.IsEmpty, FilterIds.IsEqual],
+	}),
 	Contains: new Filter({
 		id: FilterIds.Contains,
 		label: t('tables', 'Contains'),
@@ -128,8 +135,16 @@ export const Filters = {
 }
 
 export function getFiltersForColumn(column, viewSetting) {
-	if (viewSetting?.filter?.length > 0) {
-		return viewSetting.filter.filter(filter => filter.columnId === column.id)
-	}
-	return []
+	const filters = viewSetting?.filter?.filter(filter => {
+		if (filter.columnId !== column.id) {
+			return false
+		}
+
+		if (filter.operator.id === FilterIds.ContainsItem) {
+			return filter.value.length > 0
+		}
+
+		return true
+	})
+	return filters?.length > 0 ? filters : []
 }

--- a/src/shared/components/ncTable/partials/FilterLabel.vue
+++ b/src/shared/components/ncTable/partials/FilterLabel.vue
@@ -27,7 +27,7 @@ export default {
 		      default: null,
 		    },
 		value: {
-		      type: String,
+		      type: [String, Array],
 		      default: '',
 		    },
 		type: {
@@ -42,6 +42,10 @@ export default {
 
 	computed: {
 		getValue() {
+			if (FilterIds.ContainsItem === this.operator.id) {
+				return this.value
+			}
+
 			let value = this.value
 			Object.values(MagicFields).forEach(field => {
 				value = value.replace('@' + field.id, field.label)
@@ -51,6 +55,8 @@ export default {
 		labelText() {
 			if (this.operator.id === FilterIds.IsEmpty) {
 				return this.operator.getOperatorLabel()
+			} else if (this.operator.id === FilterIds.ContainsItem) {
+				return this.operator.getOperatorLabel() + ' "' + this.getValue.map(item => item.label).join(', ') + '"'
 			} else {
 				return this.operator.getOperatorLabel() + ' "' + this.getValue + '"'
 			}

--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -36,7 +36,26 @@
 					{{ t('tables', 'Back') }}
 				</NcActionButton>
 				<NcActionCaption :name="t('tables', 'Search for value')" />
+
+				<template v-if="FilterIds.ContainsItem === selectedOperator.id">
+					<NcActionInput
+						v-model="searchOptions"
+						type="multiselect"
+						:multiple="true"
+						:options="column.selectionOptions"
+						:placeholder="t('tables', 'Select options')" />
+					<NcActionButton
+						:close-after-click="true"
+						@click="submitFilterInput()">
+						<template #icon>
+							<Magnify :size="20" />
+						</template>
+						{{ t('tables', 'Submit') }}
+					</NcActionButton>
+				</template>
+
 				<NcActionInput
+					v-else
 					ref="filterInput"
 					:label-visible="false"
 					:label="t('tables', 'Keyword and submit')"
@@ -47,6 +66,7 @@
 						<Magnify :size="20" />
 					</template>
 				</NcActionInput>
+
 				<NcActionCaption
 					v-if="getMagicFields.length > 0"
 					:name="t('tables', 'Or use magic values')" />
@@ -199,12 +219,14 @@ export default {
 	data() {
 		return {
 			searchValue: '',
+			searchOptions: [],
 			operator: null,
 			sortMode: null,
 			term: '',
 			selectOperator: false,
 			selectValue: false,
 			localViewSetting: this.viewSetting,
+			FilterIds,
 		}
 	},
 	computed: {
@@ -353,6 +375,8 @@ export default {
 			}
 			this.createFilter()
 			this.localOpenState = false
+			this.searchOptions = []
+			this.selectOperator = false
 		},
 		getFilterForColumn(column) {
 			return this.localViewSetting?.filter?.filter(item => item.columnId === column.id)
@@ -361,18 +385,18 @@ export default {
 			const filterObject = {
 				columnId: this.column.id,
 				operator: this.selectedOperator,
-				value: this.searchValue,
+				value: FilterIds.ContainsItem === this.selectedOperator.id ? this.searchOptions : this.searchValue,
 			}
 			if (!this.localViewSetting.filter) {
 				this.localViewSetting.filter = []
 			}
 			this.localViewSetting.filter.push(filterObject)
 			this.localViewSetting = JSON.parse(JSON.stringify(this.localViewSetting))
-			this.close()
 		},
 		reset() {
 			this.operator = null
 			this.searchValue = ''
+			this.searchOptions = []
 			this.sortMode = this.getSortMode
 			this.selectOperator = false
 			this.selectValue = false
@@ -427,5 +451,9 @@ export default {
 
 .selected-option {
 	width: 100%;
+}
+
+:deep(.vs__dropdown-menu) {
+	--vs-dropdown-max-height: 120px;
 }
 </style>


### PR DESCRIPTION
Right now it is not possible to to search select/multiselect columns using `OR` operator (contains "aaa" or "bbb") using plain text filters. This PR adds possibility to filter select/multiselect with droprowns instead of plain text. Also it can be useful for large tables when you don't know full list of possible dropdown values

## :mag: Preview
This is how it works now  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/218e9a1d-9855-49d3-869b-12409c917d7b" />

This is how it works with patch  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fab83bed-45ee-4810-bbfa-36acbec301dc" />  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2e45c406-2b70-4959-a20f-fceb433f0e3d" />  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2fcdadee-87a4-418a-8833-54259b6d2281" />
