### PR TITLE
#1840: API structure improvement: expose columns through a technical name/slug/alias

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -941,6 +941,7 @@ class Api1Controller extends ApiController {
 		?int $tableId,
 		?int $viewId,
 		string $title,
+		?string $technicalName,
 		string $type,
 		?string $subtype,
 		bool $mandatory,
@@ -979,6 +980,7 @@ class Api1Controller extends ApiController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::from($type)->value,
 					subtype: $subtype,
 					mandatory: $mandatory,
@@ -1071,6 +1073,7 @@ class Api1Controller extends ApiController {
 	public function updateColumn(
 		int $columnId,
 		?string $title,
+		?string $technicalName,
 		?string $subtype,
 		?bool $mandatory,
 		?string $description,
@@ -1106,6 +1109,7 @@ class Api1Controller extends ApiController {
 				$this->userId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					subtype: $subtype,
 					mandatory: $mandatory,
 					description: $description,
@@ -1719,6 +1723,7 @@ class Api1Controller extends ApiController {
 	public function createTableColumn(
 		int $tableId,
 		string $title,
+		?string $technicalName,
 		string $type,
 		?string $subtype,
 		bool $mandatory,
@@ -1757,6 +1762,7 @@ class Api1Controller extends ApiController {
 				null,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::from($type)->value,
 					subtype: $subtype,
 					mandatory: $mandatory,

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -901,6 +901,7 @@ class Api1Controller extends ApiController {
 	 * @param int|null $viewId View ID
 	 * @param string $title Title
 	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory
 	 * @param string|null $description Description
@@ -1036,6 +1037,7 @@ class Api1Controller extends ApiController {
 	 *
 	 * @param int $columnId Column ID that will be updated
 	 * @param string|null $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory
 	 * @param string|null $description Description
@@ -1683,6 +1685,7 @@ class Api1Controller extends ApiController {
 	 * @param int $tableId Table ID
 	 * @param string $title Title
 	 * @param 'text'|'number'|'datetime'|'select'|'usergroup'|'relation' $type Column main type
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $subtype Column sub type
 	 * @param bool $mandatory Is the column mandatory
 	 * @param string|null $description Description

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -144,7 +144,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 */
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
-	public function createNumberColumn(int $baseNodeId, string $title, ?float $numberDefault, ?int $numberDecimals, ?string $numberPrefix, ?string $numberSuffix, ?float $numberMin, ?float $numberMax, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+	public function createNumberColumn(int $baseNodeId, string $title, ?string $technicalName, ?float $numberDefault, ?int $numberDecimals, ?string $numberPrefix, ?string $numberSuffix, ?float $numberMin, ?float $numberMax, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
 		try {
@@ -154,6 +154,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::NUMBER->value,
 					subtype: $subtype,
 					mandatory: $mandatory,
@@ -212,7 +213,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 */
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
-	public function createTextColumn(int $baseNodeId, string $title, ?string $textDefault, ?string $textAllowedPattern, ?int $textMaxLength, ?bool $textUnique = false, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+	public function createTextColumn(int $baseNodeId, string $title, ?string $technicalName, ?string $textDefault, ?string $textAllowedPattern, ?int $textMaxLength, ?bool $textUnique = false, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
 		try {
@@ -222,6 +223,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::TEXT->value,
 					subtype: $subtype,
 					mandatory: $mandatory,
@@ -280,7 +282,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 */
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
-	public function createSelectionColumn(int $baseNodeId, string $title, string $selectionOptions, ?string $selectionDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+	public function createSelectionColumn(int $baseNodeId, string $title, ?string $technicalName, string $selectionOptions, ?string $selectionDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
 		try {
@@ -290,6 +292,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::SELECTION->value,
 					subtype: $subtype,
 					mandatory: $mandatory,
@@ -343,7 +346,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 */
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
-	public function createDatetimeColumn(int $baseNodeId, string $title, ?string $datetimeDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+	public function createDatetimeColumn(int $baseNodeId, string $title, ?string $technicalName, ?string $datetimeDefault, ?string $subtype = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
 		try {
@@ -353,6 +356,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::DATETIME->value,
 					subtype: $subtype,
 					mandatory: $mandatory,
@@ -408,7 +412,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 */
 	#[NoAdminRequired]
 	#[RequirePermission(permission: Application::PERMISSION_MANAGE, typeParam: 'baseNodeType', idParam: 'baseNodeId')]
-	public function createUsergroupColumn(int $baseNodeId, string $title, ?string $usergroupDefault, ?bool $usergroupMultipleItems = null, ?bool $usergroupSelectUsers = null, ?bool $usergroupSelectGroups = null, ?bool $usergroupSelectTeams = null, ?bool $showUserStatus = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
+	public function createUsergroupColumn(int $baseNodeId, string $title, ?string $technicalName, ?string $usergroupDefault, ?bool $usergroupMultipleItems = null, ?bool $usergroupSelectUsers = null, ?bool $usergroupSelectGroups = null, ?bool $usergroupSelectTeams = null, ?bool $showUserStatus = null, ?string $description = null, ?array $selectedViewIds = [], bool $mandatory = false, string $baseNodeType = 'table', array $customSettings = []): DataResponse {
 		$tableId = $baseNodeType === 'table' ? $baseNodeId : null;
 		$viewId = $baseNodeType === 'view' ? $baseNodeId : null;
 		try {
@@ -418,6 +422,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 				$viewId,
 				new ColumnDto(
 					title: $title,
+					technicalName: $technicalName,
 					type: ColumnType::PEOPLE->value,
 					mandatory: $mandatory,
 					description: $description,

--- a/lib/Controller/ApiColumnsController.php
+++ b/lib/Controller/ApiColumnsController.php
@@ -112,6 +112,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param boolean $mandatory Is mandatory
 	 * @param 'table'|'view' $baseNodeType Context type of the column creation
 	 * @param float|null $numberDefault Default value for new rows
@@ -182,6 +183,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $textDefault Default
 	 * @param string|null $textAllowedPattern Allowed regex pattern
 	 * @param int|null $textMaxLength Max raw text length
@@ -249,6 +251,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string $selectionOptions Json array{id: int, label: string} with
 	 *                                 options that can be selected, eg [{"id": 1, "label": "first"},{"id":
 	 *                                 2, "label": "second"}]
@@ -316,6 +319,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param 'today'|'now'|null $datetimeDefault For a subtype 'date' you can
 	 *                                            set 'today'. For a main type or subtype 'time' you can set to 'now'.
 	 *
@@ -377,6 +381,7 @@ class ApiColumnsController extends ACommonColumnsOCSController {
 	 *
 	 * @param int $baseNodeId Context of the column creation
 	 * @param string $title Title
+	 * @param string|null $technicalName Technical name of the column
 	 * @param string|null $usergroupDefault Json array{id: string, type: int},
 	 *                                      eg [{"id": "admin", "type": 0}, {"id": "user1", "type": 0}]
 	 * @param boolean $usergroupMultipleItems Whether you can select multiple

--- a/lib/Db/Column.php
+++ b/lib/Db/Column.php
@@ -21,6 +21,8 @@ use ValueError;
  *
  * @method getTitle(): string
  * @method setTitle(string $title)
+ * @method getTechnicalName(): string
+ * @method setTechnicalName(?string $technicalName)
  * @method getTableId(): int
  * @method setTableId(int $tableId)
  * @method getCreatedBy(): string
@@ -119,6 +121,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	public const RELATION_LABEL_COLUMN = 'labelColumn';
 
 	protected ?string $title = null;
+	protected ?string $technicalName = null;
 	protected ?int $tableId = null;
 	protected ?string $createdBy = null;
 	protected ?string $createdAt = null;
@@ -205,6 +208,7 @@ class Column extends EntitySuper implements JsonSerializable {
 	public static function fromDto(ColumnDto $data): self {
 		$column = new self();
 		$column->setTitle($data->getTitle());
+		$column->setTechnicalName($data->getTechnicalName());
 		$column->setType($data->getType());
 		$column->setSubtype($data->getSubtype() ?? '');
 		$column->setMandatory($data->isMandatory() ?? false);
@@ -268,6 +272,7 @@ class Column extends EntitySuper implements JsonSerializable {
 			'id' => $this->id,
 			'tableId' => $this->tableId,
 			'title' => $this->title,
+			'technicalName' => $this->technicalName,
 			'createdBy' => $this->createdBy,
 			'createdByDisplayName' => $this->createdByDisplayName,
 			'createdAt' => $this->createdAt,

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -171,6 +171,7 @@ class Row2 implements JsonSerializable {
 			rowId: $this->id,
 			previousValues: $previousValues,
 			values: $this->data,
+			dataByAlias: $this->dataByAlias,
 		);
 	}
 

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -23,6 +23,8 @@ class Row2 implements JsonSerializable {
 	private ?string $lastEditBy = null;
 	private ?string $lastEditAt = null;
 	private ?array $data = [];
+	/** @var array<string, array{columnId: int, value: mixed}> */
+	private array $dataByAlias = [];
 	private array $changedColumnIds = []; // collect column ids that have changed after $loaded = true
 
 	private bool $loaded = false; // set to true if model is loaded, after that changed column ids will be collected
@@ -71,6 +73,20 @@ class Row2 implements JsonSerializable {
 
 	public function getData(): ?array {
 		return $this->data;
+	}
+
+	/**
+	 * @return array<string, array{columnId: int, value: mixed}>
+	 */
+	public function getDataByAlias(): array {
+		return $this->dataByAlias;
+	}
+
+	/**
+	 * @param array<string, array{columnId: int, value: mixed}> $dataByAlias
+	 */
+	public function setDataByAlias(array $dataByAlias): void {
+		$this->dataByAlias = $dataByAlias;
 	}
 
 	/**
@@ -145,6 +161,7 @@ class Row2 implements JsonSerializable {
 			'lastEditBy' => $this->lastEditBy,
 			'lastEditAt' => $this->lastEditAt,
 			'data' => $this->data,
+			'dataByAlias' => $this->dataByAlias,
 		];
 	}
 

--- a/lib/Db/Row2.php
+++ b/lib/Db/Row2.php
@@ -150,6 +150,18 @@ class Row2 implements JsonSerializable {
 	}
 
 	/**
+	 * @param int[] $columns
+	 * @return array
+	 */
+	public function filterDataByAliasByColumns(array $columns): array {
+		$this->dataByAlias = array_filter(
+			$this->dataByAlias,
+			static fn (array $cell): bool => in_array($cell['columnId'], $columns, true),
+		);
+		return $this->dataByAlias;
+	}
+
+	/**
 	 * @psalm-return TablesRow
 	 */
 	public function jsonSerialize(): array {

--- a/lib/Dto/Column.php
+++ b/lib/Dto/Column.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Dto;
 class Column {
 	public function __construct(
 		private ?string $title = null,
+		private ?string $technicalName = null,
 		private ?string $type = null,
 		private ?string $subtype = null,
 		private ?bool $mandatory = null,
@@ -45,6 +46,7 @@ class Column {
 
 		return new self(
 			title: $data['title'] ?? null,
+			technicalName: $data['technicalName'] ?? null,
 			type: $data['type'] ?? null,
 			subtype: $data['subtype'] ?? null,
 			mandatory: $data['mandatory'] ?? null,
@@ -86,6 +88,10 @@ class Column {
 
 	public function getTitle(): ?string {
 		return $this->title;
+	}
+
+	public function getTechnicalName(): ?string {
+		return $this->technicalName;
 	}
 
 	public function getDescription(): ?string {

--- a/lib/Migration/Version1000Date20260327000000.php
+++ b/lib/Migration/Version1000Date20260327000000.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version1000Date20260327000000 extends SimpleMigrationStep {
+	private IDBConnection $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('tables_columns')) {
+			return null;
+		}
+
+		$table = $schema->getTable('tables_columns');
+		if (!$table->hasColumn('technical_name')) {
+			$table->addColumn('technical_name', Types::STRING, [
+				'notnull' => false,
+				'length' => 200,
+			]);
+		}
+
+		if (!$table->hasIndex('tables_columns_table_tech_name_uq')) {
+			$table->addUniqueIndex(['table_id', 'technical_name'], 'tables_columns_table_tech_name_uq');
+		}
+
+		return $schema;
+	}
+
+	#[Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$selectQb = $this->connection->getQueryBuilder();
+		$selectQb->select('id')
+			->from('tables_columns')
+			->where(
+				$selectQb->expr()->orX(
+					$selectQb->expr()->isNull('technical_name'),
+					$selectQb->expr()->eq('technical_name', $selectQb->createNamedParameter('')),
+				)
+			);
+
+		$result = $selectQb->executeQuery();
+		$updatedCount = 0;
+
+		try {
+			while ($row = $result->fetchAssociative()) {
+				$columnId = (int)$row['id'];
+
+				$updateQb = $this->connection->getQueryBuilder();
+				$updateQb->update('tables_columns')
+					->set('technical_name', $updateQb->createNamedParameter('column_' . $columnId, IQueryBuilder::PARAM_STR))
+					->where($updateQb->expr()->eq('id', $updateQb->createNamedParameter($columnId, IQueryBuilder::PARAM_INT)));
+
+				$updatedCount += $updateQb->executeStatement();
+			}
+		} finally {
+			$result->closeCursor();
+		}
+
+		$output->info('Version1000Date20260327000000: backfilled technical_name for ' . $updatedCount . ' columns.');
+	}
+}

--- a/lib/Migration/Version2200Date20260707000000.php
+++ b/lib/Migration/Version2200Date20260707000000.php
@@ -18,7 +18,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Override;
 
-class Version1000Date20260327000000 extends SimpleMigrationStep {
+class Version2200Date20260707000000 extends SimpleMigrationStep {
 	private IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
@@ -79,6 +79,6 @@ class Version1000Date20260327000000 extends SimpleMigrationStep {
 			$result->closeCursor();
 		}
 
-		$output->info('Version1000Date20260327000000: backfilled technical_name for ' . $updatedCount . ' columns.');
+		$output->info('Version2200Date20260707000000: backfilled technical_name for ' . $updatedCount . ' columns.');
 	}
 }

--- a/lib/Model/Public/Row.php
+++ b/lib/Model/Public/Row.php
@@ -19,6 +19,7 @@ final class Row implements JsonSerializable {
 	 * @param int $rowId
 	 * @param array<int,mixed>|null $previousValues key is the columnId. Only set on Update events.
 	 * @param array<int,mixed>|null $values key is the columnId. Contains values across all events, including Delete.
+	 * @param array<string, array{columnId: int, value: mixed}>|null $dataByAlias key is the column technicalName (or column_{id} fallback).
 	 *
 	 * @since 0.8
 	 */
@@ -31,11 +32,13 @@ final class Row implements JsonSerializable {
 		public ?array $previousValues = null,
 		/** @readonly */
 		public ?array $values = null,
+		/** @readonly */
+		public ?array $dataByAlias = null,
 	) {
 	}
 
 	/**
-	 * @return array{"tableId": int, "rowId": int, "previousValues": null|array<int, mixed>, "values": null|array<int, mixed>}
+	 * @return array{"tableId": int, "rowId": int, "previousValues": null|array<int, mixed>, "values": null|array<int, mixed>, "dataByAlias": null|array<string, array{columnId: int, value: mixed}>}
 	 *
 	 * @since 0.8
 	 */
@@ -45,6 +48,7 @@ final class Row implements JsonSerializable {
 			'rowId' => $this->rowId,
 			'previousValues' => $this->previousValues,
 			'values' => $this->values,
+			'dataByAlias' => $this->dataByAlias,
 		];
 	}
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -21,6 +21,7 @@ namespace OCA\Tables;
  * 	ownership: string,
  * 	ownerDisplayName: string|null,
  * 	createdBy: string,
+ * 	dataByAlias: array<string, array{columnId: int, value: mixed}>,
  * 	createdAt: string,
  * 	lastEditBy: string,
  * 	lastEditAt: string,
@@ -91,6 +92,7 @@ namespace OCA\Tables;
  *    createdAt: string,
  *    lastEditAt: string,
  *    data: ?array{columnId: int, value: mixed},
+ *    dataByAlias: array<string, array{columnId: int, value: mixed}>,
  *  }
  *
  * @psalm-type TablesLinkShare = array{
@@ -118,6 +120,7 @@ namespace OCA\Tables;
  * @psalm-type TablesColumn = array{
  *  id: int,
  *  title: string,
+ *  technicalName: string,
  *  tableId: int,
  *  createdBy: string,
  *  createdByDisplayName: string,
@@ -163,6 +166,7 @@ namespace OCA\Tables;
  * @psalm-type TablesPublicColumn = array{
  *   id: int,
  *   title: string,
+ *   technicalName: string,
  *   createdAt: string,
  *   lastEditAt: string,
  *   type: string,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -85,6 +85,7 @@ namespace OCA\Tables;
  * 	lastEditBy: string,
  * 	lastEditAt: string,
  *  data: ?array{columnId: int, value: mixed},
+ *  dataByAlias: array<string, array{columnId: int, value: mixed}>,
  * }
  *
  * @psalm-type TablesPublicRow = array{

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -308,6 +308,9 @@ class ColumnService extends SuperService {
 		$item = Column::fromDto($columnDto);
 		$item->setTitle($newTitle);
 		$item->setTableId($table->getId());
+		if ($item->getTechnicalName() !== null) {
+			$this->assertTechnicalNameUnique($table->getId(), $item->getTechnicalName());
+		}
 		$this->updateMetadata($item, $userId, true);
 
 		try {
@@ -315,6 +318,15 @@ class ColumnService extends SuperService {
 		} catch (\OCP\DB\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		}
+		if ($entity->getTechnicalName() === null || $entity->getTechnicalName() === '') {
+			$entity->setTechnicalName($this->buildDefaultTechnicalName($entity->getId()));
+			try {
+				$entity = $this->mapper->update($entity);
+			} catch (Exception $e) {
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			}
 		}
 		if (isset($view) && $view) {
 			// Add columns to view(s)
@@ -366,6 +378,10 @@ class ColumnService extends SuperService {
 
 			if ($title !== null) {
 				$item->setTitle($title);
+			}
+			if ($columnDto->getTechnicalName() !== null) {
+				$this->assertTechnicalNameUnique($item->getTableId(), $columnDto->getTechnicalName(), $item->getId());
+				$item->setTechnicalName($columnDto->getTechnicalName());
 			}
 			if ($columnDto->getType() !== null) {
 				$item->setType($columnDto->getType());
@@ -674,6 +690,7 @@ class ColumnService extends SuperService {
 		$item = new Column();
 		$item->setTableId($table->getId());
 		$item->setTitle($column['title']);
+		$item->setTechnicalName($column['technicalName'] ?? null);
 		$item->setCreatedBy($table->getOwnership());
 		$item->setCreatedAt($column['createdAt']);
 		$item->setLastEditBy($table->getOwnership());
@@ -705,10 +722,41 @@ class ColumnService extends SuperService {
 
 		try {
 			$newColumn = $this->mapper->insert($item);
+			if ($newColumn->getTechnicalName() === null || $newColumn->getTechnicalName() === '') {
+				$newColumn->setTechnicalName($this->buildDefaultTechnicalName($newColumn->getId()));
+				$newColumn = $this->mapper->update($newColumn);
+			}
 		} catch (\Exception $e) {
 			$this->logger->error('importColumn insert error: ' . $e->getMessage());
 			throw new InternalError('importColumn insert error: ' . $e->getMessage());
 		}
 		return $newColumn->getId();
+	}
+
+	private function buildDefaultTechnicalName(int $columnId): string {
+		return 'column_' . $columnId;
+	}
+
+	/**
+	 * @throws BadRequestError
+	 * @throws InternalError
+	 */
+	private function assertTechnicalNameUnique(int $tableId, string $technicalName, ?int $excludeCurrentColumnId = null): void {
+		try {
+			$columns = $this->mapper->findAllByTable($tableId);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		}
+
+		foreach ($columns as $column) {
+			if ($excludeCurrentColumnId !== null && $column->getId() === $excludeCurrentColumnId) {
+				continue;
+			}
+
+			if ($column->getTechnicalName() === $technicalName) {
+				throw new BadRequestError('Technical name must be unique in the table.');
+			}
+		}
 	}
 }

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -746,7 +746,7 @@ class ColumnService extends SuperService {
 	 * @throws BadRequestError
 	 * @throws InternalError
 	 */
-	private function handleColumnPersistDbException(\OCP\DB\Exception $e, string $context): void {
+	private function handleColumnPersistDbException(\OCP\DB\Exception $e, string $context): never {
 		if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 			throw new BadRequestError('Technical name must be unique in the table.');
 		}

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -308,21 +308,19 @@ class ColumnService extends SuperService {
 		$item = Column::fromDto($columnDto);
 		$item->setTitle($newTitle);
 		$item->setTableId($table->getId());
-		if ($item->getTechnicalName() !== null) {
-			$this->assertTechnicalNameUnique($table->getId(), $item->getTechnicalName());
-		}
 		$this->updateMetadata($item, $userId, true);
 
 		try {
 			$entity = $this->mapper->insert($item);
 		} catch (\OCP\DB\Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			$this->handleColumnPersistDbException($e, get_class($this) . ' - ' . __FUNCTION__);
 		}
 		if ($entity->getTechnicalName() === null || $entity->getTechnicalName() === '') {
 			$entity->setTechnicalName($this->buildDefaultTechnicalName($entity->getId()));
 			try {
 				$entity = $this->mapper->update($entity);
+			} catch (\OCP\DB\Exception $e) {
+				$this->handleColumnPersistDbException($e, get_class($this) . ' - ' . __FUNCTION__);
 			} catch (Exception $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
 				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -380,7 +378,6 @@ class ColumnService extends SuperService {
 				$item->setTitle($title);
 			}
 			if ($columnDto->getTechnicalName() !== null) {
-				$this->assertTechnicalNameUnique($item->getTableId(), $columnDto->getTechnicalName(), $item->getId());
 				$item->setTechnicalName($columnDto->getTechnicalName());
 			}
 			if ($columnDto->getType() !== null) {
@@ -427,7 +424,11 @@ class ColumnService extends SuperService {
 			$item->setCustomSettings($columnDto->getCustomSettings());
 
 			$this->updateMetadata($item, $userId);
-			return $this->enhanceColumn($this->mapper->update($item));
+			try {
+				return $this->enhanceColumn($this->mapper->update($item));
+			} catch (\OCP\DB\Exception $e) {
+				$this->handleColumnPersistDbException($e, get_class($this) . ' - ' . __FUNCTION__);
+			}
 		} catch (BadRequestError $e) {
 			throw $e;
 		} catch (Exception $e) {
@@ -726,6 +727,10 @@ class ColumnService extends SuperService {
 				$newColumn->setTechnicalName($this->buildDefaultTechnicalName($newColumn->getId()));
 				$newColumn = $this->mapper->update($newColumn);
 			}
+		} catch (BadRequestError $e) {
+			throw $e;
+		} catch (\OCP\DB\Exception $e) {
+			$this->handleColumnPersistDbException($e, 'importColumn insert error');
 		} catch (\Exception $e) {
 			$this->logger->error('importColumn insert error: ' . $e->getMessage());
 			throw new InternalError('importColumn insert error: ' . $e->getMessage());
@@ -741,22 +746,12 @@ class ColumnService extends SuperService {
 	 * @throws BadRequestError
 	 * @throws InternalError
 	 */
-	private function assertTechnicalNameUnique(int $tableId, string $technicalName, ?int $excludeCurrentColumnId = null): void {
-		try {
-			$columns = $this->mapper->findAllByTable($tableId);
-		} catch (Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+	private function handleColumnPersistDbException(\OCP\DB\Exception $e, string $context): void {
+		if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+			throw new BadRequestError('Technical name must be unique in the table.');
 		}
 
-		foreach ($columns as $column) {
-			if ($excludeCurrentColumnId !== null && $column->getId() === $excludeCurrentColumnId) {
-				continue;
-			}
-
-			if ($column->getTechnicalName() === $technicalName) {
-				throw new BadRequestError('Technical name must be unique in the table.');
-			}
-		}
+		$this->logger->error($e->getMessage(), ['exception' => $e]);
+		throw new InternalError($context . ': ' . $e->getMessage());
 	}
 }

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -72,12 +72,13 @@ class RowService extends SuperService {
 
 	/**
 	 * @param Row2[] $rows
-	 * @return TablesPublicRow[]
+	 * @psalm-return TablesPublicRow[]
 	 */
 	public function formatRowsForPublicShare(array $rows): array {
 		return array_map(static function (Row2 $row): array {
 			$rowData = $row->jsonSerialize();
 			unset($rowData['tableId'], $rowData['createdBy'], $rowData['lastEditBy']);
+			/** @var TablesPublicRow $rowData */
 			return $rowData;
 		}, $rows);
 	}

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -266,6 +266,7 @@ class RowService extends SuperService {
 		$row2->setData($data);
 		try {
 			$insertedRow = $this->row2Mapper->insert($row2, $this->userId);
+			$this->attachAliasPayload($insertedRow, $columns);
 
 			$this->eventDispatcher->dispatchTyped(new RowAddedEvent($insertedRow));
 			$this->activityManager->triggerEvent(
@@ -694,6 +695,7 @@ class RowService extends SuperService {
 		}
 
 		$updatedRow = $this->row2Mapper->update($item, $this->userId);
+		$this->attachAliasPayload($updatedRow, $columns);
 
 		$this->eventDispatcher->dispatchTyped(new RowUpdatedEvent($updatedRow, $previousData));
 
@@ -782,6 +784,7 @@ class RowService extends SuperService {
 
 		try {
 			$deletedRow = $this->row2Mapper->delete($item);
+			$this->attachAliasPayload($item);
 
 			$event = new RowDeletedEvent($item, $item->getData());
 

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -276,9 +276,7 @@ class RowService extends SuperService {
 				author: $this->userId,
 			);
 
-			$insertedRow = $this->filterRowResult($view, $insertedRow);
-			$this->attachAliasPayload($insertedRow, $columns);
-			return $insertedRow;
+			return $this->filterRowResult($view, $insertedRow);
 		} catch (InternalError|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -712,9 +710,7 @@ class RowService extends SuperService {
 			);
 		}
 
-		$updatedRow = $this->filterRowResult($view ?? null, $updatedRow);
-		$this->attachAliasPayload($updatedRow, $columns);
-		return $updatedRow;
+		return $this->filterRowResult($view ?? null, $updatedRow);
 	}
 
 	/**
@@ -783,8 +779,9 @@ class RowService extends SuperService {
 		}
 
 		try {
+			$columns = $this->loadColumnsForData($item->getData() ?? []);
 			$deletedRow = $this->row2Mapper->delete($item);
-			$this->attachAliasPayload($item);
+			$this->attachAliasPayload($item, $columns);
 
 			$event = new RowDeletedEvent($item, $item->getData());
 
@@ -796,9 +793,7 @@ class RowService extends SuperService {
 				author: $this->userId,
 			);
 
-			$deletedRow = $this->filterRowResult($view ?? null, $deletedRow);
-			$this->attachAliasPayload($deletedRow);
-			return $deletedRow;
+			return $this->filterRowResult($view ?? null, $deletedRow);
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -896,7 +891,9 @@ class RowService extends SuperService {
 			return $row;
 		}
 
-		$row->filterDataByColumns($view->getColumnIds());
+		$columnIds = $view->getColumnIds();
+		$row->filterDataByColumns($columnIds);
+		$row->filterDataByAliasByColumns($columnIds);
 
 		return $row;
 	}

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -100,7 +100,9 @@ class RowService extends SuperService {
 				$table = $this->tableMapper->find($tableId);
 				$sort = $table->getSortArray() ?: null;
 
-				return $this->row2Mapper->findAll($showColumnIds, $tableId, $limit, $offset, null, $sort, $userId);
+				$rows = $this->row2Mapper->findAll($showColumnIds, $tableId, $limit, $offset, null, $sort, $userId);
+				$this->attachAliasPayloads($rows, $tableColumns);
+				return $rows;
 			} else {
 				throw new PermissionError('no read access to table id = ' . $tableId);
 			}
@@ -135,6 +137,7 @@ class RowService extends SuperService {
 					$view->getSortArray(),
 					$this->resolveFilterUserId($userId, $view),
 				);
+
 			} else {
 				throw new PermissionError('no read access to view id = ' . $viewId);
 			}
@@ -181,6 +184,7 @@ class RowService extends SuperService {
 			throw new NotFoundError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 		}
 
+		$this->attachAliasPayload($row, $columns);
 		return $row;
 	}
 
@@ -270,7 +274,9 @@ class RowService extends SuperService {
 				author: $this->userId,
 			);
 
-			return $this->filterRowResult($view, $insertedRow);
+			$insertedRow = $this->filterRowResult($view, $insertedRow);
+			$this->attachAliasPayload($insertedRow, $columns);
+			return $insertedRow;
 		} catch (InternalError|Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -703,7 +709,9 @@ class RowService extends SuperService {
 			);
 		}
 
-		return $this->filterRowResult($view ?? null, $updatedRow);
+		$updatedRow = $this->filterRowResult($view ?? null, $updatedRow);
+		$this->attachAliasPayload($updatedRow, $columns);
+		return $updatedRow;
 	}
 
 	/**
@@ -784,7 +792,9 @@ class RowService extends SuperService {
 				author: $this->userId,
 			);
 
-			return $this->filterRowResult($view ?? null, $deletedRow);
+			$deletedRow = $this->filterRowResult($view ?? null, $deletedRow);
+			$this->attachAliasPayload($deletedRow);
+			return $deletedRow;
 		} catch (Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -885,6 +895,72 @@ class RowService extends SuperService {
 		$row->filterDataByColumns($view->getColumnIds());
 
 		return $row;
+	}
+
+	/**
+	 * @param Row2[] $rows
+	 * @param Column[]|null $columns
+	 */
+	private function attachAliasPayloads(array $rows, ?array $columns = null): void {
+		foreach ($rows as $row) {
+			$this->attachAliasPayload($row, $columns);
+		}
+	}
+
+	/**
+	 * @param Column[]|null $columns
+	 */
+	private function attachAliasPayload(Row2 $row, ?array $columns = null): void {
+		$data = $row->getData() ?? [];
+		if ($data === []) {
+			$row->setDataByAlias([]);
+			return;
+		}
+
+		$columns ??= $this->loadColumnsForData($data);
+		$aliasByColumnId = $this->buildAliasByColumnId($columns);
+
+		$dataByAlias = [];
+		foreach ($data as $cell) {
+			$columnId = (int)$cell['columnId'];
+			$alias = $aliasByColumnId[$columnId] ?? ('column_' . $columnId);
+			$dataByAlias[$alias] = [
+				'columnId' => $columnId,
+				'value' => $cell['value'],
+			];
+		}
+
+		$row->setDataByAlias($dataByAlias);
+	}
+
+	/**
+	 * Loads Column entities for the column IDs found in a row's data cells,
+	 * skipping meta column IDs (<= 0).
+	 *
+	 * @param array<array{columnId: int|string, value: mixed}> $data
+	 * @return Column[]
+	 */
+	private function loadColumnsForData(array $data): array {
+		$columnIds = array_values(array_unique(array_map(static fn (array $cell): int => (int)$cell['columnId'], $data)));
+		$columnIds = array_values(array_filter($columnIds, static fn (int $id): bool => $id > 0));
+		return $columnIds === [] ? [] : $this->columnMapper->findAll($columnIds);
+	}
+
+	/**
+	 * Builds a map of column ID => technical name for alias resolution.
+	 *
+	 * @param Column[] $columns
+	 * @return array<int, string>
+	 */
+	private function buildAliasByColumnId(array $columns): array {
+		$aliasByColumnId = [];
+		foreach ($columns as $column) {
+			$technicalName = $column->getTechnicalName();
+			if ($technicalName !== null && $technicalName !== '') {
+				$aliasByColumnId[$column->getId()] = $technicalName;
+			}
+		}
+		return $aliasByColumnId;
 	}
 
 	/**

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -900,25 +900,24 @@ class RowService extends SuperService {
 
 	/**
 	 * @param Row2[] $rows
-	 * @param Column[]|null $columns
+	 * @param Column[] $columns
 	 */
-	private function attachAliasPayloads(array $rows, ?array $columns = null): void {
+	private function attachAliasPayloads(array $rows, array $columns): void {
 		foreach ($rows as $row) {
 			$this->attachAliasPayload($row, $columns);
 		}
 	}
 
 	/**
-	 * @param Column[]|null $columns
+	 * @param Column[] $columns
 	 */
-	private function attachAliasPayload(Row2 $row, ?array $columns = null): void {
+	private function attachAliasPayload(Row2 $row, array $columns): void {
 		$data = $row->getData() ?? [];
 		if ($data === []) {
 			$row->setDataByAlias([]);
 			return;
 		}
 
-		$columns ??= $this->loadColumnsForData($data);
 		$aliasByColumnId = $this->buildAliasByColumnId($columns);
 
 		$dataByAlias = [];

--- a/lib/Validation/ColumnDtoValidator.php
+++ b/lib/Validation/ColumnDtoValidator.php
@@ -12,6 +12,20 @@ use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Service\ValueObject\Title;
 
 class ColumnDtoValidator {
+	private const TECHNICAL_NAME_MAX_LENGTH = 200;
+
+	/**
+	 * reserved keys to avoid confusion with meta fields and common row keys.
+	 */
+	private const RESERVED_TECHNICAL_NAMES = [
+		'id',
+		'created_by',
+		'created_at',
+		'last_edit_by',
+		'last_edit_at',
+		'data',
+	];
+
 	/**
 	 * @throws BadRequestError
 	 */
@@ -28,6 +42,8 @@ class ColumnDtoValidator {
 			}
 		}
 
+		$this->validateTechnicalName($columnDto);
+
 		$textMaxLength = $columnDto->getTextMaxLength();
 		if ($textMaxLength !== null && $textMaxLength < 0) {
 			throw new BadRequestError('Maximum text length must be greater than or equal to 0.');
@@ -37,6 +53,32 @@ class ColumnDtoValidator {
 		$numberMax = $columnDto->getNumberMax();
 		if ($numberMin !== null && $numberMax !== null && $numberMin > $numberMax) {
 			throw new BadRequestError('Minimum number must be less than or equal to maximum number.');
+		}
+	}
+
+	/**
+	 * @throws BadRequestError
+	 */
+	private function validateTechnicalName(ColumnDto $columnDto): void {
+		$technicalName = $columnDto->getTechnicalName();
+		if ($technicalName === null) {
+			return;
+		}
+
+		if ($technicalName === '') {
+			throw new BadRequestError('Technical name must not be empty.');
+		}
+
+		if (strlen($technicalName) > self::TECHNICAL_NAME_MAX_LENGTH) {
+			throw new BadRequestError('Technical name must be maximum ' . self::TECHNICAL_NAME_MAX_LENGTH . ' characters long.');
+		}
+
+		if (in_array($technicalName, self::RESERVED_TECHNICAL_NAMES, true)) {
+			throw new BadRequestError('Technical name is reserved.');
+		}
+
+		if (preg_match('/^[a-z][a-z0-9_]*$/', $technicalName) !== 1) {
+			throw new BadRequestError('Technical name must start with a letter and contain only lowercase letters, digits, and underscores.');
 		}
 	}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -73,6 +73,7 @@
                 "required": [
                     "id",
                     "title",
+                    "technicalName",
                     "tableId",
                     "createdBy",
                     "createdByDisplayName",
@@ -113,6 +114,9 @@
                         "format": "int64"
                     },
                     "title": {
+                        "type": "string"
+                    },
+                    "technicalName": {
                         "type": "string"
                     },
                     "tableId": {
@@ -422,6 +426,7 @@
                 "required": [
                     "id",
                     "title",
+                    "technicalName",
                     "createdAt",
                     "lastEditAt",
                     "type",
@@ -457,6 +462,9 @@
                         "format": "int64"
                     },
                     "title": {
+                        "type": "string"
+                    },
+                    "technicalName": {
                         "type": "string"
                     },
                     "createdAt": {
@@ -590,7 +598,8 @@
                     "id",
                     "createdAt",
                     "lastEditAt",
-                    "data"
+                    "data",
+                    "dataByAlias"
                 ],
                 "properties": {
                     "id": {
@@ -619,6 +628,25 @@
                                 "type": "object"
                             }
                         }
+                    },
+                    "dataByAlias": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": [
+                                "columnId",
+                                "value"
+                            ],
+                            "properties": {
+                                "columnId": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "value": {
+                                    "type": "object"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -631,7 +659,8 @@
                     "createdAt",
                     "lastEditBy",
                     "lastEditAt",
-                    "data"
+                    "data",
+                    "dataByAlias"
                 ],
                 "properties": {
                     "id": {
@@ -668,6 +697,25 @@
                             },
                             "value": {
                                 "type": "object"
+                            }
+                        }
+                    },
+                    "dataByAlias": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": [
+                                "columnId",
+                                "value"
+                            ],
+                            "properties": {
+                                "columnId": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "value": {
+                                    "type": "object"
+                                }
                             }
                         }
                     }
@@ -904,6 +952,7 @@
                     "ownership",
                     "ownerDisplayName",
                     "createdBy",
+                    "dataByAlias",
                     "createdAt",
                     "lastEditBy",
                     "lastEditAt",
@@ -943,6 +992,25 @@
                     },
                     "createdBy": {
                         "type": "string"
+                    },
+                    "dataByAlias": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": [
+                                "columnId",
+                                "value"
+                            ],
+                            "properties": {
+                                "columnId": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "value": {
+                                    "type": "object"
+                                }
+                            }
+                        }
                     },
                     "createdAt": {
                         "type": "string"
@@ -3715,6 +3783,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "type": {
                                         "type": "string",
                                         "enum": [
@@ -4144,6 +4217,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "type": {
                                         "type": "string",
                                         "enum": [
@@ -4434,6 +4512,11 @@
                                         "type": "string",
                                         "nullable": true,
                                         "description": "Title"
+                                    },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
                                     },
                                     "subtype": {
                                         "type": "string",
@@ -8782,6 +8865,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "numberDefault": {
                                         "type": "number",
                                         "format": "double",
@@ -9136,6 +9224,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "textDefault": {
                                         "type": "string",
                                         "nullable": true,
@@ -9479,6 +9572,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "selectionOptions": {
                                         "type": "string",
                                         "description": "Json array{id: int, label: string} with options that can be selected, eg [{\"id\": 1, \"label\": \"first\"},{\"id\": 2, \"label\": \"second\"}]"
@@ -9808,6 +9906,11 @@
                                         "type": "string",
                                         "description": "Title"
                                     },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
+                                    },
                                     "datetimeDefault": {
                                         "type": "string",
                                         "nullable": true,
@@ -10135,6 +10238,11 @@
                                     "title": {
                                         "type": "string",
                                         "description": "Title"
+                                    },
+                                    "technicalName": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Technical name of the column"
                                     },
                                     "usergroupDefault": {
                                         "type": "string",

--- a/playwright/e2e/tables-import-export-scheme.spec.ts
+++ b/playwright/e2e/tables-import-export-scheme.spec.ts
@@ -277,6 +277,7 @@ test.describe('Import Export Scheme', () => {
 			'createdByDisplayName',
 			'lastEditBy',
 			'lastEditByDisplayName',
+			'technicalName',
 		]
 
 		const todoListItem = page

--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -121,6 +121,7 @@ import { useTablesStore } from '../../store/store.js'
 import { useDataStore } from '../../store/data.js'
 import { mapActions } from 'pinia'
 import { COLUMN_WIDTH_MAX, COLUMN_WIDTH_MIN } from '../../shared/constants.js'
+import { normalizeTechnicalName, isTechnicalNameValid } from '../../shared/utils/columnUtils.js'
 
 export default {
 	name: 'CreateColumn',
@@ -470,16 +471,10 @@ export default {
 			this.typeMissingError = false
 		},
 		normalizeTechnicalName(technicalName) {
-			const normalized = technicalName?.trim()
-			return normalized === '' ? null : normalized
+			return normalizeTechnicalName(technicalName)
 		},
 		isTechnicalNameValid() {
-			const technicalName = this.normalizeTechnicalName(this.column.technicalName)
-			if (technicalName === null) {
-				return true
-			}
-
-			return /^[a-z][a-z0-9_]*$/.test(technicalName)
+			return isTechnicalNameValid(this.column.technicalName)
 		},
 	},
 }

--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -12,10 +12,12 @@
 				<div class="fix-col-2">
 					<MainForm :description.sync="column.description"
 						:mandatory.sync="column.mandatory"
+						:technical-name.sync="column.technicalName"
 						:title.sync="column.title"
 						:custom-settings.sync="column.customSettings"
 						:selected-views.sync="column.selectedViews"
 						:title-missing-error="titleMissingError"
+						:technical-name-invalid-error="technicalNameInvalidError"
 						:width-invalid-error="widthInvalidError" />
 				</div>
 				<div class="fix-col-2" style="display: block">
@@ -175,6 +177,7 @@ export default {
 				numberPrefix: '',
 				numberSuffix: '',
 				selectedViews: [],
+				technicalName: '',
 				mandatory: false,
 				numberDefault: null,
 				numberMin: 0,
@@ -200,6 +203,7 @@ export default {
 			typeMissingError: false,
 			widthInvalidError: false,
 			titleMissingError: false,
+			technicalNameInvalidError: false,
 			typeOptions: [
 				{ id: 'text', label: t('tables', 'Text') },
 				{ id: 'text-link', label: t('tables', 'Link') },
@@ -297,6 +301,9 @@ export default {
 			if (!title) {
 				showInfo(t('tables', 'Please insert a title for the new column.'))
 				this.titleMissingError = true
+			} else if (!this.isTechnicalNameValid()) {
+				showError(t('tables', 'Cannot save column. Technical name must start with a lowercase letter and only contain lowercase letters, numbers, and underscores.'))
+				this.technicalNameInvalidError = true
 			} else if (this.column.customSettings?.width
 				&& (this.column.customSettings?.width < COLUMN_WIDTH_MIN || this.column.customSettings?.width > COLUMN_WIDTH_MAX)) {
 				showError(t('tables', 'Cannot save column. Column width must be between {min} and {max}.', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX }))
@@ -336,10 +343,12 @@ export default {
 			this.column.customSettings = { ...this.column.customSettings, ...customSettings }
 		},
 		prepareSubmitData() {
+			const technicalName = this.normalizeTechnicalName(this.column.technicalName)
 			const data = {
 				type: this.column.type,
 				subtype: this.column.subtype,
 				title: this.column.title,
+				technicalName,
 				description: this.column.description,
 				selectedViewIds: this.column.selectedViews.map(view => view.id),
 				mandatory: this.column.mandatory,
@@ -417,6 +426,7 @@ export default {
 				type: this.column.type,
 				subtype: this.column.subtype,
 				title: this.column.title,
+				technicalName: this.column.technicalName,
 				description: this.column.description,
 				selectedViews: this.column.selectedViews,
 				mandatory: this.column.mandatory,
@@ -443,6 +453,7 @@ export default {
 			}
 			if (mainForm) {
 				this.column.title = ''
+				this.column.technicalName = ''
 				this.column.description = ''
 				this.column.mandatory = false
 			}
@@ -454,8 +465,21 @@ export default {
 				this.column.selectedViews = []
 			}
 			this.titleMissingError = false
+			this.technicalNameInvalidError = false
 			this.widthInvalidError = false
 			this.typeMissingError = false
+		},
+		normalizeTechnicalName(technicalName) {
+			const normalized = technicalName?.trim()
+			return normalized === '' ? null : normalized
+		},
+		isTechnicalNameValid() {
+			const technicalName = this.normalizeTechnicalName(this.column.technicalName)
+			if (technicalName === null) {
+				return true
+			}
+
+			return /^[a-z][a-z0-9_]*$/.test(technicalName)
 		},
 	},
 }

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -76,6 +76,7 @@ import moment from '@nextcloud/moment'
 import { mapActions } from 'pinia'
 import { useDataStore } from '../../store/data.js'
 import { COLUMN_WIDTH_MAX, COLUMN_WIDTH_MIN } from '../../shared/constants.js'
+import { normalizeTechnicalName, isTechnicalNameValid } from '../../shared/utils/columnUtils.js'
 
 export default {
 	name: 'EditColumn',
@@ -238,16 +239,10 @@ export default {
 			}
 		},
 		normalizeTechnicalName(technicalName) {
-			const normalized = technicalName?.trim()
-			return normalized === '' ? null : normalized
+			return normalizeTechnicalName(technicalName)
 		},
 		isTechnicalNameValid() {
-			const technicalName = this.normalizeTechnicalName(this.editColumn.technicalName)
-			if (technicalName === null) {
-				return false
-			}
-
-			return /^[a-z][a-z0-9_]*$/.test(technicalName)
+			return isTechnicalNameValid(this.editColumn.technicalName)
 		},
 	},
 }

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -225,8 +225,7 @@ export default {
 			delete data.lastEditBy
 
 			data.technicalName = this.normalizeTechnicalName(data.technicalName)
-			data.customSettings = { width: data.customSettings.width }
-			console.debug('this column data will be send', data)
+			data.customSettings = { ...data.customSettings, width: data.customSettings.width }
 			const res = await this.updateColumn({
 				id: this.editColumn.id,
 				isView: this.isView,

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -12,10 +12,12 @@
 				<div class="col-2">
 					<MainForm :description.sync="editColumn.description"
 						:mandatory.sync="editColumn.mandatory"
+						:technical-name.sync="editColumn.technicalName"
 						:title.sync="editColumn.title"
 						:custom-settings.sync="editColumn.customSettings"
 						:edit-column="true"
 						:title-missing-error="editErrorTitle"
+						:technical-name-invalid-error="technicalNameInvalidError"
 						:width-invalid-error="widthInvalidError" />
 				</div>
 				<div class="col-2 space-LR space-T">
@@ -129,6 +131,7 @@ export default {
 			editColumn: JSON.parse(JSON.stringify(this.column)),
 			deleteId: null,
 			editErrorTitle: false,
+			technicalNameInvalidError: false,
 			widthInvalidError: false,
 			canSave: true, // used to avoid saving an incorrect config
 		}
@@ -180,6 +183,12 @@ export default {
 			}
 			this.editColumn.title = title
 
+			if (!this.isTechnicalNameValid()) {
+				showError(t('tables', 'Cannot save column. Technical name must start with a lowercase letter and only contain lowercase letters, numbers, and underscores.'))
+				this.technicalNameInvalidError = true
+				return
+			}
+
 			if (this.editColumn.customSettings?.width
 				&& (this.editColumn.customSettings?.width < COLUMN_WIDTH_MIN || this.editColumn.customSettings?.width > COLUMN_WIDTH_MAX)) {
 				showError(t('tables', 'Cannot save column. Column width must be between {min} and {max}.', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX }))
@@ -196,6 +205,7 @@ export default {
 			this.editColumn = null
 			this.deleteId = null
 			this.editErrorTitle = false
+			this.technicalNameInvalidError = false
 			this.widthInvalidError = false
 		},
 		async updateLocalColumn() {
@@ -212,6 +222,10 @@ export default {
 			delete data.createdBy
 			delete data.lastEditAt
 			delete data.lastEditBy
+
+			data.technicalName = this.normalizeTechnicalName(data.technicalName)
+			data.customSettings = { width: data.customSettings.width }
+			console.debug('this column data will be send', data)
 			const res = await this.updateColumn({
 				id: this.editColumn.id,
 				isView: this.isView,
@@ -222,6 +236,18 @@ export default {
 			if (res) {
 				showSuccess(t('tables', 'The column "{column}" was updated.', { column: this.editColumn.title }))
 			}
+		},
+		normalizeTechnicalName(technicalName) {
+			const normalized = technicalName?.trim()
+			return normalized === '' ? null : normalized
+		},
+		isTechnicalNameValid() {
+			const technicalName = this.normalizeTechnicalName(this.editColumn.technicalName)
+			if (technicalName === null) {
+				return false
+			}
+
+			return /^[a-z][a-z0-9_]*$/.test(technicalName)
 		},
 	},
 }

--- a/src/modules/modals/EditColumn.vue
+++ b/src/modules/modals/EditColumn.vue
@@ -6,9 +6,9 @@
 	<NcDialog size="large"
 		:name="t('tables', 'Edit column')"
 		@closing="actionCancel">
-		<div class="modal__content">
+		<div class="modal__content create-column">
 			<div v-if="loading" class="icon-loading" />
-			<div class="row space-L">
+			<div class="row">
 				<div class="col-2">
 					<MainForm :description.sync="editColumn.description"
 						:mandatory.sync="editColumn.mandatory"

--- a/src/shared/components/ncTable/mixins/columnClass.js
+++ b/src/shared/components/ncTable/mixins/columnClass.js
@@ -18,6 +18,7 @@ export class AbstractColumn {
 		this.mandatory = data.mandatory
 		this.tableId = data.tableId
 		this.title = data.title
+		this.technicalName = data.technicalName
 		this.description = data.description
 		this.createdByDisplayName = data.createdByDisplayName
 		this.viewColumnInformation = data.viewColumnInformation

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
@@ -12,6 +12,17 @@
 			<input v-model="localTitle" data-cy="columnTypeFormInput" :placeholder="t('tables', 'Enter a column title')">
 		</div>
 
+		<!-- technical name -->
+		<div class="fix-col-4 title space-T" :class="{error: technicalNameInvalidError}">
+			{{ t('tables', 'Technical name') }}
+		</div>
+		<div class="fix-col-4" :class="{error: technicalNameInvalidError}">
+			<input
+				v-model="localTechnicalName"
+				data-cy="columnTechnicalNameInput"
+				:placeholder="t('tables', 'Optional, e.g. customer_name')">
+		</div>
+
 		<!-- description -->
 		<div class="fix-col-4 title space-T">
 			{{ t('tables', 'Description') }}
@@ -98,6 +109,10 @@ export default {
 			type: Boolean,
 			default: null,
 		},
+		technicalName: {
+			type: String,
+			default: null,
+		},
 		selectedViews: {
 			type: Array,
 			default: null,
@@ -107,6 +122,10 @@ export default {
 			default: false,
 		},
 		widthInvalidError: {
+			type: Boolean,
+			default: false,
+		},
+		technicalNameInvalidError: {
 			type: Boolean,
 			default: false,
 		},
@@ -136,6 +155,10 @@ export default {
 		localDescription: {
 			get() { return this.description },
 			set(description) { this.$emit('update:description', description) },
+		},
+		localTechnicalName: {
+			get() { return this.technicalName },
+			set(technicalName) { this.$emit('update:technicalName', technicalName) },
 		},
 		localMandatory: {
 			get() { return this.mandatory },

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
@@ -4,23 +4,16 @@
 -->
 <template>
 	<div class="row space-R">
+		<h3 class="section-heading">
+			{{ t('tables', 'Title') }}
+		</h3>
+
 		<!-- title -->
 		<div class="fix-col-4 mandatory title space-T" :class="{error: titleMissingError}">
 			{{ t('tables', 'Title') }}
 		</div>
 		<div class="fix-col-4" :class="{error: titleMissingError}">
 			<input v-model="localTitle" data-cy="columnTypeFormInput" :placeholder="t('tables', 'Enter a column title')">
-		</div>
-
-		<!-- technical name -->
-		<div class="fix-col-4 title space-T" :class="{error: technicalNameInvalidError}">
-			{{ t('tables', 'Technical name') }}
-		</div>
-		<div class="fix-col-4" :class="{error: technicalNameInvalidError}">
-			<input
-				v-model="localTechnicalName"
-				data-cy="columnTechnicalNameInput"
-				:placeholder="t('tables', 'Optional, e.g. customer_name')">
 		</div>
 
 		<!-- description -->
@@ -37,20 +30,6 @@
 		</div>
 		<div class="fix-col-4">
 			<NcCheckboxRadioSwitch type="switch" :checked.sync="localMandatory" />
-		</div>
-
-		<!-- column width -->
-		<div class="fix-col-4 mandatory title space-T" :class="{error: widthInvalidError}">
-			{{ t('tables', 'Column width') }}
-		</div>
-		<div class="fix-col-4" :class="{error: widthInvalidError}">
-			<input
-				v-model.number="localColumnWidth"
-				type="number"
-				pattern="\d+"
-				:min="COLUMN_WIDTH_MIN"
-				:max="COLUMN_WIDTH_MAX"
-				:placeholder="t('tables', 'Enter a column width between {min} and {max}', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX })">
 		</div>
 
 		<!-- add to views -->
@@ -80,11 +59,48 @@
 				</template>
 			</NcSelect>
 		</div>
+
+		<h3 class="section-heading">
+			{{ t('tables', 'Advanced settings') }}
+		</h3>
+
+		<!-- technical name -->
+		<div class="fix-col-4 title space-T" :class="{error: technicalNameInvalidError}">
+			{{ t('tables', 'Technical name') }}
+		</div>
+		<div class="fix-col-4" :class="{error: technicalNameInvalidError}">
+			<input
+				v-model="localTechnicalName"
+				data-cy="columnTechnicalNameInput"
+				:placeholder="t('tables', 'Optional, e.g. customer_name')">
+		</div>
+
+		<!-- warning for technical name changes -->
+		<div v-if="editColumn" class="fix-col-4 space-T">
+			<NcNoteCard type="warning">
+				<p>{{ t('tables', 'Changing the technical name affects integrations and API. Make sure to update your services accordingly.') }}</p>
+			</NcNoteCard>
+		</div>
+
+		<!-- column width -->
+		<div class="fix-col-4 mandatory title space-T" :class="{error: widthInvalidError}">
+			{{ t('tables', 'Column width') }}
+		</div>
+		<div class="fix-col-4" :class="{error: widthInvalidError}">
+			<input
+				v-model.number="localColumnWidth"
+				type="number"
+				pattern="\d+"
+				:min="COLUMN_WIDTH_MIN"
+				:max="COLUMN_WIDTH_MAX"
+				:placeholder="t('tables', 'Enter a column width between {min} and {max}', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX })">
+		</div>
+
 	</div>
 </template>
 
 <script>
-import { NcCheckboxRadioSwitch, NcSelect } from '@nextcloud/vue'
+import { NcCheckboxRadioSwitch, NcNoteCard, NcSelect } from '@nextcloud/vue'
 import { mapState } from 'pinia'
 import { translate as t } from '@nextcloud/l10n'
 import { useTablesStore } from '../../../../../../store/store.js'
@@ -94,6 +110,7 @@ export default {
 	name: 'MainForm',
 	components: {
 		NcCheckboxRadioSwitch,
+		NcNoteCard,
 		NcSelect,
 	},
 	props: {
@@ -205,5 +222,12 @@ export default {
 
 .error input {
 	border-color: var(--color-error);
+}
+
+.section-heading {
+	margin: calc(var(--default-grid-baseline) * 2) 0 var(--default-grid-baseline) 0;
+	font-size: 20px;
+	font-weight: 600;
+	width: 100%;
 }
 </style>

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/MainForm.vue
@@ -64,51 +64,74 @@
 			{{ t('tables', 'Advanced settings') }}
 		</h3>
 
-		<!-- technical name -->
-		<div class="fix-col-4 title space-T" :class="{error: technicalNameInvalidError}">
-			{{ t('tables', 'Technical name') }}
-		</div>
-		<div class="fix-col-4" :class="{error: technicalNameInvalidError}">
-			<input
-				v-model="localTechnicalName"
-				data-cy="columnTechnicalNameInput"
-				:placeholder="t('tables', 'Optional, e.g. customer_name')">
-		</div>
-
-		<!-- warning for technical name changes -->
-		<div v-if="editColumn" class="fix-col-4 space-T">
-			<NcNoteCard type="warning">
-				<p>{{ t('tables', 'Changing the technical name affects integrations and API. Make sure to update your services accordingly.') }}</p>
-			</NcNoteCard>
+		<div class="fix-col-4">
+			<NcButton
+				type="tertiary"
+				data-cy="columnAdvancedSettingsToggle"
+				:aria-expanded="showAdvanced"
+				:aria-label="advancedToggleLabel"
+				@click="showAdvanced = !showAdvanced">
+				<template #icon>
+					<ChevronUp v-if="showAdvanced" :size="20" />
+					<ChevronDown v-else :size="20" />
+				</template>
+				{{ advancedToggleLabel }}
+			</NcButton>
 		</div>
 
-		<!-- column width -->
-		<div class="fix-col-4 mandatory title space-T" :class="{error: widthInvalidError}">
-			{{ t('tables', 'Column width') }}
-		</div>
-		<div class="fix-col-4" :class="{error: widthInvalidError}">
-			<input
-				v-model.number="localColumnWidth"
-				type="number"
-				pattern="\d+"
-				:min="COLUMN_WIDTH_MIN"
-				:max="COLUMN_WIDTH_MAX"
-				:placeholder="t('tables', 'Enter a column width between {min} and {max}', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX })">
-		</div>
+		<template v-if="showAdvanced">
+			<!-- technical name -->
+			<div class="fix-col-4 title space-T" :class="{error: technicalNameInvalidError}">
+				{{ t('tables', 'Technical name') }}
+			</div>
+			<div class="fix-col-4" :class="{error: technicalNameInvalidError}">
+				<input
+					v-model="localTechnicalName"
+					type="text"
+					data-cy="columnTechnicalNameInput"
+					:placeholder="t('tables', 'Optional, e.g. customer_name')">
+			</div>
+
+			<!-- warning for technical name changes -->
+			<div class="fix-col-4 space-T">
+				<NcNoteCard type="warning">
+					<p>{{ t('tables', 'Changing the technical name affects integrations and API. Make sure to update your services accordingly.') }}</p>
+				</NcNoteCard>
+			</div>
+
+			<!-- column width -->
+			<div class="fix-col-4 mandatory title space-T" :class="{error: widthInvalidError}">
+				{{ t('tables', 'Column width') }}
+			</div>
+			<div class="fix-col-4" :class="{error: widthInvalidError}">
+				<input
+					v-model.number="localColumnWidth"
+					type="number"
+					pattern="\d+"
+					:min="COLUMN_WIDTH_MIN"
+					:max="COLUMN_WIDTH_MAX"
+					:placeholder="t('tables', 'Enter a column width between {min} and {max}', { min: COLUMN_WIDTH_MIN, max: COLUMN_WIDTH_MAX })">
+			</div>
+		</template>
 
 	</div>
 </template>
 
 <script>
-import { NcCheckboxRadioSwitch, NcNoteCard, NcSelect } from '@nextcloud/vue'
+import { NcButton, NcCheckboxRadioSwitch, NcNoteCard, NcSelect } from '@nextcloud/vue'
 import { mapState } from 'pinia'
 import { translate as t } from '@nextcloud/l10n'
+import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
+import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import { useTablesStore } from '../../../../../../store/store.js'
 import { COLUMN_WIDTH_MAX, COLUMN_WIDTH_MIN } from '../../../../../constants.js'
 
 export default {
 	name: 'MainForm',
 	components: {
+		ChevronDown,
+		ChevronUp,
+		NcButton,
 		NcCheckboxRadioSwitch,
 		NcNoteCard,
 		NcSelect,
@@ -161,10 +184,20 @@ export default {
 		return {
 			COLUMN_WIDTH_MIN,
 			COLUMN_WIDTH_MAX,
+			showAdvanced: false,
 		}
+	},
+	watch: {
+		technicalNameInvalidError: 'expandAdvancedOnError',
+		widthInvalidError: 'expandAdvancedOnError',
 	},
 	computed: {
 		...mapState(useTablesStore, ['views', 'activeElement', 'isView']),
+		advancedToggleLabel() {
+			return this.showAdvanced
+				? t('tables', 'Hide advanced settings')
+				: t('tables', 'Show advanced settings')
+		},
 		localTitle: {
 			get() { return this.title },
 			set(title) { this.$emit('update:title', title) },
@@ -202,7 +235,12 @@ export default {
 	},
 
 	mounted() {
-		if (this.editColumn) return
+		if (this.editColumn) {
+			if (this.technicalName || this.customSettings?.width) {
+				this.showAdvanced = true
+			}
+			return
+		}
 		if (!this.isView) {
 			this.localSelectedViews = this.viewsForTable
 		} else {
@@ -211,6 +249,11 @@ export default {
 	},
 	methods: {
 		t,
+		expandAdvancedOnError(show) {
+			if (show) {
+				this.showAdvanced = true
+			}
+		},
 	},
 }
 </script>

--- a/src/shared/utils/columnUtils.js
+++ b/src/shared/utils/columnUtils.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * @param {string|null|undefined} technicalName
+ * @return {string|null}
+ */
+export function normalizeTechnicalName(technicalName) {
+	const normalized = technicalName?.trim()
+	return normalized === '' ? null : normalized
+}
+
+/**
+ * returns true if the technical name is valid including null value.
+ *
+ * @param {string|null|undefined} technicalName
+ * @return {boolean}
+ */
+export function isTechnicalNameValid(technicalName) {
+	const normalized = normalizeTechnicalName(technicalName)
+	if (normalized === null) {
+		return true
+	}
+	return /^[a-z][a-z0-9_]*$/.test(normalized)
+}

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -933,6 +933,7 @@ export type components = {
             /** Format: int64 */
             readonly id: number;
             readonly title: string;
+            readonly technicalName: string;
             /** Format: int64 */
             readonly tableId: number;
             readonly createdBy: string;
@@ -1038,6 +1039,7 @@ export type components = {
             /** Format: int64 */
             readonly id: number;
             readonly title: string;
+            readonly technicalName: string;
             readonly createdAt: string;
             readonly lastEditAt: string;
             readonly type: string;
@@ -1093,6 +1095,13 @@ export type components = {
                 readonly columnId: number;
                 readonly value: Record<string, never>;
             } | null;
+            readonly dataByAlias: {
+                readonly [key: string]: {
+                    /** Format: int64 */
+                    readonly columnId: number;
+                    readonly value: Record<string, never>;
+                };
+            };
         };
         readonly Row: {
             /** Format: int64 */
@@ -1108,6 +1117,13 @@ export type components = {
                 readonly columnId: number;
                 readonly value: Record<string, never>;
             } | null;
+            readonly dataByAlias: {
+                readonly [key: string]: {
+                    /** Format: int64 */
+                    readonly columnId: number;
+                    readonly value: Record<string, never>;
+                };
+            };
         };
         readonly Share: {
             /** Format: int64 */
@@ -1178,6 +1194,13 @@ export type components = {
             readonly ownership: string;
             readonly ownerDisplayName: string | null;
             readonly createdBy: string;
+            readonly dataByAlias: {
+                readonly [key: string]: {
+                    /** Format: int64 */
+                    readonly columnId: number;
+                    readonly value: Record<string, never>;
+                };
+            };
             readonly createdAt: string;
             readonly lastEditBy: string;
             readonly lastEditAt: string;
@@ -2720,6 +2743,8 @@ export interface operations {
                 readonly "application/json": {
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /**
                      * @description Column main type
                      * @enum {string}
@@ -2980,6 +3005,8 @@ export interface operations {
                     readonly viewId?: number | null;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /**
                      * @description Column main type
                      * @enum {string}
@@ -3236,6 +3263,8 @@ export interface operations {
                 readonly "application/json": {
                     /** @description Title */
                     readonly title?: string | null;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /** @description Column sub type */
                     readonly subtype?: string | null;
                     /** @description Is the column mandatory */
@@ -5300,6 +5329,8 @@ export interface operations {
                     readonly baseNodeId: number;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /**
                      * Format: double
                      * @description Default value for new rows
@@ -5476,6 +5507,8 @@ export interface operations {
                     readonly baseNodeId: number;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /** @description Default */
                     readonly textDefault?: string | null;
                     /** @description Allowed regex pattern */
@@ -5642,6 +5675,8 @@ export interface operations {
                     readonly baseNodeId: number;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /** @description Json array{id: int, label: string} with options that can be selected, eg [{"id": 1, "label": "first"},{"id": 2, "label": "second"}] */
                     readonly selectionOptions: string;
                     /** @description Json int|list<int> for default selected option(s), eg 5 or ["1", "8"] */
@@ -5798,6 +5833,8 @@ export interface operations {
                     readonly baseNodeId: number;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /**
                      * @description For a subtype 'date' you can set 'today'. For a main type or subtype 'time' you can set to 'now'.
                      * @enum {string|null}
@@ -5955,6 +5992,8 @@ export interface operations {
                     readonly baseNodeId: number;
                     /** @description Title */
                     readonly title: string;
+                    /** @description Technical name of the column */
+                    readonly technicalName?: string | null;
                     /** @description Json array{id: string, type: int}, eg [{"id": "admin", "type": 0}, {"id": "user1", "type": 0}] */
                     readonly usergroupDefault?: string | null;
                     /**

--- a/tests/integration/features/APIv1.feature
+++ b/tests/integration/features/APIv1.feature
@@ -649,3 +649,23 @@ Feature: APIv1
     Then relation column "product" exists on table "secret-orders" pointing to table "secret-products" using label column "name"
     When user "participant2" fetches relations for table "secret-orders"
     Then the reported status is "404"
+
+  @api1 @columns @rows
+  Scenario: Column technicalName is returned and dataByAlias maps alias to row values
+    Given table "Alias test" with emoji "🔖" exists for user "participant1" as "base1"
+    Then column "name" exists with following properties
+      | type          | text        |
+      | subtype       | line        |
+      | mandatory     | 0           |
+      | technicalName | name        |
+    Then column "score" exists with following properties
+      | type          | number      |
+      | mandatory     | 0           |
+      | technicalName | score       |
+    Then row exists with following values
+      | name  | check1 |
+      | score | 42    |
+    Then the last created row has the following dataByAlias
+      | name  | check1 |
+      | score | 42    |
+    Then user "participant1" deletes table with keyword "Alias test"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3120,4 +3120,27 @@ class FeatureContext implements Context {
 			);
 		}
 	}
+
+	/**
+	 * @Then the last created row has the following dataByAlias
+	 *
+	 * @param TableNode $table
+	 */
+	public function theLastCreatedRowHasTheFollowingDataByAlias(TableNode $table): void {
+		$this->sendRequest(
+			'GET',
+			'/apps/tables/api/1/rows/' . $this->rowId,
+		);
+
+		$row = $this->getDataFromResponse($this->response);
+		Assert::assertEquals(200, $this->response->getStatusCode());
+		$dataByAlias = $row['dataByAlias'];
+
+		foreach ($table->getRows() as [$alias, $expectedValue]) {
+			Assert::assertArrayHasKey($alias, $dataByAlias, "Alias '$alias' not found in dataByAlias");
+			Assert::assertEquals($expectedValue, (string)$dataByAlias[$alias]['value'], "Value mismatch for alias '$alias'");
+			$columnId = $this->collectionManager->getByAlias('column', $alias)['id'];
+			Assert::assertEquals($columnId, $dataByAlias[$alias]['columnId'], "columnId mismatch for alias '$alias'");
+		}
+	}
 }

--- a/tests/unit/Service/LegacyRowMapperTest.php
+++ b/tests/unit/Service/LegacyRowMapperTest.php
@@ -138,6 +138,8 @@ class LegacyRowMapperTest extends TestCase {
 		$data2 = $row2->getData();
 
 		self::assertTrue($data === $data2);
-		self::assertTrue($legacyRow->jsonSerialize() === $row2->jsonSerialize());
+		$row2Serialized = $row2->jsonSerialize();
+		unset($row2Serialized['dataByAlias']);
+		self::assertTrue($legacyRow->jsonSerialize() === $row2Serialized);
 	}
 }

--- a/tests/unit/Validation/ColumnDtoValidatorTest.php
+++ b/tests/unit/Validation/ColumnDtoValidatorTest.php
@@ -54,6 +54,9 @@ class ColumnDtoValidatorTest extends TestCase {
 		$this->validator->validate($this->dto('test' . str_repeat('t', 197)));
 	}
 
+	/**
+	 * @dataProvider reservedNameProvider
+	 */
 	#[DataProvider('reservedNameProvider')]
 	public function testReservedTechnicalNamesAreRejected(string $name): void {
 		$this->expectException(BadRequestError::class);
@@ -72,6 +75,9 @@ class ColumnDtoValidatorTest extends TestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider invalidFormatProvider
+	 */
 	#[DataProvider('invalidFormatProvider')]
 	public function testInvalidFormatIsRejected(string $name): void {
 		$this->expectException(BadRequestError::class);
@@ -90,6 +96,9 @@ class ColumnDtoValidatorTest extends TestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider validFormatProvider
+	 */
 	#[DataProvider('validFormatProvider')]
 	public function testValidFormatIsAccepted(string $name): void {
 		$this->expectNotToPerformAssertions();

--- a/tests/unit/Validation/ColumnDtoValidatorTest.php
+++ b/tests/unit/Validation/ColumnDtoValidatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Tests\Unit\Validation;
+
+use OCA\Tables\Dto\Column as ColumnDto;
+use OCA\Tables\Errors\BadRequestError;
+use OCA\Tables\Validation\ColumnDtoValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Test\TestCase;
+
+class ColumnDtoValidatorTest extends TestCase {
+	private ColumnDtoValidator $validator;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->validator = new ColumnDtoValidator();
+	}
+
+	private function dto(?string $technicalName, ?int $textMaxLength = null, ?float $numberMin = null, ?float $numberMax = null): ColumnDto {
+		return new ColumnDto(
+			technicalName: $technicalName,
+			textMaxLength: $textMaxLength,
+			numberMin: $numberMin,
+			numberMax: $numberMax,
+		);
+	}
+
+	public function testNullTechnicalNameIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+		$this->validator->validate($this->dto(null));
+	}
+
+	public function testEmptyTechnicalNameIsRejected(): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/must not be empty/i');
+		$this->validator->validate($this->dto(''));
+	}
+
+	public function testTechnicalNameExactly200CharsIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+		$this->validator->validate($this->dto('tes' . str_repeat('t', 196)));
+	}
+
+	public function testTechnicalNameOver200CharsIsRejected(): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/maximum.*200/i');
+		$this->validator->validate($this->dto('test' . str_repeat('t', 197)));
+	}
+
+	#[DataProvider('reservedNameProvider')]
+	public function testReservedTechnicalNamesAreRejected(string $name): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/reserved/i');
+		$this->validator->validate($this->dto($name));
+	}
+
+	public static function reservedNameProvider(): array {
+		return [
+			['id'],
+			['created_by'],
+			['created_at'],
+			['last_edit_by'],
+			['last_edit_at'],
+			['data'],
+		];
+	}
+
+	#[DataProvider('invalidFormatProvider')]
+	public function testInvalidFormatIsRejected(string $name): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/start with a letter|lowercase|underscores/i');
+		$this->validator->validate($this->dto($name));
+	}
+
+	public static function invalidFormatProvider(): array {
+		return [
+			['1starts_with_digit'],
+			['_starts_with_underscore'],
+			['Has_Uppercase'],
+			['has space'],
+			['has-dash'],
+			['has.dot'],
+		];
+	}
+
+	#[DataProvider('validFormatProvider')]
+	public function testValidFormatIsAccepted(string $name): void {
+		$this->expectNotToPerformAssertions();
+		$this->validator->validate($this->dto($name));
+	}
+
+	public static function validFormatProvider(): array {
+		return [
+			['customer_name'],
+			['field1'],
+			['abc'],
+			['a123_xyz'],
+			['column_42'],
+		];
+	}
+
+	public function testNegativeTextMaxLengthIsRejected(): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/maximum text length/i');
+		$this->validator->validate($this->dto(null, textMaxLength: -1));
+	}
+
+	public function testTextMaxLengthZeroIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+		$this->validator->validate($this->dto(null, textMaxLength: 0));
+	}
+
+	public function testNumberMinGreaterThanMaxIsRejected(): void {
+		$this->expectException(BadRequestError::class);
+		$this->expectExceptionMessageMatches('/minimum number must be less/i');
+		$this->validator->validate($this->dto(null, numberMin: 10.0, numberMax: 5.0));
+	}
+
+	public function testValidNumberRangeIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+		$this->validator->validate($this->dto(null, numberMin: 0.0, numberMax: 100.0));
+	}
+}

--- a/tests/unit/Validation/ColumnDtoValidatorTest.php
+++ b/tests/unit/Validation/ColumnDtoValidatorTest.php
@@ -12,7 +12,6 @@ namespace OCA\Tables\Tests\Unit\Validation;
 use OCA\Tables\Dto\Column as ColumnDto;
 use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Validation\ColumnDtoValidator;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Test\TestCase;
 
 class ColumnDtoValidatorTest extends TestCase {
@@ -57,7 +56,6 @@ class ColumnDtoValidatorTest extends TestCase {
 	/**
 	 * @dataProvider reservedNameProvider
 	 */
-	#[DataProvider('reservedNameProvider')]
 	public function testReservedTechnicalNamesAreRejected(string $name): void {
 		$this->expectException(BadRequestError::class);
 		$this->expectExceptionMessageMatches('/reserved/i');
@@ -78,7 +76,6 @@ class ColumnDtoValidatorTest extends TestCase {
 	/**
 	 * @dataProvider invalidFormatProvider
 	 */
-	#[DataProvider('invalidFormatProvider')]
 	public function testInvalidFormatIsRejected(string $name): void {
 		$this->expectException(BadRequestError::class);
 		$this->expectExceptionMessageMatches('/start with a letter|lowercase|underscores/i');
@@ -99,7 +96,6 @@ class ColumnDtoValidatorTest extends TestCase {
 	/**
 	 * @dataProvider validFormatProvider
 	 */
-	#[DataProvider('validFormatProvider')]
 	public function testValidFormatIsAccepted(string $name): void {
 		$this->expectNotToPerformAssertions();
 		$this->validator->validate($this->dto($name));


### PR DESCRIPTION
Feature ticket: #1840 

New response structure:
```js
data: [
    {
        columnId: 70,
        value: 11
    },
    {
        columnId: 72,
        value: 3
    },
    {
        columnId: 76,
        value: [
            {
                id: user1,
                type: 0,
                displayName: user1
            }
        ]
    }
],
dataByAlias: {
    column_70: {
        columnId: 70,
        value: 11
    },
    column_72: {
        columnId: 72,
        value: 3
    },
    test_customer: {
        columnId: 76,
        value: [
            {
                id: user1,
                type: 0,
                displayName: user1
            }
        ]
    }
}
```

now we have new field added to columns called 'technical_name' which if user does not add it as default will be 'column_{id}', 'dataByAlias' added on top of 'data' not to break the current structure.
<img width="904" height="674" alt="Screenshot 2026-03-30 at 15 13 32" src="https://github.com/user-attachments/assets/056f42e4-1941-4e89-91f0-029f0c6d35e5" />
