### PR TITLE
validate text column value limit only if the limit in the DB is a valid value

### DIFF
--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -877,7 +877,7 @@ class RowService extends SuperService {
 	 */
 	private function validateColumnValueLimits(Column $column, $value): void {
 		$textMaxLength = $column->getTextMaxLength();
-		if ($textMaxLength !== null && is_string($value) && mb_strlen($value) > $textMaxLength) {
+		if ($textMaxLength !== null && $textMaxLength >= 0 && is_string($value) && mb_strlen($value) > $textMaxLength) {
 			throw new BadRequestError('Value for column ' . $column->getTitle() . ' exceeds maximum length of ' . $textMaxLength);
 		}
 		$numberMin = $column->getNumberMin();


### PR DESCRIPTION
On some Nextcloud platforms, there are columns of the tables app in the DB with text_max_length equal to -1. These columns cannot be filled in with the current code.
Issue on our platform with these columns started after upgrading to Tables app 1.0.5.
The error thrown is "An bad request was encountered: Value for column What to do exceeds maximum length of -1".