### PR TITLE
Fix: not possible to clear usergroup column via inline edit

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellUsergroup.vue
+++ b/src/shared/components/ncTable/partials/TableCellUsergroup.vue
@@ -161,7 +161,10 @@ export default {
 				return
 			}
 
-			let newValue = !Array.isArray(this.editValue) ? [this.editValue] : this.editValue
+			let newValue = []
+			if (this.editValue !== null) {
+				newValue = !Array.isArray(this.editValue) ? [this.editValue] : this.editValue
+			}
 			// If the column does not allow multiple items, limit to one item
 			// in case we switched from multiple to single selection
 			if (!this.column.usergroupMultipleItems) {


### PR DESCRIPTION
## Reproducer:
1. Create a table with a non-mandatory usergroup column
2. Create a row, set some value to usergroup column
3. Try to remove that value via inline edit

### Expected result
it is possible to remove value and save changes

### Actual result
there is an error


## :framed_picture: Screenshots
| :heavy_minus_sign:  Before | :heavy_plus_sign:  After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/3f2412c8-581e-4d92-8dcd-34d59be2d760" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1a4da5fa-e892-4f67-9f55-9573045cb2af" /> | 


BTW we have huge duplication between row edit in popup and inline edit