### PR TITLE
Enhancement: Extract method for getting filters for column

### DIFF
--- a/src/shared/components/ncTable/mixins/filter.js
+++ b/src/shared/components/ncTable/mixins/filter.js
@@ -126,3 +126,10 @@ export const Filters = {
 		noSearchValue: true,
 	}),
 }
+
+export function getFiltersForColumn(column, viewSetting) {
+	if (viewSetting?.filter?.length > 0) {
+		return viewSetting.filter.filter(filter => filter.columnId === column.id)
+	}
+	return []
+}

--- a/src/shared/components/ncTable/partials/TableHeader.vue
+++ b/src/shared/components/ncTable/partials/TableHeader.vue
@@ -25,7 +25,7 @@
 							@edit-column="col => $emit('edit-column', col)"
 							@delete-column="col => $emit('delete-column', col)" />
 					</div>
-					<div v-if="getFilterForColumn(col)" class="filter-wrapper">
+					<div v-if="getFilterForColumn(col).length > 0" class="filter-wrapper">
 						<FilterLabel v-for="filter in getFilterForColumn(col)"
 							:id="filter.columnId + filter.operator.id+ filter.value"
 							:key="filter.columnId + filter.operator.id+ filter.value"
@@ -47,7 +47,7 @@
 import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import TableHeaderColumnOptions from './TableHeaderColumnOptions.vue'
 import FilterLabel from './FilterLabel.vue'
-import { getFilterWithId } from '../mixins/filter.js'
+import { getFilterWithId, getFiltersForColumn } from '../mixins/filter.js'
 import { getColumnWidthStyle } from '../mixins/columnHandler.js'
 
 export default {
@@ -117,7 +117,7 @@ export default {
 			this.openedColumnHeaderMenus = Object.assign({}, this.openedColumnHeaderMenus)
 		},
 		getFilterForColumn(column) {
-			return this.localViewSetting?.filter?.filter(item => item.columnId === column.id)
+			return getFiltersForColumn(column, this.localViewSetting)
 		},
 		hasRightHiddenNeighbor(colId) {
 			return this.localViewSetting?.hiddenColumns?.includes(this.columns[this.columns.indexOf(this.columns.find(col => col.id === colId)) + 1]?.id)

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -98,6 +98,7 @@ import {
 import { MetaColumns } from '../mixins/metaColumns.js'
 import { translate as t } from '@nextcloud/l10n'
 import { useTablesStore } from '../../../../store/store.js'
+import { getFiltersForColumn } from '../mixins/filter.js'
 
 export default {
 	name: 'CustomTable',
@@ -221,7 +222,7 @@ export default {
 					}
 					let filterStatus = null
 					let searchStatus = true
-					const filters = this.getFiltersForColumn(column)
+					const filters = getFiltersForColumn(column, this.viewSetting)
 					let cell
 					if (column.id < 0) {
 						cell = { columnId: column.id }
@@ -257,15 +258,13 @@ export default {
 					delete cell.searchStringFound
 					delete cell.filterFound
 
-					// if we should filter
-					if (filters !== null) {
-						filters.forEach(fil => {
-							this.addMagicFieldsValues(fil)
-							if (filterStatus === null || filterStatus === true) {
-								filterStatus = column.isFilterFound(cell, fil)
-							}
-						})
-					}
+					// apply filters (if any)
+					filters.forEach(fil => {
+						this.addMagicFieldsValues(fil)
+						if (filterStatus === null || filterStatus === true) {
+							filterStatus = column.isFilterFound(cell, fil)
+						}
+					})
 					// if we should search
 					if (searchString) {
 						console.debug('look for searchString', searchString)
@@ -354,15 +353,6 @@ export default {
 					filter.magicValuesEnriched = newFilterValue
 				}
 			})
-		},
-		getFiltersForColumn(column) {
-			if (this.viewSetting?.filter?.length > 0) {
-				const columnFilter = this.viewSetting.filter.filter(item => item.columnId === column.id)
-				if (columnFilter.length > 0) {
-					return columnFilter
-				}
-			}
-			return null
 		},
 		deselectAllRows(elementId, isView) {
 			if (parseInt(elementId) === parseInt(this.elementId) && isView === this.isView) {


### PR DESCRIPTION
During work on https://github.com/nextcloud/tables/pull/2387 I've realized that we have some code duplication. Let's extract it into separate function. This logic going to be extended in the mentioned PR:

```js
export function getFiltersForColumn(column, viewSetting) {
	if (viewSetting?.filter?.length > 0) {
		return viewSetting.filter.filter(filter => {
			if (filter.columnId !== column.id) {
				return false
			}
			if (filter.operator.id === FilterIds.ContainsItem) {
				return filter.value.length > 0
			}

			return true
		})
	}
	return []
}
```