### PR TITLE
Fix: Make case-insensitive search for the usergroup and multi selection columns

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/relation.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/relation.js
@@ -79,11 +79,11 @@ export default class RelationColumn extends AbstractColumn {
 	 * @return {boolean} Whether the filter matches
 	 */
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
-		const cellLabel = this.getLabel(cell.value)
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const cellLabel = this.getLabel(cell.value)?.toLowerCase()
 		const filterMethod = {
-			[FilterIds.Contains]() { return cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
-			[FilterIds.DoesNotContain]() { return !cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
+			[FilterIds.Contains]() { return cellLabel?.includes(filterValue) },
+			[FilterIds.DoesNotContain]() { return !cellLabel?.includes(filterValue) },
 			[FilterIds.IsEqual]() { return cellLabel === filterValue },
 			[FilterIds.IsNotEqual]() { return cellLabel !== filterValue },
 			[FilterIds.IsEmpty]() { return !cellLabel },

--- a/src/shared/components/ncTable/mixins/columnsTypes/selection.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selection.js
@@ -52,15 +52,15 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 
 	isFilterFound(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
-		const cellLabel = this.getLabel(cell.value)
+		const cellLabel = this.getLabel(cell.value)?.toLowerCase()
 		const filterMethod = {
 			[FilterIds.ContainsItem]() { return filterValue.map(option => option.id).includes(cell.value) },
-			[FilterIds.Contains]() { return cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
-			[FilterIds.DoesNotContain]() { return !cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
-			[FilterIds.BeginsWith]() { return cellLabel?.startsWith(filterValue) },
-			[FilterIds.EndsWith]() { return cellLabel?.endsWith(filterValue) },
-			[FilterIds.IsEqual]() { return cellLabel === filterValue },
-			[FilterIds.IsNotEqual]() { return cellLabel !== filterValue },
+			[FilterIds.Contains]() { return cellLabel?.includes(filterValue.toLowerCase()) },
+			[FilterIds.DoesNotContain]() { return !cellLabel?.includes(filterValue.toLowerCase()) },
+			[FilterIds.BeginsWith]() { return cellLabel?.startsWith(filterValue.toLowerCase()) },
+			[FilterIds.EndsWith]() { return cellLabel?.endsWith(filterValue.toLowerCase()) },
+			[FilterIds.IsEqual]() { return cellLabel === filterValue.toLowerCase() },
+			[FilterIds.IsNotEqual]() { return cellLabel !== filterValue.toLowerCase() },
 			[FilterIds.IsEmpty]() { return !cellLabel },
 		}[filter.operator.id]
 		return super.isFilterFound(filterMethod, cell)

--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
@@ -68,7 +68,7 @@ export default class SelectionMutliColumn extends AbstractSelectionColumn {
 
 	isFilterFound(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
-		const valueString = this.getValueString(cell)
+		const valueString = this.getValueString(cell)?.toLowerCase()
 
 		const filterMethod = {
 			[FilterIds.ContainsItem]() {
@@ -78,10 +78,10 @@ export default class SelectionMutliColumn extends AbstractSelectionColumn {
 				const filterOptionIds = filter.value.map(option => option.id)
 				return cell.value.filter(v => filterOptionIds.includes(v)).length > 0
 			},
-			[FilterIds.Contains]() { return valueString?.includes(filterValue) },
-			[FilterIds.DoesNotContain]() { return !valueString?.includes(filterValue) },
-			[FilterIds.IsEqual]() { return valueString === filterValue },
-			[FilterIds.IsNotEqual]() { return valueString !== filterValue },
+			[FilterIds.Contains]() { return valueString?.includes(filterValue.toLowerCase()) },
+			[FilterIds.DoesNotContain]() { return !valueString?.includes(filterValue.toLowerCase()) },
+			[FilterIds.IsEqual]() { return valueString === filterValue.toLowerCase() },
+			[FilterIds.IsNotEqual]() { return valueString !== filterValue.toLowerCase() },
 			[FilterIds.IsEmpty]() { return !valueString },
 		}[filter.operator.id]
 		return super.isFilterFound(filterMethod, cell)

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
@@ -52,7 +52,7 @@ export default class TextLinkColumn extends AbstractTextColumn {
 	}
 
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
 		const value = this.getValueFromCellValue(cell.value)
 
 		const filterMethod = {

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
@@ -52,8 +52,8 @@ export default class TextLinkColumn extends AbstractTextColumn {
 	}
 
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
-		const value = this.getValueFromCellValue(cell.value)
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const value = this.getValueFromCellValue(cell.value).toLowerCase()
 
 		const filterMethod = {
 			[FilterIds.Contains]() { return value.includes(filterValue) },

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
@@ -22,11 +22,12 @@ export default class TextLongColumn extends AbstractTextColumn {
 	}
 
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const cellValue = cell.value.toLowerCase()
 
 		const filterMethod = {
-			[FilterIds.Contains]() { return cell.value.includes(filterValue) },
-			[FilterIds.DoesNotContain]() { return !cell.value.includes(filterValue) },
+			[FilterIds.Contains]() { return cellValue && cellValue.includes(filterValue) },
+			[FilterIds.DoesNotContain]() { return cellValue && !cellValue.includes(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
 		}[filter.operator.id]
 		return super.isFilterFound(filterMethod, cell)

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
@@ -22,11 +22,12 @@ export default class TextLongColumn extends AbstractTextColumn {
 	}
 
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const cellValue = cell.value?.toLowerCase()
 
 		const filterMethod = {
-			[FilterIds.Contains]() { return cell.value.includes(filterValue) },
-			[FilterIds.DoesNotContain]() { return !cell.value.includes(filterValue) },
+			[FilterIds.Contains]() { return cellValue && cellValue.includes(filterValue) },
+			[FilterIds.DoesNotContain]() { return cellValue && !cellValue.includes(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
 		}[filter.operator.id]
 		return super.isFilterFound(filterMethod, cell)

--- a/src/shared/components/ncTable/mixins/columnsTypes/textRich.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textRich.js
@@ -18,11 +18,12 @@ export default class TextRichColumn extends AbstractTextColumn {
 	}
 
 	isFilterFound(cell, filter) {
-		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const cellValue = cell.value?.toLowerCase()
 
 		const filterMethod = {
-			[FilterIds.Contains]() { return cell.value && cell.value.includes(filterValue) },
-			[FilterIds.DoesNotContain]() { return cell.value && !cell.value.includes(filterValue) },
+			[FilterIds.Contains]() { return cellValue && cellValue.includes(filterValue) },
+			[FilterIds.DoesNotContain]() { return cellValue && !cellValue.includes(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
 		}[filter.operator.id]
 		return super.isFilterFound(filterMethod, cell)

--- a/src/shared/components/ncTable/mixins/columnsTypes/usergroup.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/usergroup.js
@@ -4,6 +4,7 @@
  */
 import { AbstractUsergroupColumn } from '../columnClass.js'
 import { ColumnTypes } from '../columnHandler.js'
+import { FilterIds } from '../filter.js'
 
 export default class UsergroupColumn extends AbstractUsergroupColumn {
 
@@ -42,6 +43,20 @@ export default class UsergroupColumn extends AbstractUsergroupColumn {
 
 	isSearchStringFound(cell, searchString) {
 		return super.isSearchStringFound(this.getValueString(cell), cell, searchString)
+	}
+
+	isFilterFound(cell, filter) {
+		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
+		const valueString = this.getValueString(cell).toLowerCase()
+
+		const filterMethod = {
+			[FilterIds.Contains]() { return valueString?.includes(filterValue) },
+			[FilterIds.DoesNotContain]() { return !valueString?.includes(filterValue) },
+			[FilterIds.IsEqual]() { return valueString === filterValue },
+			[FilterIds.IsNotEqual]() { return valueString !== filterValue },
+			[FilterIds.IsEmpty]() { return !valueString },
+		}[filter.operator.id]
+		return super.isFilterFound(filterMethod, cell)
 	}
 
 }

--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -374,8 +374,8 @@ export default {
 				const columnFilters = this.getFilterForColumn(this.column)
 				if (columnFilters && columnFilters
 					.filter(fil => fil.operator.id === this.selectedOperator.id)
-					.map(fil => fil.value)
-					.includes(this.searchValue)) {
+					.map(fil => fil.value.toLowerCase())
+					.includes(this.searchValue.toLowerCase())) {
 					this.reset()
 					return
 				}


### PR DESCRIPTION
This is a follow-up for the #1798. It spreads same logic what we have in text line type to other column types. So, now everything is case insensitive.

It also fixes filters for usergroup single selection

## :radio_button: Single selection
| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/97cd9d05-562f-45bd-aa25-d80de8495faa" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4e40e134-a1fb-4b46-883b-d483a51673af" /> |

## :ballot_box_with_check: Multi selection
| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/4f126a44-0d93-4d0a-a895-f03760bf3ce1" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/38c2802f-52ad-4e85-8dda-b72f30452c36" /> |


## :bust_in_silhouette: User single selection
| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/c4286c4c-8827-4b38-ab5f-13eea2d404e7" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/a68be739-3877-46f5-90d4-46afc33d3e08" /> |


## :busts_in_silhouette: User multi selection
| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/8f422564-9003-4749-b510-81edda1c4f4c" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/20b451db-4d3c-4dc9-a6ed-e77375c810d6" /> |
