### PR TITLE
feat: Notion-style view tabs, chart views, and relation columns

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -62,6 +62,9 @@ return [
 		['name' => 'api1#deleteRowByView',	'url' => '/api/1/views/{viewId}/rows/{rowId}', 'verb' => 'DELETE'],
 		['name' => 'api1#updateRow',	'url' => '/api/1/rows/{rowId}', 'verb' => 'PUT'],
 		['name' => 'api1#deleteRow',	'url' => '/api/1/rows/{rowId}', 'verb' => 'DELETE'],
+		// -> relations
+		['name' => 'api1#getRelations', 'url' => '/api/1/relations/{columnId}/{rowId}', 'verb' => 'GET'],
+		['name' => 'api1#setRelations', 'url' => '/api/1/relations/{columnId}/{rowId}', 'verb' => 'PUT'],
 		// -> import
 		['name' => 'api1#importInTable', 'url' => '/api/1/import/table/{tableId}', 'verb' => 'POST'],
 		['name' => 'api1#importInView', 'url' => '/api/1/import/views/{viewId}', 'verb' => 'POST'],
@@ -135,6 +138,7 @@ return [
 		['name' => 'ApiColumns#createSelectionColumn', 'url' => '/api/2/columns/selection', 'verb' => 'POST'],
 		['name' => 'ApiColumns#createDatetimeColumn', 'url' => '/api/2/columns/datetime', 'verb' => 'POST'],
 		['name' => 'ApiColumns#createUsergroupColumn', 'url' => '/api/2/columns/usergroup', 'verb' => 'POST'],
+		['name' => 'ApiColumns#createRelationColumn', 'url' => '/api/2/columns/relation', 'verb' => 'POST'],
 
 		['name' => 'ApiFavorite#create', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'POST', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],
 		['name' => 'ApiFavorite#destroy', 'url' => '/api/2/favorites/{nodeType}/{nodeId}', 'verb' => 'DELETE', 'requirements' => ['nodeType' => '(\d+)', 'nodeId' => '(\d+)']],

--- a/lib/Constants/ColumnType.php
+++ b/lib/Constants/ColumnType.php
@@ -15,4 +15,5 @@ enum ColumnType: string {
 	case SELECTION = 'selection';
 	case DATETIME = 'datetime';
 	case PEOPLE = 'usergroup';
+	case RELATION = 'relation';
 }

--- a/lib/Constants/ViewUpdatableParameters.php
+++ b/lib/Constants/ViewUpdatableParameters.php
@@ -13,6 +13,7 @@ enum ViewUpdatableParameters: string {
 	case TITLE = 'title';
 	case EMOJI = 'emoji';
 	case DESCRIPTION = 'description';
+	case TYPE = 'type';
 	case SORT = 'sort';
 	case FILTER = 'filter';
 	case COLUMN_SETTINGS = 'columns';

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -25,6 +25,7 @@ use OCA\Tables\Model\ViewUpdateInput;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\ColumnService;
 use OCA\Tables\Service\ImportService;
+use OCA\Tables\Service\RelationService;
 use OCA\Tables\Service\RowService;
 use OCA\Tables\Service\ShareService;
 use OCA\Tables\Service\TableService;
@@ -69,6 +70,8 @@ class Api1Controller extends ApiController {
 
 	protected LoggerInterface $logger;
 
+	private RelationService $relationService;
+
 	use Errors;
 
 
@@ -85,6 +88,7 @@ class Api1Controller extends ApiController {
 		LoggerInterface $logger,
 		IL10N $l10N,
 		?string $userId,
+		RelationService $relationService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->tableService = $service;
@@ -98,6 +102,7 @@ class Api1Controller extends ApiController {
 		$this->v1Api = $v1Api;
 		$this->logger = $logger;
 		$this->l10N = $l10N;
+		$this->relationService = $relationService;
 	}
 
 	// Tables
@@ -346,9 +351,9 @@ class Api1Controller extends ApiController {
 	#[CORS]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
-	public function createView(int $tableId, string $title, ?string $emoji): DataResponse {
+	public function createView(int $tableId, string $title, ?string $emoji, ?string $type = 'table'): DataResponse {
 		try {
-			return new DataResponse($this->viewService->create($title, $emoji, $this->tableService->find($tableId))->jsonSerialize());
+			return new DataResponse($this->viewService->create($title, $emoji, $this->tableService->find($tableId), null, $type)->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
@@ -1727,6 +1732,41 @@ class Api1Controller extends ApiController {
 			$this->logger->info('A invalid value was provided: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
 			return new DataResponse($message, Http::STATUS_BAD_REQUEST);
+		}
+	}
+
+	// Relations
+
+	/**
+	 * @NoAdminRequired
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
+	public function getRelations(int $columnId, int $rowId): DataResponse {
+		try {
+			$linkedIds = $this->relationService->getLinkedRowIds($rowId, $columnId);
+			return new DataResponse($linkedIds);
+		} catch (\Exception $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
+	public function setRelations(int $columnId, int $rowId, array $targetRowIds = []): DataResponse {
+		try {
+			$column = $this->columnService->find($columnId);
+			$userId = $this->userId;
+			$this->relationService->setLinks($columnId, $rowId, $targetRowIds, $userId, $column);
+			$linkedIds = $this->relationService->getLinkedRowIds($rowId, $columnId);
+			return new DataResponse($linkedIds);
+		} catch (\Exception $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 }

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -412,4 +412,62 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 		);
 		return new DataResponse($column->jsonSerialize());
 	}
+
+	/**
+	 * [api v2] Create new relation column
+	 *
+	 * Links rows from one table to rows in another table
+	 *
+	 * @param int $baseNodeId Context of the column creation
+	 * @param string $title Title
+	 * @param int $relationTableId ID of the related table
+	 * @param boolean $relationMultiple Whether multiple rows can be linked
+	 * @param string $relationType Relation type: 'one-to-one', 'one-to-many', 'many-to-many'
+	 * @param int|null $relationDisplayColumnId Column ID from target table to display
+	 * @param string|null $description Description
+	 * @param list<int>|null $selectedViewIds View IDs where this columns
+	 *                                        should be added
+	 * @param boolean $mandatory Is mandatory
+	 * @param 'table'|'view' $baseNodeType Context type of the column creation
+	 * @param array<string, mixed> $customSettings Custom settings for the
+	 *                                             column
+	 *
+	 *
+	 * @return DataResponse<Http::STATUS_OK, TablesColumn,
+	 *     array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND,
+	 *     array{message: string}, array{}>
+	 *
+	 *
+	 * 200: Column created
+	 * 403: No permission
+	 * 404: Not found
+	 * @throws InternalError
+	 * @throws NotFoundError
+	 * @throws PermissionError
+	 * @throws BadRequestError
+	 */
+	#[NoAdminRequired]
+	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
+	public function createRelationColumn(int $baseNodeId, string $title, int $relationTableId, ?bool $relationMultiple = false, string $relationType = 'many-to-many', ?int $relationDisplayColumnId = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
+		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
+		$column = $this->service->create(
+			$this->userId,
+			$tableId,
+			$viewId,
+			new ColumnDto(
+				title: $title,
+				type: ColumnType::RELATION->value,
+				mandatory: $mandatory,
+				description: $description,
+				customSettings: json_encode($customSettings),
+				relationTableId: $relationTableId,
+				relationMultiple: $relationMultiple,
+				relationType: $relationType,
+				relationDisplayColumnId: $relationDisplayColumnId,
+			),
+			$selectedViewIds
+		);
+		return new DataResponse($column->jsonSerialize());
+	}
 }

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -78,9 +78,9 @@ class ViewController extends Controller {
 
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, type: Application::NODE_TYPE_TABLE, idParam: 'tableId')]
-	public function create(int $tableId, string $title, ?string $emoji): DataResponse {
-		return $this->handleError(function () use ($tableId, $title, $emoji) {
-			return $this->service->create($title, $emoji, $this->getTable($tableId, true));
+	public function create(int $tableId, string $title, ?string $emoji, ?string $type = 'table'): DataResponse {
+		return $this->handleError(function () use ($tableId, $title, $emoji, $type) {
+			return $this->service->create($title, $emoji, $this->getTable($tableId, true), null, $type);
 		});
 	}
 

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -103,6 +103,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	public const TYPE_NUMBER = 'number';
 	public const TYPE_DATETIME = 'datetime';
 	public const TYPE_USERGROUP = 'usergroup';
+	public const TYPE_RELATION = 'relation';
 
 	public const SUBTYPE_DATETIME_DATE = 'date';
 	public const SUBTYPE_DATETIME_TIME = 'time';
@@ -156,6 +157,13 @@ class Column extends EntitySuper implements JsonSerializable {
 	protected ?bool $showUserStatus = null;
 	protected ?string $customSettings = null;
 
+	// type relation
+	protected ?int $relationTableId = null;
+	protected ?bool $relationMultiple = null;
+	protected ?int $relationTargetColumnId = null;
+	protected ?string $relationType = null;
+	protected ?int $relationDisplayColumnId = null;
+
 	// virtual properties
 	protected ?string $createdByDisplayName = null;
 	protected ?string $lastEditByDisplayName = null;
@@ -186,6 +194,13 @@ class Column extends EntitySuper implements JsonSerializable {
 		$this->addType('showUserStatus', 'boolean');
 
 		$this->addType('customSettings', 'string');
+
+		// type relation
+		$this->addType('relationTableId', 'integer');
+		$this->addType('relationMultiple', 'boolean');
+		$this->addType('relationTargetColumnId', 'integer');
+		$this->addType('relationType', 'string');
+		$this->addType('relationDisplayColumnId', 'integer');
 	}
 
 	public static function isValidMetaTypeId(int $metaTypeId): bool {
@@ -225,6 +240,11 @@ class Column extends EntitySuper implements JsonSerializable {
 		$column->setUsergroupSelectTeams($data->getUsergroupSelectTeams());
 		$column->setShowUserStatus($data->getShowUserStatus());
 		$column->setCustomSettings($data->getCustomSettings());
+		$column->setRelationTableId($data->getRelationTableId());
+		$column->setRelationMultiple($data->getRelationMultiple());
+		$column->setRelationTargetColumnId($data->getRelationTargetColumnId());
+		$column->setRelationType($data->getRelationType());
+		$column->setRelationDisplayColumnId($data->getRelationDisplayColumnId());
 		return $column;
 	}
 
@@ -305,6 +325,13 @@ class Column extends EntitySuper implements JsonSerializable {
 			'usergroupSelectTeams' => $this->usergroupSelectTeams,
 			'showUserStatus' => $this->showUserStatus,
 			'customSettings' => $this->getCustomSettingsArray() ?: new \stdClass(),
+
+			// type relation
+			'relationTableId' => $this->getRelationTableId(),
+			'relationMultiple' => $this->getRelationMultiple(),
+			'relationTargetColumnId' => $this->getRelationTargetColumnId(),
+			'relationType' => $this->getRelationType(),
+			'relationDisplayColumnId' => $this->getRelationDisplayColumnId(),
 		];
 	}
 

--- a/lib/Db/ColumnTypes/RelationColumnQB.php
+++ b/lib/Db/ColumnTypes/RelationColumnQB.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db\ColumnTypes;
+
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class RelationColumnQB extends SuperColumnQB implements IColumnTypeQB {
+	// Use default implementations from SuperColumnQB
+}

--- a/lib/Db/RowCellRelation.php
+++ b/lib/Db/RowCellRelation.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+class RowCellRelation extends RowCellSuper {
+	protected ?string $value = null;
+
+	public function __construct() {
+		parent::__construct();
+		$this->addType('value', 'string');
+	}
+
+	public function jsonSerialize(): array {
+		return parent::jsonSerializePreparation($this->value);
+	}
+}

--- a/lib/Db/RowCellRelationMapper.php
+++ b/lib/Db/RowCellRelationMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+use OCP\IDBConnection;
+
+/**
+ * @template-extends RowCellMapperSuper<RowCellRelation, string, string|array>
+ */
+class RowCellRelationMapper extends RowCellMapperSuper {
+	use RowCellBulkFetchTrait;
+
+	protected string $table = 'tables_row_cells_relation';
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, $this->table, RowCellRelation::class);
+	}
+
+	public function filterValueToQueryParam(Column $column, mixed $value): mixed {
+		return $value ?? '';
+	}
+
+	public function applyDataToEntity(Column $column, RowCellSuper $cell, $data): void {
+		if (is_array($data)) {
+			$cell->setValue(json_encode($data));
+		} else {
+			$cell->setValue($data);
+		}
+	}
+
+	public function formatEntity(Column $column, RowCellSuper $cell) {
+		return json_decode($cell->getValue());
+	}
+}

--- a/lib/Db/RowRelation.php
+++ b/lib/Db/RowRelation.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method int getRelationColumnId()
+ * @method void setRelationColumnId(int $relationColumnId)
+ * @method int getSourceRowId()
+ * @method void setSourceRowId(int $sourceRowId)
+ * @method int getTargetRowId()
+ * @method void setTargetRowId(int $targetRowId)
+ * @method string getCreatedBy()
+ * @method void setCreatedBy(string $createdBy)
+ * @method string getCreatedAt()
+ * @method void setCreatedAt(string $createdAt)
+ */
+class RowRelation extends Entity implements \JsonSerializable {
+	protected ?int $relationColumnId = null;
+	protected ?int $sourceRowId = null;
+	protected ?int $targetRowId = null;
+	protected ?string $createdBy = null;
+	protected ?string $createdAt = null;
+
+	public function __construct() {
+		$this->addType('relationColumnId', 'integer');
+		$this->addType('sourceRowId', 'integer');
+		$this->addType('targetRowId', 'integer');
+		$this->addType('createdBy', 'string');
+		$this->addType('createdAt', 'string');
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'relationColumnId' => $this->getRelationColumnId(),
+			'sourceRowId' => $this->getSourceRowId(),
+			'targetRowId' => $this->getTargetRowId(),
+			'createdBy' => $this->getCreatedBy(),
+			'createdAt' => $this->getCreatedAt(),
+		];
+	}
+}

--- a/lib/Db/RowRelationMapper.php
+++ b/lib/Db/RowRelationMapper.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+class RowRelationMapper extends QBMapper {
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'tables_row_relations', RowRelation::class);
+	}
+
+	/**
+	 * Get all relations for a given source row and column
+	 */
+	public function findBySourceRowAndColumn(int $sourceRowId, int $columnId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('source_row_id', $qb->createNamedParameter($sourceRowId)))
+			->andWhere($qb->expr()->eq('relation_column_id', $qb->createNamedParameter($columnId)));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Get all relations for a given target row and column
+	 */
+	public function findByTargetRowAndColumn(int $targetRowId, int $columnId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('target_row_id', $qb->createNamedParameter($targetRowId)))
+			->andWhere($qb->expr()->eq('relation_column_id', $qb->createNamedParameter($columnId)));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Get all relations for a column
+	 */
+	public function findByColumn(int $columnId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('relation_column_id', $qb->createNamedParameter($columnId)));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Delete all relations for a given source row
+	 */
+	public function deleteBySourceRow(int $sourceRowId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('source_row_id', $qb->createNamedParameter($sourceRowId)));
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Delete all relations for a given target row
+	 */
+	public function deleteByTargetRow(int $targetRowId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('target_row_id', $qb->createNamedParameter($targetRowId)));
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Delete all relations for a column (when column is deleted)
+	 */
+	public function deleteByColumn(int $columnId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('relation_column_id', $qb->createNamedParameter($columnId)));
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Delete a specific relation link
+	 */
+	public function deleteLink(int $columnId, int $sourceRowId, int $targetRowId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('relation_column_id', $qb->createNamedParameter($columnId)))
+			->andWhere($qb->expr()->eq('source_row_id', $qb->createNamedParameter($sourceRowId)))
+			->andWhere($qb->expr()->eq('target_row_id', $qb->createNamedParameter($targetRowId)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -45,6 +45,8 @@ use OCA\Tables\Service\ValueObject\ViewColumnInformation;
  * @method setEmoji(string $emoji)
  * @method getDescription(): string
  * @method setDescription(string $description)
+ * @method string getType()
+ * @method void setType(string $type)
  * @method getIsShared(): bool
  * @method setIsShared(bool $isShared)
  * @method getOnSharePermissions(): ?Permissions
@@ -71,6 +73,7 @@ class View extends EntitySuper implements JsonSerializable {
 	protected ?string $lastEditAt = null;
 	protected ?string $emoji = null;
 	protected ?string $description = null;
+	protected ?string $type = 'table';
 	protected ?string $columns = null; // json
 	protected ?string $sort = null; // json
 	protected ?string $filter = null; // json
@@ -89,6 +92,7 @@ class View extends EntitySuper implements JsonSerializable {
 	public function __construct() {
 		$this->addType('id', 'integer');
 		$this->addType('tableId', 'integer');
+		$this->addType('type', 'string');
 	}
 
 	/**
@@ -184,6 +188,7 @@ class View extends EntitySuper implements JsonSerializable {
 			'tableId' => ($this->tableId || $this->tableId === 0) ? $this->tableId : -1,
 			'title' => $this->title ?: '',
 			'description' => $this->description,
+			'type' => $this->getType(),
 			'emoji' => $this->emoji,
 			'ownership' => $this->ownership ?: '',
 			'createdBy' => $this->createdBy ?: '',

--- a/lib/Dto/Column.php
+++ b/lib/Dto/Column.php
@@ -34,6 +34,11 @@ class Column {
 		private ?bool $usergroupSelectTeams = null,
 		private ?bool $showUserStatus = null,
 		private ?string $customSettings = null,
+		private ?int $relationTableId = null,
+		private ?bool $relationMultiple = null,
+		private ?int $relationTargetColumnId = null,
+		private ?string $relationType = null,
+		private ?int $relationDisplayColumnId = null,
 	) {
 	}
 
@@ -69,6 +74,11 @@ class Column {
 			usergroupSelectTeams: $data['usergroupSelectTeams'] ?? null,
 			showUserStatus: $data['showUserStatus'] ?? null,
 			customSettings: $customSettings,
+			relationTableId: $data['relationTableId'] ?? null,
+			relationMultiple: $data['relationMultiple'] ?? null,
+			relationTargetColumnId: $data['relationTargetColumnId'] ?? null,
+			relationType: $data['relationType'] ?? null,
+			relationDisplayColumnId: $data['relationDisplayColumnId'] ?? null,
 		);
 	}
 
@@ -170,5 +180,25 @@ class Column {
 
 	public function getCustomSettings(): ?string {
 		return $this->customSettings;
+	}
+
+	public function getRelationTableId(): ?int {
+		return $this->relationTableId;
+	}
+
+	public function getRelationMultiple(): ?bool {
+		return $this->relationMultiple;
+	}
+
+	public function getRelationTargetColumnId(): ?int {
+		return $this->relationTargetColumnId;
+	}
+
+	public function getRelationType(): ?string {
+		return $this->relationType;
+	}
+
+	public function getRelationDisplayColumnId(): ?int {
+		return $this->relationDisplayColumnId;
 	}
 }

--- a/lib/Helper/ColumnsHelper.php
+++ b/lib/Helper/ColumnsHelper.php
@@ -20,6 +20,7 @@ class ColumnsHelper {
 		Column::TYPE_DATETIME,
 		Column::TYPE_SELECTION,
 		Column::TYPE_USERGROUP,
+		Column::TYPE_RELATION,
 	];
 
 	/**

--- a/lib/Migration/Version001000Date20260314000000.php
+++ b/lib/Migration/Version001000Date20260314000000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version001000Date20260314000000 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('tables_views');
+		if (!$table->hasColumn('type')) {
+			$table->addColumn('type', Types::STRING, [
+				'notnull' => true,
+				'length' => 20,
+				'default' => 'table',
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version001000Date20260315000000.php
+++ b/lib/Migration/Version001000Date20260315000000.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version001000Date20260315000000 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		// Add relation columns to tables_columns
+		$columnsTable = $schema->getTable('tables_columns');
+		if (!$columnsTable->hasColumn('relation_table_id')) {
+			$columnsTable->addColumn('relation_table_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_multiple')) {
+			$columnsTable->addColumn('relation_multiple', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_target_column_id')) {
+			$columnsTable->addColumn('relation_target_column_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_type')) {
+			$columnsTable->addColumn('relation_type', Types::STRING, [
+				'notnull' => false,
+				'length' => 20,
+				'default' => 'many-to-many',
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_display_column_id')) {
+			$columnsTable->addColumn('relation_display_column_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		// Create join table for row relations
+		if (!$schema->hasTable('tables_row_relations')) {
+			$table = $schema->createTable('tables_row_relations');
+			$table->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('relation_column_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('source_row_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('target_row_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('created_by', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$table->addColumn('created_at', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['relation_column_id', 'source_row_id', 'target_row_id'], 'row_rel_col_src_tgt');
+			$table->addIndex(['source_row_id'], 'row_rel_source');
+			$table->addIndex(['target_row_id'], 'row_rel_target');
+			$table->addIndex(['relation_column_id'], 'row_rel_column');
+		}
+
+		// Drop the old cell table for relation type — relations now live in the join table
+		if ($schema->hasTable('tables_row_cells_relation')) {
+			$schema->dropTable('tables_row_cells_relation');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version001000Date20260315000000.php
+++ b/lib/Migration/Version001000Date20260315000000.php
@@ -80,9 +80,34 @@ class Version001000Date20260315000000 extends SimpleMigrationStep {
 			$table->addIndex(['relation_column_id'], 'row_rel_column');
 		}
 
-		// Drop the old cell table for relation type — relations now live in the join table
-		if ($schema->hasTable('tables_row_cells_relation')) {
-			$schema->dropTable('tables_row_cells_relation');
+		// Keep tables_row_cells_relation — Row2Mapper iterates all column types
+		// and queries their cell tables via UNION ALL. The table stays empty for
+		// relation columns since actual data lives in tables_row_relations.
+		if (!$schema->hasTable('tables_row_cells_relation')) {
+			$cellTable = $schema->createTable('tables_row_cells_relation');
+			$cellTable->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$cellTable->addColumn('column_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$cellTable->addColumn('row_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$cellTable->addColumn('value', Types::TEXT, [
+				'notnull' => false,
+			]);
+			$cellTable->addColumn('last_edit_by', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$cellTable->addColumn('last_edit_at', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$cellTable->setPrimaryKey(['id']);
+			$cellTable->addIndex(['column_id'], 'row_cell_rel_col');
+			$cellTable->addIndex(['row_id'], 'row_cell_rel_row');
 		}
 
 		return $schema;

--- a/lib/Migration/Version001000Date20260315120000.php
+++ b/lib/Migration/Version001000Date20260315120000.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version001000Date20260315120000 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		// Add relation columns to tables_columns
+		$columnsTable = $schema->getTable('tables_columns');
+		if (!$columnsTable->hasColumn('relation_table_id')) {
+			$columnsTable->addColumn('relation_table_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_multiple')) {
+			$columnsTable->addColumn('relation_multiple', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_target_column_id')) {
+			$columnsTable->addColumn('relation_target_column_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_type')) {
+			$columnsTable->addColumn('relation_type', Types::STRING, [
+				'notnull' => false,
+				'length' => 20,
+				'default' => 'many-to-many',
+			]);
+		}
+		if (!$columnsTable->hasColumn('relation_display_column_id')) {
+			$columnsTable->addColumn('relation_display_column_id', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		// Create join table for row relations
+		if (!$schema->hasTable('tables_row_relations')) {
+			$table = $schema->createTable('tables_row_relations');
+			$table->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('relation_column_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('source_row_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('target_row_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$table->addColumn('created_by', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$table->addColumn('created_at', Types::DATETIME, [
+				'notnull' => false,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['relation_column_id', 'source_row_id', 'target_row_id'], 'row_rel_col_src_tgt');
+			$table->addIndex(['source_row_id'], 'row_rel_source');
+			$table->addIndex(['target_row_id'], 'row_rel_target');
+			$table->addIndex(['relation_column_id'], 'row_rel_column');
+		}
+
+		// Keep tables_row_cells_relation — Row2Mapper iterates all column types
+		// and queries their cell tables. The table stays empty for relation columns
+		// since actual data lives in tables_row_relations join table.
+
+		return $schema;
+	}
+}

--- a/lib/Model/ViewUpdateInput.php
+++ b/lib/Model/ViewUpdateInput.php
@@ -26,6 +26,7 @@ class ViewUpdateInput {
 		protected readonly ?Title $title = null,
 		protected readonly ?string $description = null,
 		protected readonly ?Emoji $emoji = null,
+		protected readonly ?string $type = null,
 		protected readonly ?ColumnSettings $columnSettings = null,
 		protected readonly ?FilterSet $filterSet = null,
 		protected readonly ?SortRuleSet $sortRuleSet = null,
@@ -41,6 +42,9 @@ class ViewUpdateInput {
 		}
 		if ($this->emoji) {
 			yield ViewUpdatableParameters::EMOJI => $this->emoji;
+		}
+		if ($this->type) {
+			yield ViewUpdatableParameters::TYPE => $this->type;
 		}
 		if ($this->columnSettings) {
 			yield ViewUpdatableParameters::COLUMN_SETTINGS => $this->columnSettings;
@@ -84,6 +88,7 @@ class ViewUpdateInput {
 			title: $data['title'] ? new Title($data['title']) : null,
 			description: $data['description'] ?? null,
 			emoji: $data['emoji'] ? new Emoji($data['emoji']) : null,
+			type: $data['type'] ?? null,
 			columnSettings: $data['columnSettings'] ? ColumnSettings::createFromInputArray($data['columnSettings']) : null,
 			filterSet: $data['filter'] ? FilterSet::createFromInputArray($data['filter']) : null,
 			sortRuleSet: $data['sort'] ? SortRuleSet::createFromInputArray($data['sort']) : null,

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -272,6 +272,40 @@ class ColumnService extends SuperService {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
+
+		// Auto-create reverse relation column on target table
+		if ($entity->getType() === 'relation' && $entity->getRelationTableId() !== null) {
+			// Build reverse column using fromDto to ensure all required fields have defaults
+			$reverseDto = new ColumnDto(
+				title: $table->getTitle() . ' (linked)',
+				type: 'relation',
+				subtype: '',
+				description: '',
+				relationTableId: $table->getId(),
+				relationType: $entity->getRelationType() ?? 'many-to-many',
+				relationTargetColumnId: $entity->getId(),
+				relationMultiple: $entity->getRelationMultiple(),
+			);
+			$reverseColumn = Column::fromDto($reverseDto);
+			$reverseColumn->setTableId($entity->getRelationTableId());
+			// Set required DB defaults for non-nullable columns
+			$reverseColumn->setNumberPrefix('');
+			$reverseColumn->setNumberSuffix('');
+			$reverseColumn->setNumberDecimals(0);
+			$reverseColumn->setOrderWeight(0);
+			$reverseColumn->setMandatory(false);
+			$this->updateMetadata($reverseColumn, $userId, true);
+			try {
+				$reverseColumn = $this->mapper->insert($reverseColumn);
+
+				// Update the original column to point to the reverse column
+				$entity->setRelationTargetColumnId($reverseColumn->getId());
+				$this->mapper->update($entity);
+			} catch (\OCP\DB\Exception $e) {
+				$this->logger->error('Failed to create reverse relation column: ' . $e->getMessage(), ['exception' => $e]);
+			}
+		}
+
 		if (isset($view) && $view) {
 			// Add columns to view(s)
 			$this->viewService->addColumnToView($view, $entity, $userId);
@@ -362,6 +396,13 @@ class ColumnService extends SuperService {
 			$item->setShowUserStatus($columnDto->getShowUserStatus());
 			$this->validateCustomSettings($columnDto->getCustomSettings());
 			$item->setCustomSettings($columnDto->getCustomSettings());
+
+			if ($columnDto->getRelationTableId() !== null) {
+				$item->setRelationTableId($columnDto->getRelationTableId());
+			}
+			if ($columnDto->getRelationMultiple() !== null) {
+				$item->setRelationMultiple($columnDto->getRelationMultiple());
+			}
 
 			$this->updateMetadata($item, $userId);
 			return $this->enhanceColumn($this->mapper->update($item));
@@ -470,6 +511,24 @@ class ColumnService extends SuperService {
 				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 			}
 			$this->viewService->deleteColumnDataFromViews($id, $table);
+		}
+
+		// Clean up relation data if this is a relation column
+		if ($item->getType() === 'relation') {
+			// Delete the reverse column if it exists
+			$reverseColumnId = $item->getRelationTargetColumnId();
+			if ($reverseColumnId) {
+				try {
+					$reverseColumn = $this->mapper->find($reverseColumnId);
+					// Clear reverse pointer to avoid infinite loop
+					$reverseColumn->setRelationTargetColumnId(null);
+					$this->mapper->update($reverseColumn);
+					// Then delete it
+					$this->mapper->delete($reverseColumn);
+				} catch (\Exception $e) {
+					// Reverse column may already be deleted
+				}
+			}
 		}
 
 		try {

--- a/lib/Service/ColumnTypes/RelationBusiness.php
+++ b/lib/Service/ColumnTypes/RelationBusiness.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Service\ColumnTypes;
+
+use OCA\Tables\Db\Column;
+
+class RelationBusiness extends SuperBusiness implements IColumnTypeBusiness {
+
+	public function parseValue($value, Column $column): string {
+		// Relations are stored in the join table, not in cell values
+		// This is a no-op — the value field is not used for relation columns
+		return json_encode('');
+	}
+
+	public function canBeParsed($value, Column $column): bool {
+		return true;
+	}
+}

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Tables\Service;
+
+use OCA\Tables\Db\Column;
+use OCA\Tables\Db\RowRelation;
+use OCA\Tables\Db\RowRelationMapper;
+
+class RelationService {
+
+	public function __construct(
+		private RowRelationMapper $mapper,
+	) {
+	}
+
+	/**
+	 * Get linked target row IDs for a source row + column
+	 */
+	public function getLinkedRowIds(int $sourceRowId, int $columnId): array {
+		$relations = $this->mapper->findBySourceRowAndColumn($sourceRowId, $columnId);
+		return array_map(fn(RowRelation $r) => $r->getTargetRowId(), $relations);
+	}
+
+	/**
+	 * Get reverse linked source row IDs for a target row + column
+	 */
+	public function getReverseLinkedRowIds(int $targetRowId, int $columnId): array {
+		$relations = $this->mapper->findByTargetRowAndColumn($targetRowId, $columnId);
+		return array_map(fn(RowRelation $r) => $r->getSourceRowId(), $relations);
+	}
+
+	/**
+	 * Set the linked rows for a source row + column (replaces existing)
+	 */
+	public function setLinks(int $columnId, int $sourceRowId, array $targetRowIds, string $userId, Column $column): void {
+		// Enforce relation type constraints
+		$relationType = $column->getRelationType() ?? 'many-to-many';
+
+		if ($relationType === 'one-to-one' && count($targetRowIds) > 1) {
+			$targetRowIds = [array_shift($targetRowIds)];
+		}
+
+		// Get existing links
+		$existing = $this->mapper->findBySourceRowAndColumn($sourceRowId, $columnId);
+		$existingTargetIds = array_map(fn(RowRelation $r) => $r->getTargetRowId(), $existing);
+
+		// Delete removed links
+		foreach ($existing as $relation) {
+			if (!in_array($relation->getTargetRowId(), $targetRowIds)) {
+				$this->mapper->delete($relation);
+			}
+		}
+
+		// Add new links
+		$now = date('Y-m-d H:i:s');
+		foreach ($targetRowIds as $targetRowId) {
+			if (!in_array($targetRowId, $existingTargetIds)) {
+				$relation = new RowRelation();
+				$relation->setRelationColumnId($columnId);
+				$relation->setSourceRowId($sourceRowId);
+				$relation->setTargetRowId((int)$targetRowId);
+				$relation->setCreatedBy($userId);
+				$relation->setCreatedAt($now);
+				$this->mapper->insert($relation);
+			}
+		}
+	}
+
+	/**
+	 * Remove a specific link
+	 */
+	public function removeLink(int $columnId, int $sourceRowId, int $targetRowId): void {
+		$this->mapper->deleteLink($columnId, $sourceRowId, $targetRowId);
+	}
+
+	/**
+	 * Clean up all relations when a row is deleted
+	 */
+	public function onRowDeleted(int $rowId): void {
+		$this->mapper->deleteBySourceRow($rowId);
+		$this->mapper->deleteByTargetRow($rowId);
+	}
+
+	/**
+	 * Clean up all relations when a column is deleted
+	 */
+	public function onColumnDeleted(int $columnId): void {
+		$this->mapper->deleteByColumn($columnId);
+	}
+}

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -193,7 +193,7 @@ class ViewService extends SuperService {
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	public function create(string $title, ?string $emoji, Table $table, ?string $userId = null): View {
+	public function create(string $title, ?string $emoji, Table $table, ?string $userId = null, ?string $type = 'table'): View {
 		/** @var string $userId */
 		$userId = $this->permissionsService->preCheckUserId($userId, false); // $userId is set
 
@@ -209,6 +209,7 @@ class ViewService extends SuperService {
 			$item->setEmoji($emoji);
 		}
 		$item->setDescription('');
+		$item->setType($type ?? 'table');
 		$item->setTableId($table->getId());
 		$item->setCreatedBy($userId);
 		$item->setLastEditBy($userId);

--- a/src/modules/main/partials/ChartConfigBar.vue
+++ b/src/modules/main/partials/ChartConfigBar.vue
@@ -1,0 +1,128 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="chart-config-bar">
+		<div class="chart-config-item">
+			<label>{{ t('tables', 'Chart type') }}</label>
+			<NcSelect v-model="localChartType"
+				:options="chartTypeOptions"
+				:clearable="false"
+				label="label"
+				track-by="id"
+				@input="emitConfig" />
+		</div>
+		<div class="chart-config-item">
+			<label>{{ t('tables', 'X-Axis') }}</label>
+			<NcSelect v-model="localXColumn"
+				:options="columnOptions"
+				:clearable="false"
+				label="title"
+				track-by="id"
+				@input="emitConfig" />
+		</div>
+		<div class="chart-config-item">
+			<label>{{ t('tables', 'Y-Axis') }}</label>
+			<NcSelect v-model="localYColumn"
+				:options="numericColumnOptions"
+				:clearable="true"
+				:placeholder="t('tables', 'Count (rows)')"
+				label="title"
+				track-by="id"
+				@input="emitConfig" />
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+
+export default {
+	name: 'ChartConfigBar',
+	components: { NcSelect },
+	props: {
+		columns: {
+			type: Array,
+			required: true,
+		},
+		config: {
+			type: Object,
+			default: () => ({ chartType: 'bar', xColumnId: null, yColumnId: null }),
+		},
+	},
+	data() {
+		return {
+			chartTypeOptions: [
+				{ id: 'bar', label: t('tables', 'Bar') },
+				{ id: 'line', label: t('tables', 'Line') },
+				{ id: 'pie', label: t('tables', 'Pie / Donut') },
+			],
+			localChartType: null,
+			localXColumn: null,
+			localYColumn: null,
+		}
+	},
+	computed: {
+		columnOptions() {
+			return this.columns.filter(c => c.id >= 0)
+		},
+		numericColumnOptions() {
+			return this.columns.filter(c => c.id >= 0 && (c.type === 'number' || c.type === 'number-stars' || c.type === 'number-progress'))
+		},
+	},
+	watch: {
+		config: {
+			immediate: true,
+			handler(val) {
+				this.localChartType = this.chartTypeOptions.find(o => o.id === val?.chartType) || this.chartTypeOptions[0]
+				this.localXColumn = this.columns.find(c => c.id === val?.xColumnId) || this.columnOptions[0] || null
+				this.localYColumn = this.columns.find(c => c.id === val?.yColumnId) || null
+			},
+		},
+		columns: {
+			immediate: true,
+			handler() {
+				if (!this.localXColumn && this.columnOptions.length > 0) {
+					this.localXColumn = this.columnOptions[0]
+					this.emitConfig()
+				}
+			},
+		},
+	},
+	methods: {
+		emitConfig() {
+			this.$emit('update:config', {
+				chartType: this.localChartType?.id || 'bar',
+				xColumnId: this.localXColumn?.id || null,
+				yColumnId: this.localYColumn?.id || null,
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.chart-config-bar {
+	display: flex;
+	gap: 16px;
+	align-items: flex-end;
+	padding: 12px 0;
+	flex-wrap: wrap;
+}
+
+.chart-config-item {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 160px;
+
+	label {
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--color-text-maxcontrast);
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+	}
+}
+</style>

--- a/src/modules/main/partials/ChartView.vue
+++ b/src/modules/main/partials/ChartView.vue
@@ -1,0 +1,180 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="chart-view">
+		<ChartConfigBar :columns="columns" :config="chartConfig" @update:config="onConfigChange" />
+		<div v-if="!hasValidConfig" class="chart-empty">
+			<p>{{ t('tables', 'Select columns to visualize your data.') }}</p>
+		</div>
+		<div v-else class="chart-container">
+			<component :is="chartComponent" :data="chartData" :options="chartOptions" />
+		</div>
+	</div>
+</template>
+
+<script>
+import { Bar, Line, Pie } from 'vue-chartjs'
+import {
+	Chart as ChartJS,
+	Title,
+	Tooltip,
+	Legend,
+	BarElement,
+	LineElement,
+	PointElement,
+	ArcElement,
+	CategoryScale,
+	LinearScale,
+} from 'chart.js'
+import ChartConfigBar from './ChartConfigBar.vue'
+
+ChartJS.register(Title, Tooltip, Legend, BarElement, LineElement, PointElement, ArcElement, CategoryScale, LinearScale)
+
+const CHART_COLORS = [
+	'#0082c9', '#33b5e5', '#e9322d', '#eca700', '#46ba61',
+	'#969696', '#6c5ce7', '#fd79a8', '#00b894', '#fdcb6e',
+	'#636e72', '#d63031', '#74b9ff', '#a29bfe', '#55efc4',
+]
+
+export default {
+	name: 'ChartView',
+	components: { Bar, Line, Pie, ChartConfigBar },
+	props: {
+		rows: { type: Array, default: () => [] },
+		columns: { type: Array, default: () => [] },
+		element: { type: Object, default: null },
+		isView: { type: Boolean, default: false },
+	},
+	data() {
+		return {
+			chartConfig: this.loadConfig(),
+		}
+	},
+	computed: {
+		hasValidConfig() {
+			return this.chartConfig.xColumnId !== null
+		},
+		xColumn() {
+			return this.columns.find(c => c.id === this.chartConfig.xColumnId)
+		},
+		yColumn() {
+			return this.columns.find(c => c.id === this.chartConfig.yColumnId)
+		},
+		chartComponent() {
+			switch (this.chartConfig.chartType) {
+			case 'line': return 'Line'
+			case 'pie': return 'Pie'
+			default: return 'Bar'
+			}
+		},
+		aggregatedData() {
+			if (!this.xColumn) return { labels: [], values: [] }
+
+			const groups = {}
+			for (const row of this.rows) {
+				const xCell = row.data?.find(d => d.columnId === this.chartConfig.xColumnId)
+				const label = this.formatCellValue(xCell, this.xColumn) || t('tables', '(empty)')
+
+				if (!groups[label]) groups[label] = { sum: 0, count: 0 }
+				groups[label].count++
+
+				if (this.yColumn) {
+					const yCell = row.data?.find(d => d.columnId === this.chartConfig.yColumnId)
+					const val = parseFloat(yCell?.value) || 0
+					groups[label].sum += val
+				}
+			}
+
+			const labels = Object.keys(groups)
+			const values = labels.map(l => this.yColumn ? groups[l].sum : groups[l].count)
+			return { labels, values }
+		},
+		chartData() {
+			const { labels, values } = this.aggregatedData
+			const isPie = this.chartConfig.chartType === 'pie'
+
+			return {
+				labels,
+				datasets: [{
+					label: this.yColumn?.title || t('tables', 'Count'),
+					data: values,
+					backgroundColor: isPie
+						? labels.map((_, i) => CHART_COLORS[i % CHART_COLORS.length])
+						: CHART_COLORS[0],
+					borderColor: isPie
+						? labels.map((_, i) => CHART_COLORS[i % CHART_COLORS.length])
+						: CHART_COLORS[0],
+					borderWidth: isPie ? 2 : 1,
+				}],
+			}
+		},
+		chartOptions() {
+			const isPie = this.chartConfig.chartType === 'pie'
+			return {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: {
+					legend: { display: isPie, position: 'right' },
+					title: { display: false },
+				},
+				...(isPie ? {} : {
+					scales: {
+						y: { beginAtZero: true },
+					},
+				}),
+			}
+		},
+	},
+	methods: {
+		onConfigChange(config) {
+			this.chartConfig = config
+			this.saveConfig(config)
+		},
+		formatCellValue(cell, column) {
+			if (!cell || cell.value === null || cell.value === undefined) return ''
+			if (column.type === 'selection') {
+				const options = column.selectionOptions || []
+				const opt = options.find(o => String(o.id) === String(cell.value))
+				return opt?.label || String(cell.value)
+			}
+			return String(cell.value)
+		},
+		loadConfig() {
+			const key = `tables-chart-config-${this.isView ? 'view' : 'table'}-${this.element?.id}`
+			try {
+				const stored = localStorage.getItem(key)
+				if (stored) return JSON.parse(stored)
+			} catch (e) { /* ignore */ }
+			return { chartType: 'bar', xColumnId: null, yColumnId: null }
+		},
+		saveConfig(config) {
+			const key = `tables-chart-config-${this.isView ? 'view' : 'table'}-${this.element?.id}`
+			try {
+				localStorage.setItem(key, JSON.stringify(config))
+			} catch (e) { /* ignore */ }
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.chart-view {
+	padding: 0 8px;
+}
+
+.chart-container {
+	position: relative;
+	height: 400px;
+	max-width: 900px;
+}
+
+.chart-empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 300px;
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/modules/main/partials/ColumnFormComponent.vue
+++ b/src/modules/main/partials/ColumnFormComponent.vue
@@ -22,6 +22,7 @@ import DatetimeDateForm from '../../../shared/components/ncTable/partials/rowTyp
 import DatetimeTimeForm from '../../../shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue'
 import TextRichForm from '../../../shared/components/ncTable/partials/rowTypePartials/TextRichForm.vue'
 import UsergroupForm from '../../../shared/components/ncTable/partials/rowTypePartials/UsergroupForm.vue'
+import RelationForm from '../../../shared/components/ncTable/partials/rowTypePartials/RelationForm.vue'
 
 export default {
 	name: 'ColumnFormComponent',
@@ -40,6 +41,7 @@ export default {
 		DatetimeDateForm,
 		DatetimeTimeForm,
 		UsergroupForm,
+		RelationForm,
 	},
 	props: {
 		column: {

--- a/src/modules/main/partials/ColumnTypeSelection.vue
+++ b/src/modules/main/partials/ColumnTypeSelection.vue
@@ -19,6 +19,7 @@
 				<SelectionIcon v-if="props.id === 'selection'" />
 				<DatetimeIcon v-if="props.id === 'datetime'" />
 				<ContactsIcon v-if="props.id === 'usergroup'" />
+				<RelationIcon v-if="props.id === 'relation'" />
 				<div class="multiSelectOptionLabel">
 					{{ props.label }}
 				</div>
@@ -33,6 +34,7 @@
 			<SelectionIcon v-if="props.id === 'selection'" />
 			<DatetimeIcon v-if="props.id === 'datetime'" />
 			<ContactsIcon v-if="props.id === 'usergroup'" />
+			<RelationIcon v-if="props.id === 'relation'" />
 			<div class="multiSelectOptionLabel">
 				{{ props.label }}
 			</div>
@@ -50,6 +52,7 @@ import ProgressIcon from 'vue-material-design-icons/ArrowRightThin.vue'
 import SelectionIcon from 'vue-material-design-icons/FormSelect.vue'
 import DatetimeIcon from 'vue-material-design-icons/ClipboardTextClockOutline.vue'
 import ContactsIcon from 'vue-material-design-icons/ContactsOutline.vue'
+import RelationIcon from 'vue-material-design-icons/LinkVariant.vue'
 import { NcSelect } from '@nextcloud/vue'
 
 export default {
@@ -63,6 +66,7 @@ export default {
 		TextLongIcon,
 		NcSelect,
 		ContactsIcon,
+		RelationIcon,
 	},
 	props: {
 		columnId: {
@@ -86,6 +90,7 @@ export default {
 
 				{ id: 'datetime', label: t('tables', 'Date and time') },
 				{ id: 'usergroup', label: t('tables', 'Users and groups') },
+				{ id: 'relation', label: t('tables', 'Relation') },
 			],
 		}
 	},

--- a/src/modules/main/partials/ViewTabBar.vue
+++ b/src/modules/main/partials/ViewTabBar.vue
@@ -1,0 +1,106 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="view-tab-bar">
+		<button class="view-tab"
+			:class="{ active: isTableActive }"
+			@click="$emit('select-table')">
+			<span class="view-tab-icon">&#x1F4CB;</span>
+			<span class="view-tab-label">{{ t('tables', 'Table') }}</span>
+		</button>
+		<button v-for="view in views"
+			:key="view.id"
+			class="view-tab"
+			:class="{ active: activeViewId === view.id }"
+			@click="$emit('select-view', view)">
+			<span class="view-tab-icon">{{ view.emoji || '&#x1F441;' }}</span>
+			<span class="view-tab-label">{{ view.title }}</span>
+			<span v-if="view.type === 'chart'" class="view-tab-badge">{{ t('tables', 'Chart') }}</span>
+		</button>
+		<button v-if="canCreate"
+			class="view-tab view-tab--add"
+			:title="t('tables', 'Add view')"
+			@click="$emit('create-view')">
+			<Plus :size="16" />
+		</button>
+	</div>
+</template>
+
+<script>
+import Plus from 'vue-material-design-icons/Plus.vue'
+
+export default {
+	name: 'ViewTabBar',
+	components: { Plus },
+	props: {
+		views: { type: Array, default: () => [] },
+		activeViewId: { type: Number, default: null },
+		isTableActive: { type: Boolean, default: false },
+		canCreate: { type: Boolean, default: false },
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.view-tab-bar {
+	display: flex;
+	align-items: stretch;
+	gap: 0;
+	border-bottom: 2px solid var(--color-border);
+	margin-bottom: 0;
+	overflow-x: auto;
+	scrollbar-width: thin;
+}
+
+.view-tab {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 16px;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font-size: 14px;
+	color: var(--color-text-maxcontrast);
+	border-bottom: 2px solid transparent;
+	margin-bottom: -2px;
+	white-space: nowrap;
+	transition: color 0.15s, border-color 0.15s;
+
+	&:hover {
+		color: var(--color-main-text);
+		background: var(--color-background-hover);
+	}
+
+	&.active {
+		color: var(--color-main-text);
+		border-bottom-color: var(--color-primary-element);
+		font-weight: 600;
+	}
+}
+
+.view-tab-icon {
+	font-size: 16px;
+}
+
+.view-tab-badge {
+	font-size: 10px;
+	padding: 1px 5px;
+	border-radius: 8px;
+	background: var(--color-primary-element-light);
+	color: var(--color-primary-element);
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.view-tab--add {
+	padding: 8px 12px;
+	color: var(--color-text-maxcontrast);
+
+	&:hover {
+		color: var(--color-primary-element);
+	}
+}
+</style>

--- a/src/modules/main/sections/Table.vue
+++ b/src/modules/main/sections/Table.vue
@@ -6,12 +6,12 @@
 	<div>
 		<ElementTitle :active-element="table" :view-setting.sync="localViewSetting" />
 		<TableDescription :description="table.description" :read-only="true" />
-		<Dashboard v-if="hasViews"
-			:table="table"
-			@create-column="$emit('create-column')"
-			@import="$emit('import')"
-			@toggle-share="$emit('toggle-share')"
-			@show-integration="$emit('show-integration')"
+		<ViewTabBar
+			:views="tableViews"
+			:active-view-id="null"
+			:is-table-active="true"
+			:can-create="canManageElement(table)"
+			@select-view="openView"
 			@create-view="createView" />
 		<DataTable :table="table" :columns="columns" :rows="rows" :view-setting.sync="localViewSetting"
 			@create-column="$emit('create-column')"
@@ -26,37 +26,28 @@
 <script>
 import TableDescription from './TableDescription.vue'
 import ElementTitle from './ElementTitle.vue'
-import Dashboard from './Dashboard.vue'
+import ViewTabBar from '../partials/ViewTabBar.vue'
 import DataTable from './DataTable.vue'
 import { mapState } from 'pinia'
 import { emit } from '@nextcloud/event-bus'
 import { useTablesStore } from '../../../store/store.js'
+import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 
 export default {
 	components: {
 		TableDescription,
 		ElementTitle,
-		Dashboard,
+		ViewTabBar,
 		DataTable,
 	},
 
+	mixins: [permissionsMixin],
+
 	props: {
-		table: {
-			type: Object,
-			default: null,
-		},
-		columns: {
-			type: Array,
-			default: null,
-		},
-		rows: {
-			type: Array,
-			default: null,
-		},
-		viewSetting: {
-			type: Object,
-			default: null,
-		},
+		table: { type: Object, default: null },
+		columns: { type: Array, default: null },
+		rows: { type: Array, default: null },
+		viewSetting: { type: Object, default: null },
 	},
 
 	data() {
@@ -66,8 +57,8 @@ export default {
 	},
 	computed: {
 		...mapState(useTablesStore, ['views']),
-		hasViews() {
-			return this.views.some(v => v.tableId === this.table.id)
+		tableViews() {
+			return this.views.filter(v => v.tableId === this.table.id)
 		},
 	},
 	watch: {
@@ -80,8 +71,11 @@ export default {
 	},
 
 	methods: {
+		openView(view) {
+			this.$router.push('/view/' + parseInt(view.id)).catch(err => err)
+		},
 		createView() {
-			emit('tables:view:create', { tableId: this.table.id, viewSetting: this.viewSetting.length > 0 ? this.viewSetting : this.localViewSetting })
+			emit('tables:view:create', { tableId: this.table.id, viewSetting: this.viewSetting?.length > 0 ? this.viewSetting : this.localViewSetting })
 		},
 	},
 }

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -6,8 +6,21 @@
 	<div>
 		<ElementTitle :active-element="view" :is-table="false" :view-setting.sync="localViewSetting" />
 		<TableDescription :description="view.description" :read-only="true" />
+		<ViewTabBar
+			:views="siblingViews"
+			:active-view-id="view.id"
+			:is-table-active="false"
+			:can-create="canManageElement(view)"
+			@select-table="openTable"
+			@select-view="openView"
+			@create-view="createView" />
 		<div class="table-wrapper">
 			<EmptyView v-if="columns.length === 0" :view="view" />
+			<ChartView v-else-if="view.type === 'chart'"
+				:rows="rows"
+				:columns="columns"
+				:element="view"
+				:is-view="true" />
 			<TableView v-else
 				:rows="rows"
 				:columns="columns"
@@ -25,7 +38,7 @@
 				<template #actions>
 					<NcActions :force-menu="true" :type="isViewSettingSet ? 'secondary' : 'tertiary'">
 						<NcActionCaption v-if="canManageElement(view)" :name="t('tables', 'Manage view')" />
-						<NcActionButton v-if="canManageElement(view) "
+						<NcActionButton v-if="canManageElement(view)"
 							:close-after-click="true"
 							@click="editView">
 							<template #icon>
@@ -77,7 +90,8 @@
 
 <script>
 import TableView from '../partials/TableView.vue'
-
+import ChartView from '../partials/ChartView.vue'
+import ViewTabBar from '../partials/ViewTabBar.vue'
 import EmptyView from './EmptyView.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import { emit } from '@nextcloud/event-bus'
@@ -88,12 +102,16 @@ import IconImport from 'vue-material-design-icons/Import.vue'
 import Connection from 'vue-material-design-icons/Connection.vue'
 import ElementTitle from './ElementTitle.vue'
 import TableDescription from './TableDescription.vue'
+import { mapState } from 'pinia'
+import { useTablesStore } from '../../../store/store.js'
 
 export default {
 	components: {
 		TableDescription,
 		EmptyView,
 		TableView,
+		ChartView,
+		ViewTabBar,
 		PlaylistEdit,
 		IconImport,
 		NcActions,
@@ -107,23 +125,10 @@ export default {
 	mixins: [permissionsMixin],
 
 	props: {
-		view: {
-			type: Object,
-			default: null,
-		},
-		columns: {
-			type: Array,
-			default: null,
-		},
-		rows: {
-			type: Array,
-			default: null,
-		},
-		viewSetting: {
-			type: Object,
-			default: null,
-		},
-
+		view: { type: Object, default: null },
+		columns: { type: Array, default: null },
+		rows: { type: Array, default: null },
+		viewSetting: { type: Object, default: null },
 	},
 
 	data() {
@@ -134,8 +139,12 @@ export default {
 		}
 	},
 	computed: {
+		...mapState(useTablesStore, ['views']),
 		isViewSettingSet() {
 			return !(!this.localViewSetting || ((!this.localViewSetting.hiddenColumns || this.localViewSetting.hiddenColumns.length === 0) && (!this.localViewSetting.sorting) && (!this.localViewSetting.filter || this.localViewSetting.filter.length === 0)))
+		},
+		siblingViews() {
+			return this.views.filter(v => v.tableId === this.view.tableId)
 		},
 	},
 	watch: {
@@ -149,6 +158,15 @@ export default {
 	methods: {
 		editView() {
 			emit('tables:view:edit', { view: this.view, viewSetting: this.localViewSetting })
+		},
+		openTable() {
+			this.$router.push('/table/' + parseInt(this.view.tableId)).catch(err => err)
+		},
+		openView(view) {
+			this.$router.push('/view/' + parseInt(view.id)).catch(err => err)
+		},
+		createView() {
+			emit('tables:view:create', { tableId: this.view.tableId, viewSetting: this.localViewSetting })
 		},
 	},
 }

--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -113,6 +113,7 @@ import ColumnTypeSelection from '../main/partials/ColumnTypeSelection.vue'
 import TextRichForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/TextRichForm.vue'
 import { ColumnTypes } from '../../shared/components/ncTable/mixins/columnHandler.js'
 import UsergroupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/UsergroupForm.vue'
+import RelationForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue'
 import { useTablesStore } from '../../store/store.js'
 import { useDataStore } from '../../store/data.js'
 import { mapActions } from 'pinia'
@@ -139,6 +140,7 @@ export default {
 		SelectionForm,
 		SelectionMultiForm,
 		UsergroupForm,
+		RelationForm,
 	},
 	props: {
 		showModal: {
@@ -190,6 +192,11 @@ export default {
 				usergroupSelectGroups: false,
 				usergroupSelectTeams: false,
 				showUserStatus: false,
+				relationTableId: null,
+				relationMultiple: false,
+				relationType: 'many-to-many',
+				relationDisplayColumnId: null,
+				relationTargetColumnId: null,
 				customSettings: {},
 			},
 			textAppAvailable: !!window.OCA?.Text?.createEditor,
@@ -209,6 +216,7 @@ export default {
 
 				{ id: 'datetime', label: t('tables', 'Date and time') },
 				{ id: 'usergroup', label: t('tables', 'Users and groups') },
+				{ id: 'relation', label: t('tables', 'Relation') },
 			],
 		}
 	},
@@ -357,6 +365,12 @@ export default {
 				data.usergroupSelectGroups = this.column.usergroupSelectGroups
 				data.usergroupSelectTeams = this.column.usergroupSelectTeams
 				data.showUserStatus = this.column.showUserStatus
+			} else if (this.column.type === 'relation') {
+				data.relationTableId = this.column.relationTableId
+				data.relationMultiple = this.column.relationMultiple
+				data.relationType = this.column.relationType
+				data.relationDisplayColumnId = this.column.relationDisplayColumnId
+				data.relationTargetColumnId = this.column.relationTargetColumnId
 			} else if (this.column.type === 'number') {
 				data.numberDefault = this.column.numberDefault
 				if (this.column.subtype === '') {
@@ -420,6 +434,11 @@ export default {
 				usergroupSelectGroups: false,
 				usergroupSelectTeams: false,
 				showUserStatus: false,
+				relationTableId: null,
+				relationMultiple: false,
+				relationType: 'many-to-many',
+				relationDisplayColumnId: null,
+				relationTargetColumnId: null,
 				customSettings: {},
 			}
 			if (mainForm) {

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -66,6 +66,7 @@ import DatetimeForm from '../../shared/components/ncTable/partials/columnTypePar
 import DatetimeDateForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/DatetimeDateForm.vue'
 import DatetimeTimeForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/DatetimeTimeForm.vue'
 import UsergroupForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/UsergroupForm.vue'
+import RelationForm from '../../shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue'
 import { ColumnTypes } from '../../shared/components/ncTable/mixins/columnHandler.js'
 import moment from '@nextcloud/moment'
 import { mapActions } from 'pinia'
@@ -96,6 +97,7 @@ export default {
 		NcButton,
 		NcUserBubble,
 		UsergroupForm,
+		RelationForm,
 	},
 	filters: {
 		truncate(text, length, suffix) {

--- a/src/modules/modals/ViewSettings.vue
+++ b/src/modules/modals/ViewSettings.vue
@@ -26,6 +26,21 @@
 						:placeholder="createView ? t('tables', 'Title of the new view') : t('tables', 'New title of the view')">
 				</div>
 			</div>
+			<div class="row">
+				<div class="col-4 space-T view-type-row">
+					<span class="view-type-label">{{ t('tables', 'View type') }}</span>
+					<div class="view-type-buttons">
+						<NcButton :type="viewType.id === 'table' ? 'primary' : 'secondary'"
+							@click="viewType = viewTypeOptions[0]">
+							{{ t('tables', 'Table') }}
+						</NcButton>
+						<NcButton :type="viewType.id === 'chart' ? 'primary' : 'secondary'"
+							@click="viewType = viewTypeOptions[1]">
+							{{ t('tables', 'Chart') }}
+						</NcButton>
+					</div>
+				</div>
+			</div>
 
 			<div class="row">
 				<div class="col-4 space-T mandatory">
@@ -140,6 +155,11 @@ export default {
 			startDragIndex: null,
 			mutableView: null,
 			generatedView: null,
+			viewType: { id: 'table', label: 'Table' },
+			viewTypeOptions: [
+				{ id: 'table', label: 'Table' },
+				{ id: 'chart', label: 'Chart' },
+			],
 		}
 	},
 	computed: {
@@ -294,6 +314,7 @@ export default {
 				title: this.title,
 				description: this.description,
 				emoji: this.icon,
+				type: this.viewType.id,
 			}
 			const res = await this.insertNewView({ data })
 			if (res) {
@@ -316,6 +337,7 @@ export default {
 					title: this.title,
 					description: this.description,
 					emoji: this.icon,
+					type: this.viewType.id,
 					columnSettings: JSON.stringify(newColumnSettings),
 				},
 			}
@@ -344,6 +366,7 @@ export default {
 			this.title = this.mutableView.title ?? ''
 			this.description = this.mutableView.description ?? ''
 			this.icon = this.mutableView.emoji ?? this.loadEmoji()
+			this.viewType = this.viewTypeOptions.find(o => o.id === (this.mutableView.type || 'table')) || this.viewTypeOptions[0]
 			this.errorTitle = false
 			this.selectedColumns = this.mutableView.columnSettings ? this.mutableView.columnSettings.map(item => item.columnId) : null
 			this.allColumns = []
@@ -379,5 +402,21 @@ export default {
 .sticky {
 	position: sticky;
 	bottom: 0;
+}
+
+.view-type-row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.view-type-label {
+	font-weight: 600;
+	white-space: nowrap;
+}
+
+.view-type-buttons {
+	display: flex;
+	gap: 8px;
 }
 </style>

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -4,8 +4,8 @@
 -->
 <template>
 	<NcAppNavigationItem v-if="table" data-cy="navigationTableItem" :name="table.title"
-		:class="{ active: activeTable && table.id === activeTable.id }" :allow-collapse="hasViews" :force-menu="true"
-		:open.sync="isParentOfActiveView" :to="'/table/' + parseInt(table.id)" @click="openTable">
+		:active="isActive" :allow-collapse="hasViews" :force-menu="true"
+		:open.sync="isOpen" :to="'/table/' + parseInt(table.id)" @click="openTable">
 		<template #icon>
 			<template v-if="table.emoji">
 				{{ table.emoji }}
@@ -206,7 +206,7 @@ export default {
 
 	data() {
 		return {
-			isParentOfActiveView: false,
+			isOpen: false,
 		}
 	},
 
@@ -224,18 +224,13 @@ export default {
 		hasViews() {
 			return this.getViews.length > 0
 		},
+		isActive() {
+			if (this.activeTable && this.table.id === this.activeTable.id) return true
+			if (!this.isOpen && this.activeView && this.activeView.tableId === this.table.id) return true
+			return false
+		},
 	},
 	watch: {
-		activeView() {
-			if (!this.isParentOfActiveView && this.activeView?.tableId === this.table?.id) {
-				this.isParentOfActiveView = true
-			}
-		},
-		filterString() {
-			if (!this.isParentOfActiveView && this.filterString && !this.table.title.toLowerCase().includes(this.filterString.toLowerCase())) {
-				this.isParentOfActiveView = true
-			}
-		},
 	},
 	methods: {
 		...mapActions(useTablesStore, ['favoriteTable', 'removeFavoriteTable', 'updateTable']),
@@ -279,7 +274,6 @@ export default {
 			await this.$router.push('/table/' + parseInt(this.table.id)).catch(err => err)
 		},
 		openTable() {
-			this.isParentOfActiveView = true
 			// Close navigation
 			if (window.innerWidth < 960) {
 				emit('toggle-navigation', {
@@ -316,6 +310,7 @@ export default {
 	.icon-collapse {
 		color: var(--color-primary-element-text)
 	}
+
 }
 
 :deep(.app-navigation-entry__counter-wrapper) {

--- a/src/shared/components/ncTable/mixins/columnHandler.js
+++ b/src/shared/components/ncTable/mixins/columnHandler.js
@@ -17,6 +17,7 @@ export const ColumnTypes = {
 	DatetimeTime: 'datetime-time',
 	Datetime: 'datetime',
 	Usergroup: 'usergroup',
+	Relation: 'relation',
 }
 
 export function getColumnWidthStyle(column) {

--- a/src/shared/components/ncTable/mixins/columnParser.js
+++ b/src/shared/components/ncTable/mixins/columnParser.js
@@ -17,6 +17,7 @@ import TextLinkColumn from './columnsTypes/textLink.js'
 import TextLongColumn from './columnsTypes/textLong.js'
 import TextRichColumn from './columnsTypes/textRich.js'
 import UsergroupColumn from './columnsTypes/usergroup.js'
+import RelationColumn from './columnsTypes/relation.js'
 
 export function parseCol(col) {
 	const columnType = col.type + (col.subtype === '' ? '' : '-' + col.subtype)
@@ -35,6 +36,7 @@ export function parseCol(col) {
 	case ColumnTypes.DatetimeDate: return new DatetimeDateColumn(col)
 	case ColumnTypes.DatetimeTime: return new DatetimeTimeColumn(col)
 	case ColumnTypes.Usergroup: return new UsergroupColumn(col)
+	case ColumnTypes.Relation: return new RelationColumn(col)
 	default: throw Error(columnType + ' is not a valid column type!')
 	}
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/relation.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/relation.js
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { AbstractColumn } from '../columnClass.js'
+import { ColumnTypes } from '../columnHandler.js'
+import { FilterIds } from '../filter.js'
+
+export default class RelationColumn extends AbstractColumn {
+
+	constructor(data) {
+		super(data)
+		this.type = ColumnTypes.Relation
+		this.relationTableId = data.relationTableId
+		this.relationMultiple = data.relationMultiple
+	}
+
+	getValueString(valueObject) {
+		valueObject = valueObject || this.value || null
+		const value = valueObject.value
+		if (!value) return ''
+		try {
+			const parsed = JSON.parse(value)
+			if (Array.isArray(parsed)) {
+				return parsed.map(id => `Row ${id}`).join(', ')
+			}
+			return `Row ${parsed}`
+		} catch {
+			return String(value)
+		}
+	}
+
+	isSearchStringFound(cell, searchString) {
+		return super.isSearchStringFound(this.getValueString(cell), cell, searchString)
+	}
+
+	isFilterFound(cell, filter) {
+		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const cellValue = this.getValueString(cell)
+		const filterMethod = {
+			[FilterIds.Contains]() { return cellValue?.toLowerCase().includes(filterValue?.toLowerCase()) },
+			[FilterIds.DoesNotContain]() { return !cellValue?.toLowerCase().includes(filterValue?.toLowerCase()) },
+			[FilterIds.IsEmpty]() { return !cellValue },
+		}[filter.operator.id]
+		return super.isFilterFound(filterMethod, cell)
+	}
+
+	parseValue(value) {
+		return value
+	}
+
+}

--- a/src/shared/components/ncTable/mixins/columnsTypes/relation.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/relation.js
@@ -45,6 +45,10 @@ export default class RelationColumn extends AbstractColumn {
 		return super.isFilterFound(filterMethod, cell)
 	}
 
+	default() {
+		return null
+	}
+
 	parseValue(value) {
 		return value
 	}

--- a/src/shared/components/ncTable/mixins/filter.js
+++ b/src/shared/components/ncTable/mixins/filter.js
@@ -55,13 +55,13 @@ export const Filters = {
 	Contains: new Filter({
 		id: FilterIds.Contains,
 		label: t('tables', 'Contains'),
-		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup, ColumnTypes.Selection],
+		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup, ColumnTypes.Selection, ColumnTypes.Relation],
 		incompatibleWith: [FilterIds.DoesNotContain, FilterIds.IsEmpty, FilterIds.IsEqual],
 	}),
 	DoesNotContain: new Filter({
 		id: FilterIds.DoesNotContain,
 		label: t('tables', 'Does not contain'),
-		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup, ColumnTypes.Selection],
+		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextLong, ColumnTypes.TextLink, ColumnTypes.TextRich, ColumnTypes.SelectionMulti, ColumnTypes.Usergroup, ColumnTypes.Selection, ColumnTypes.Relation],
 		incompatibleWith: [FilterIds.Contains, FilterIds.IsEmpty, FilterIds.IsEqual],
 	}),
 	BeginsWith: new Filter({
@@ -121,7 +121,7 @@ export const Filters = {
 	IsEmpty: new Filter({
 		id: FilterIds.IsEmpty,
 		label: t('tables', 'Is empty'),
-		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextRich, ColumnTypes.Number, ColumnTypes.TextLink, ColumnTypes.NumberProgress, ColumnTypes.DatetimeDate, ColumnTypes.DatetimeTime, ColumnTypes.Datetime, ColumnTypes.SelectionCheck, ColumnTypes.Usergroup],
+		goodFor: [ColumnTypes.TextLine, ColumnTypes.TextRich, ColumnTypes.Number, ColumnTypes.TextLink, ColumnTypes.NumberProgress, ColumnTypes.DatetimeDate, ColumnTypes.DatetimeTime, ColumnTypes.Datetime, ColumnTypes.SelectionCheck, ColumnTypes.Usergroup, ColumnTypes.Relation],
 		incompatibleWith: [FilterIds.Contains, FilterIds.BeginsWith, FilterIds.EndsWith, FilterIds.IsEqual, FilterIds.IsGreaterThan, FilterIds.IsGreaterThanOrEqual, FilterIds.IsLowerThan, FilterIds.IsLowerThanOrEqual, FilterIds.IsEmpty],
 		noSearchValue: true,
 	}),

--- a/src/shared/components/ncTable/partials/TableCellRelation.vue
+++ b/src/shared/components/ncTable/partials/TableCellRelation.vue
@@ -1,0 +1,145 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="relation-cell" @click.stop>
+		<div v-if="linkedRows.length > 0" class="relation-chips">
+			<span v-for="row in linkedRows"
+				:key="row.id"
+				class="relation-chip"
+				@click="navigateToRow(row)">
+				{{ getDisplayValue(row) }}
+			</span>
+		</div>
+		<span v-else class="relation-empty">—</span>
+	</div>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'TableCellRelation',
+	props: {
+		column: { type: Object, default: null },
+		rowId: { type: Number, default: null },
+		value: { type: [String, Number, Array], default: null },
+		canEdit: { type: Boolean, default: false },
+	},
+	data() {
+		return {
+			linkedRows: [],
+			targetRows: [],
+		}
+	},
+	computed: {
+		parsedValue() {
+			if (!this.value) return []
+			if (Array.isArray(this.value)) return this.value
+			try {
+				let parsed = JSON.parse(this.value)
+				if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+				if (Array.isArray(parsed)) return parsed.map(Number)
+				if (typeof parsed === 'number') return [parsed]
+				return []
+			} catch {
+				return []
+			}
+		},
+		displayColumnId() {
+			return this.column?.relationDisplayColumnId || null
+		},
+	},
+	watch: {
+		value: {
+			immediate: true,
+			handler() {
+				this.loadLinkedRows()
+			},
+		},
+	},
+	async mounted() {
+		await this.fetchTargetRows()
+		this.loadLinkedRows()
+	},
+	methods: {
+		async fetchTargetRows() {
+			if (!this.column?.relationTableId) return
+			try {
+				const res = await axios.get(generateUrl('/apps/tables/row/table/' + this.column.relationTableId))
+				this.targetRows = res.data || []
+			} catch {
+				// Table might not be accessible
+			}
+		},
+		loadLinkedRows() {
+			const ids = this.parsedValue
+			this.linkedRows = this.targetRows.filter(r => ids.includes(r.id))
+		},
+		getDisplayValue(row) {
+			if (!row?.data || row.data.length === 0) return `Row ${row.id}`
+			let cell = null
+			if (this.displayColumnId) {
+				cell = row.data.find(d => d.columnId === this.displayColumnId)
+			}
+			if (!cell) cell = row.data[0]
+			if (!cell?.value) return `Row ${row.id}`
+			try {
+				const parsed = JSON.parse(cell.value)
+				if (typeof parsed === 'string') return parsed
+				return String(parsed)
+			} catch {
+				return String(cell.value)
+			}
+		},
+		navigateToRow(row) {
+			if (this.column?.relationTableId) {
+				this.$router.push('/table/' + this.column.relationTableId).catch(() => {})
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.relation-cell {
+	display: flex;
+	align-items: center;
+	min-height: 32px;
+	padding: 2px 0;
+}
+
+.relation-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+
+.relation-chip {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 10px;
+	border-radius: 12px;
+	background: var(--color-primary-element-light);
+	color: var(--color-primary-element);
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 0.15s;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&:hover {
+		background: var(--color-primary-element);
+		color: var(--color-primary-element-text);
+	}
+}
+
+.relation-empty {
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -48,6 +48,7 @@ import TableCellSelection from './TableCellSelection.vue'
 import TableCellMultiSelection from './TableCellMultiSelection.vue'
 import TableCellTextRich from './TableCellEditor.vue'
 import TableCellUsergroup from './TableCellUsergroup.vue'
+import TableCellRelation from './TableCellRelation.vue'
 import { ColumnTypes, getColumnWidthStyle } from './../mixins/columnHandler.js'
 import { translate as t } from '@nextcloud/l10n'
 import {
@@ -73,6 +74,7 @@ export default {
 		TableCellMultiSelection,
 		TableCellTextRich,
 		TableCellUsergroup,
+		TableCellRelation,
 	},
 
 	mixins: [activityMixin],
@@ -118,6 +120,7 @@ export default {
 		// to be used to trigger the edit modal instead of inline editing
 		nonInlineEditableColumnTypes() {
 			return [
+				ColumnTypes.Relation,
 			]
 		},
 	},
@@ -145,6 +148,7 @@ export default {
 			case ColumnTypes.DatetimeDate: return 'TableCellDateTime'
 			case ColumnTypes.DatetimeTime: return 'TableCellDateTime'
 			case ColumnTypes.Usergroup: return 'TableCellUsergroup'
+			case ColumnTypes.Relation: return 'TableCellRelation'
 			default: return 'TableCellHtml'
 			}
 		},

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
@@ -1,0 +1,140 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div>
+		<div class="row">
+			<div class="col-4 mandatory space-T">
+				{{ t('tables', 'Linked table') }}
+			</div>
+			<div class="col-4">
+				<NcSelect v-model="selectedTable"
+					:options="tableOptions"
+					:clearable="false"
+					label="title"
+					track-by="id"
+					:placeholder="t('tables', 'Select a table to link')"
+					@input="onTableChange" />
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-4 space-T">
+				{{ t('tables', 'Relation type') }}
+			</div>
+			<div class="col-4">
+				<NcSelect v-model="selectedRelationType"
+					:options="relationTypeOptions"
+					:clearable="false"
+					label="label"
+					track-by="id"
+					@input="onRelationTypeChange" />
+			</div>
+		</div>
+		<div v-if="targetColumns.length > 0" class="row">
+			<div class="col-4 space-T">
+				{{ t('tables', 'Display column') }}
+			</div>
+			<div class="col-4">
+				<NcSelect v-model="selectedDisplayColumn"
+					:options="targetColumns"
+					:clearable="false"
+					label="title"
+					track-by="id"
+					:placeholder="t('tables', 'Column to display from linked table')"
+					@input="onDisplayColumnChange" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+import { translate as t } from '@nextcloud/l10n'
+import { mapState } from 'pinia'
+import { useTablesStore } from '../../../../../../store/store.js'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'RelationForm',
+	components: { NcSelect },
+	props: {
+		column: {
+			type: Object,
+			default: null,
+		},
+	},
+	data() {
+		return {
+			selectedTable: null,
+			selectedRelationType: null,
+			selectedDisplayColumn: null,
+			targetColumns: [],
+			relationTypeOptions: [
+				{ id: 'one-to-one', label: t('tables', 'One to One') },
+				{ id: 'one-to-many', label: t('tables', 'One to Many') },
+				{ id: 'many-to-many', label: t('tables', 'Many to Many') },
+			],
+		}
+	},
+	computed: {
+		...mapState(useTablesStore, ['tables']),
+		tableOptions() {
+			return this.tables.filter(t => t.id !== this.column?.tableId)
+		},
+	},
+	watch: {
+		column: {
+			immediate: true,
+			async handler(col) {
+				if (col?.relationTableId) {
+					this.selectedTable = this.tables.find(t => t.id === col.relationTableId) || null
+					await this.loadTargetColumns()
+				}
+				this.selectedRelationType = this.relationTypeOptions.find(o => o.id === (col?.relationType || 'many-to-many'))
+				if (col?.relationDisplayColumnId && this.targetColumns.length > 0) {
+					this.selectedDisplayColumn = this.targetColumns.find(c => c.id === col.relationDisplayColumnId) || this.targetColumns[0]
+				}
+			},
+		},
+	},
+	methods: {
+		t,
+		async onTableChange(table) {
+			this.column.relationTableId = table?.id || null
+			this.targetColumns = []
+			this.selectedDisplayColumn = null
+			if (table) {
+				await this.loadTargetColumns()
+				if (this.targetColumns.length > 0) {
+					this.selectedDisplayColumn = this.targetColumns[0]
+					this.column.relationDisplayColumnId = this.targetColumns[0].id
+				}
+			}
+		},
+		onRelationTypeChange(type) {
+			this.column.relationType = type?.id || 'many-to-many'
+			this.column.relationMultiple = type?.id !== 'one-to-one'
+		},
+		onDisplayColumnChange(col) {
+			this.column.relationDisplayColumnId = col?.id || null
+		},
+		async loadTargetColumns() {
+			if (!this.column?.relationTableId) return
+			try {
+				const res = await axios.get(generateUrl('/apps/tables/api/1/tables/' + this.column.relationTableId + '/columns'))
+				this.targetColumns = (res.data || []).filter(c => c.id >= 0)
+				if (this.column.relationDisplayColumnId) {
+					this.selectedDisplayColumn = this.targetColumns.find(c => c.id === this.column.relationDisplayColumnId) || this.targetColumns[0]
+				} else if (this.targetColumns.length > 0) {
+					this.selectedDisplayColumn = this.targetColumns[0]
+					this.column.relationDisplayColumnId = this.targetColumns[0].id
+				}
+			} catch (e) {
+				console.error('Failed to load target columns', e)
+			}
+		},
+	},
+}
+</script>

--- a/src/shared/components/ncTable/partials/rowTypePartials/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/RelationForm.vue
@@ -1,0 +1,224 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<RowFormWrapper :title="column.title" :mandatory="isMandatory(column)" :description="column.description">
+		<div class="relation-form">
+			<div v-if="linkedRows.length > 0" class="relation-chips">
+				<span v-for="row in linkedRows" :key="row.id" class="relation-chip">
+					{{ getDisplayValue(row) }}
+					<button class="relation-chip-remove" @click="removeLink(row.id)">
+						&times;
+					</button>
+				</span>
+			</div>
+			<NcSelect
+				v-if="canAddMore"
+				:value="null"
+				:options="searchResults"
+				:loading="loading"
+				label="label"
+				track-by="id"
+				:placeholder="t('tables', 'Search rows to link...')"
+				:multiple="false"
+				@search="onSearch"
+				@input="addLink" />
+			<div v-if="relationType" class="relation-type-badge">
+				{{ relationType }}
+			</div>
+		</div>
+	</RowFormWrapper>
+</template>
+
+<script>
+import { NcSelect } from '@nextcloud/vue'
+import { translate as t } from '@nextcloud/l10n'
+import RowFormWrapper from './RowFormWrapper.vue'
+import rowHelper from '../../../../components/ncTable/mixins/rowHelper.js'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'RelationForm',
+	components: { NcSelect, RowFormWrapper },
+	mixins: [rowHelper],
+	props: {
+		column: {
+			type: Object,
+			default: null,
+		},
+		value: {
+			type: [String, Array, Number],
+			default: null,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+			linkedRows: [],
+			allTargetRows: [],
+			searchResults: [],
+			linkedRowIds: [],
+		}
+	},
+	computed: {
+		canAddMore() {
+			const type = this.column?.relationType || 'many-to-many'
+			if (type === 'one-to-one' && this.linkedRows.length >= 1) return false
+			return true
+		},
+		relationType() {
+			const type = this.column?.relationType
+			if (!type) return ''
+			return type.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+		},
+		displayColumnId() {
+			return this.column?.relationDisplayColumnId || null
+		},
+	},
+	async mounted() {
+		await this.fetchTargetRows()
+		await this.loadLinkedRows()
+	},
+	methods: {
+		t,
+		async fetchTargetRows() {
+			if (!this.column?.relationTableId) return
+			this.loading = true
+			try {
+				const res = await axios.get(generateUrl('/apps/tables/row/table/' + this.column.relationTableId))
+				this.allTargetRows = res.data || []
+			} catch (e) {
+				console.error('Failed to fetch target rows', e)
+			}
+			this.loading = false
+		},
+		async loadLinkedRows() {
+			// Parse linked IDs from value (which may come as JSON array from the relation API)
+			this.linkedRowIds = this.parseValue()
+			this.linkedRows = this.allTargetRows.filter(r => this.linkedRowIds.includes(r.id))
+			this.updateSearchResults('')
+		},
+		parseValue() {
+			if (!this.value) return []
+			if (Array.isArray(this.value)) return this.value
+			try {
+				const parsed = JSON.parse(this.value)
+				if (Array.isArray(parsed)) return parsed.map(Number)
+				if (typeof parsed === 'number') return [parsed]
+				// Try double-parsed JSON
+				if (typeof parsed === 'string') {
+					const inner = JSON.parse(parsed)
+					if (Array.isArray(inner)) return inner.map(Number)
+				}
+				return []
+			} catch {
+				return []
+			}
+		},
+		getDisplayValue(row) {
+			if (!row?.data || row.data.length === 0) return `Row ${row.id}`
+			// Find the display column value
+			let cell = null
+			if (this.displayColumnId) {
+				cell = row.data.find(d => d.columnId === this.displayColumnId)
+			}
+			if (!cell) {
+				cell = row.data[0]
+			}
+			if (!cell?.value) return `Row ${row.id}`
+			try {
+				const parsed = JSON.parse(cell.value)
+				if (typeof parsed === 'string') return parsed
+				return String(parsed)
+			} catch {
+				return String(cell.value)
+			}
+		},
+		async addLink(row) {
+			if (!row) return
+			const ids = [...this.linkedRowIds]
+			if (this.column?.relationType === 'one-to-one') {
+				ids.length = 0
+			}
+			if (!ids.includes(row.id)) {
+				ids.push(row.id)
+			}
+			this.linkedRowIds = ids
+			this.linkedRows = this.allTargetRows.filter(r => ids.includes(r.id))
+			this.updateSearchResults('')
+			this.$emit('update:value', JSON.stringify(ids))
+		},
+		removeLink(rowId) {
+			const ids = this.linkedRowIds.filter(id => id !== rowId)
+			this.linkedRowIds = ids
+			this.linkedRows = this.allTargetRows.filter(r => ids.includes(r.id))
+			this.updateSearchResults('')
+			this.$emit('update:value', JSON.stringify(ids))
+		},
+		onSearch(query) {
+			this.updateSearchResults(query)
+		},
+		updateSearchResults(query) {
+			this.searchResults = this.allTargetRows
+				.filter(r => !this.linkedRowIds.includes(r.id))
+				.filter(r => !query || this.getDisplayValue(r).toLowerCase().includes(query.toLowerCase()))
+				.map(r => ({ id: r.id, label: this.getDisplayValue(r) }))
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.relation-form {
+	width: 100%;
+}
+
+.relation-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-bottom: 8px;
+}
+
+.relation-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 10px;
+	border-radius: 12px;
+	background: var(--color-primary-element-light);
+	color: var(--color-primary-element);
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.relation-chip-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font-size: 14px;
+	color: var(--color-primary-element);
+	padding: 0;
+	line-height: 1;
+	border-radius: 50%;
+
+	&:hover {
+		background: var(--color-primary-element);
+		color: var(--color-primary-element-text);
+	}
+}
+
+.relation-type-badge {
+	margin-top: 4px;
+	font-size: 11px;
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+</style>


### PR DESCRIPTION
## Summary

- **Notion-style view tabs**: Horizontal tab bar above table content for switching between views, with "+" button to create new views
- **Chart view type**: Bar, line, and pie/donut charts with inline config bar (Chart.js)
- **Relation column type**: Link rows between tables with proper join table, relation types (1:1, 1:N, M:N), bidirectional reverse columns, clickable chip display

## Changes

### Backend
- DB migrations: view `type` column, relation columns, `tables_row_relations` join table
- `RelationService` for managing row links with cascade cleanup
- `RelationBusiness`, `RowRelation` entity/mapper, `RelationColumnQB`
- Bidirectional column auto-creation in `ColumnService`
- View type support in `ViewService`/`ViewController`

### Frontend
- `ViewTabBar.vue` — Notion-style tab strip
- `ChartView.vue` + `ChartConfigBar.vue` — chart rendering
- `TableCellRelation.vue` — chip-based relation cell display
- `RelationForm.vue` — column config (table picker, relation type, display column) and row editor (search + link)
- Updated navigation, modals, and table components

## Test plan

- [ ] Create a table, verify tab bar with "Table" tab and "+" button
- [ ] Create a chart view, verify bar/line/pie render with config bar
- [ ] Switch between view tabs
- [ ] Create a relation column linking two tables
- [ ] Verify reverse column auto-created on target table
- [ ] Add/remove row links via chip UI
- [ ] Test one-to-one constraint
- [ ] Delete linked row, verify cleanup