### PR TITLE
refactor: Refactor filter methods to prevent errors in new columns

### DIFF
--- a/src/shared/components/ncTable/mixins/columnClass.js
+++ b/src/shared/components/ncTable/mixins/columnClass.js
@@ -58,7 +58,15 @@ export class AbstractColumn {
 		return false
 	}
 
-	isFilterFound(filterMethod, cell) {
+	getFilterMethods(cell, filter) {
+		throw new Error(`getFilterMethods() must be implemented by ${this.constructor.name}`)
+	}
+
+	isFilterFound(cell, filter) {
+		const filterMethod = this.getFilterMethods(cell, filter)[filter.operator.id]
+		if (!filterMethod) {
+			throw new Error(`No filter method found for column ${this.constructor.name} and operator ${filter.operator.id}`)
+		}
 		if (filterMethod()) {
 			cell.filterFound = true
 			return true

--- a/src/shared/components/ncTable/mixins/columnsTypes/datetime.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/datetime.js
@@ -57,12 +57,12 @@ export default class DatetimeColumn extends AbstractDatetimeColumn {
 		return super.isSearchStringFound(date, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const filterDate = new Moment(filterValue, 'YYYY-MM-DD HH:mm')
 		const valueDate = new Moment(cell.value, 'YYYY-MM-DD HH:mm')
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return filterDate.isSame(valueDate) },
 			[FilterIds.IsNotEqual]() { return !filterDate.isSame(valueDate) },
 			[FilterIds.IsGreaterThan]() { return filterDate.isBefore(valueDate) },
@@ -70,8 +70,7 @@ export default class DatetimeColumn extends AbstractDatetimeColumn {
 			[FilterIds.IsLowerThan]() { return filterDate.isAfter(valueDate) },
 			[FilterIds.IsLowerThanOrEqual]() { return filterDate.isSameOrAfter(valueDate) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/datetimeDate.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/datetimeDate.js
@@ -43,12 +43,12 @@ export default class DatetimeDateColumn extends AbstractDatetimeColumn {
 		return super.isSearchStringFound(date, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const filterDate = new Moment(filterValue)
 		const valueDate = new Moment(cell.value)
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return filterDate.isSame(valueDate) },
 			[FilterIds.IsNotEqual]() { return !filterDate.isSame(valueDate) },
 			[FilterIds.IsGreaterThan]() { return filterDate.isBefore(valueDate) },
@@ -56,8 +56,7 @@ export default class DatetimeDateColumn extends AbstractDatetimeColumn {
 			[FilterIds.IsLowerThan]() { return filterDate.isAfter(valueDate) },
 			[FilterIds.IsLowerThanOrEqual]() { return filterDate.isSameOrAfter(valueDate) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/datetimeTime.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/datetimeTime.js
@@ -43,12 +43,12 @@ export default class DatetimeTimeColumn extends AbstractDatetimeColumn {
 		return super.isSearchStringFound(time, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const filterTime = new Moment(filterValue, 'HH:mm')
 		const valueTime = new Moment(cell.value, 'HH:mm')
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return filterTime.isSame(valueTime) },
 			[FilterIds.IsNotEqual]() { return !filterTime.isSame(valueTime) },
 			[FilterIds.IsGreaterThan]() { return filterTime.isBefore(valueTime) },
@@ -56,8 +56,7 @@ export default class DatetimeTimeColumn extends AbstractDatetimeColumn {
 			[FilterIds.IsLowerThan]() { return filterTime.isAfter(valueTime) },
 			[FilterIds.IsLowerThanOrEqual]() { return filterTime.isSameOrAfter(valueTime) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/number.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/number.js
@@ -45,10 +45,10 @@ export default class NumberColumn extends AbstractNumberColumn {
 		return super.isSearchStringFound(('' + cell.value), cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return parseInt(cell.value) === parseInt(filterValue) },
 			[FilterIds.IsNotEqual]() { return parseInt(cell.value) !== parseInt(filterValue) },
 			[FilterIds.IsGreaterThan]() { return parseInt(cell.value) > parseInt(filterValue) },
@@ -56,8 +56,7 @@ export default class NumberColumn extends AbstractNumberColumn {
 			[FilterIds.IsLowerThan]() { return parseInt(cell.value) < parseInt(filterValue) },
 			[FilterIds.IsLowerThanOrEqual]() { return parseInt(cell.value) <= parseInt(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 	parseValue(value) {

--- a/src/shared/components/ncTable/mixins/columnsTypes/numberProgress.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/numberProgress.js
@@ -28,10 +28,10 @@ export default class NumberProgressColumn extends AbstractNumberColumn {
 		return super.isSearchStringFound(('' + cell.value), cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return parseInt(cell.value) === parseInt(filterValue) },
 			[FilterIds.IsNotEqual]() { return parseInt(cell.value) !== parseInt(filterValue) },
 			[FilterIds.IsGreaterThan]() { return parseInt(cell.value) > parseInt(filterValue) },
@@ -39,8 +39,7 @@ export default class NumberProgressColumn extends AbstractNumberColumn {
 			[FilterIds.IsLowerThan]() { return parseInt(cell.value) < parseInt(filterValue) },
 			[FilterIds.IsLowerThanOrEqual]() { return parseInt(cell.value) <= parseInt(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 	parseValue(value) {

--- a/src/shared/components/ncTable/mixins/columnsTypes/numberStars.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/numberStars.js
@@ -28,10 +28,10 @@ export default class NumberStarsColumn extends AbstractNumberColumn {
 		return super.isSearchStringFound(('' + cell.value), cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return parseInt(cell.value ? cell.value : 0) === parseInt(filterValue) },
 			[FilterIds.IsNotEqual]() { return parseInt(cell.value ? cell.value : 0) !== parseInt(filterValue) },
 			[FilterIds.IsGreaterThan]() { return parseInt(cell.value ? cell.value : 0) > parseInt(filterValue) },
@@ -39,8 +39,7 @@ export default class NumberStarsColumn extends AbstractNumberColumn {
 			[FilterIds.IsLowerThan]() { return parseInt(cell.value ? cell.value : 0) < parseInt(filterValue) },
 			[FilterIds.IsLowerThanOrEqual]() { return parseInt(cell.value ? cell.value : 0) <= parseInt(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/selection.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selection.js
@@ -50,10 +50,11 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 		return super.isSearchStringFound(this.getLabel(cell.value), cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const cellLabel = this.getLabel(cell.value)
-		const filterMethod = {
+
+		return {
 			[FilterIds.Contains]() { return cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
 			[FilterIds.DoesNotContain]() { return !cellLabel?.toLowerCase().includes(filterValue?.toLowerCase()) },
 			[FilterIds.BeginsWith]() { return cellLabel?.startsWith(filterValue) },
@@ -61,8 +62,7 @@ export default class SelectionColumn extends AbstractSelectionColumn {
 			[FilterIds.IsEqual]() { return cellLabel === filterValue },
 			[FilterIds.IsNotEqual]() { return cellLabel !== filterValue },
 			[FilterIds.IsEmpty]() { return !cellLabel },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 	parseValue(value) {

--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionCheck.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionCheck.js
@@ -28,7 +28,7 @@ export default class SelectionCheckColumn extends AbstractSelectionColumn {
 		return false
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ?? filter.value
 
 		// Normalize cell value to boolean
@@ -49,12 +49,11 @@ export default class SelectionCheckColumn extends AbstractSelectionColumn {
 			filterBoolean = Boolean(filterValue)
 		}
 
-		const filterMethod = {
+		return {
 			[FilterIds.IsEqual]() { return cellBoolean === filterBoolean },
 			[FilterIds.IsNotEqual]() { return cellBoolean !== filterBoolean },
 			[FilterIds.IsEmpty]() { return cell.value === null || cell.value === undefined || cell.value === '' },
-		}[filter.operator.id]
-		return filterMethod ? filterMethod() : super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionMulti.js
@@ -66,18 +66,17 @@ export default class SelectionMutliColumn extends AbstractSelectionColumn {
 		return super.isSearchStringFound(this.getValueString(cell), cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const valueString = this.getValueString(cell)
 
-		const filterMethod = {
-			[FilterIds.Contains]() { return valueString?.includes(filterValue) },
-			[FilterIds.DoesNotContain]() { return !valueString?.includes(filterValue) },
+		return {
+			[FilterIds.Contains]() { return valueString?.toLowerCase().includes(filterValue.toLowerCase()) },
+			[FilterIds.DoesNotContain]() { return !valueString?.toLowerCase().includes(filterValue.toLowerCase()) },
 			[FilterIds.IsEqual]() { return valueString === filterValue },
 			[FilterIds.IsNotEqual]() { return valueString !== filterValue },
 			[FilterIds.IsEmpty]() { return !valueString },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLine.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLine.js
@@ -41,11 +41,12 @@ export default class TextLineColumn extends AbstractTextColumn {
 		return super.isSearchStringFound(cell.value, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = (filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value).toLowerCase()
 		const cellValue = cell.value?.toLowerCase()
-		if (!cellValue & filter.operator.id !== FilterIds.IsEmpty) return false
-		const filterMethod = {
+		if (!cellValue && filter.operator.id !== FilterIds.IsEmpty) return {}
+
+		return {
 			[FilterIds.Contains]() { return cellValue.includes(filterValue) },
 			[FilterIds.DoesNotContain]() { return !cellValue.includes(filterValue) },
 			[FilterIds.BeginsWith]() { return cellValue.startsWith(filterValue) },
@@ -53,10 +54,7 @@ export default class TextLineColumn extends AbstractTextColumn {
 			[FilterIds.IsEqual]() { return cellValue === filterValue },
 			[FilterIds.IsNotEqual]() { return cellValue !== filterValue },
 			[FilterIds.IsEmpty]() { return !cellValue },
-		}[filter.operator.id]
-
-		return super.isFilterFound(filterMethod, cell)
-
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLink.js
@@ -51,11 +51,11 @@ export default class TextLinkColumn extends AbstractTextColumn {
 		return super.isSearchStringFound(cell.value, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 		const value = this.getValueFromCellValue(cell.value)
 
-		const filterMethod = {
+		return {
 			[FilterIds.Contains]() { return value.includes(filterValue) },
 			[FilterIds.DoesNotContain]() { return !value.includes(filterValue) },
 			[FilterIds.BeginsWith]() { return value.startsWith(filterValue) },
@@ -63,8 +63,7 @@ export default class TextLinkColumn extends AbstractTextColumn {
 			[FilterIds.IsEqual]() { return value === filterValue },
 			[FilterIds.IsNotEqual]() { return value !== filterValue },
 			[FilterIds.IsEmpty]() { return !value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textLong.js
@@ -21,15 +21,14 @@ export default class TextLongColumn extends AbstractTextColumn {
 		return super.isSearchStringFound(cell.value, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-		const filterMethod = {
+		return {
 			[FilterIds.Contains]() { return cell.value.includes(filterValue) },
 			[FilterIds.DoesNotContain]() { return !cell.value.includes(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/textRich.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/textRich.js
@@ -17,15 +17,14 @@ export default class TextRichColumn extends AbstractTextColumn {
 		return super.isSearchStringFound(cell.value, cell, searchString)
 	}
 
-	isFilterFound(cell, filter) {
+	getFilterMethods(cell, filter) {
 		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
 
-		const filterMethod = {
+		return {
 			[FilterIds.Contains]() { return cell.value && cell.value.includes(filterValue) },
 			[FilterIds.DoesNotContain]() { return cell.value && !cell.value.includes(filterValue) },
 			[FilterIds.IsEmpty]() { return !cell.value },
-		}[filter.operator.id]
-		return super.isFilterFound(filterMethod, cell)
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/mixins/columnsTypes/usergroup.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/usergroup.js
@@ -4,6 +4,7 @@
  */
 import { AbstractUsergroupColumn } from '../columnClass.js'
 import { ColumnTypes } from '../columnHandler.js'
+import { FilterIds } from '../filter.js'
 
 export default class UsergroupColumn extends AbstractUsergroupColumn {
 
@@ -29,7 +30,7 @@ export default class UsergroupColumn extends AbstractUsergroupColumn {
 				ret += ', ' + obj.id
 			}
 		})
-		return ret
+		return ret.toLowerCase()
 	}
 
 	getObjects(values) {
@@ -42,6 +43,19 @@ export default class UsergroupColumn extends AbstractUsergroupColumn {
 
 	isSearchStringFound(cell, searchString) {
 		return super.isSearchStringFound(this.getValueString(cell), cell, searchString)
+	}
+
+	getFilterMethods(cell, filter) {
+		const filterValue = filter.magicValuesEnriched ? filter.magicValuesEnriched : filter.value
+		const valueString = this.getValueString(cell)
+
+		return {
+			[FilterIds.Contains]() { return valueString?.toLowerCase().includes(filterValue.toLowerCase()) },
+			[FilterIds.DoesNotContain]() { return !valueString?.toLowerCase().includes(filterValue.toLowerCase()) },
+			[FilterIds.IsEqual]() { return valueString === filterValue },
+			[FilterIds.IsNotEqual]() { return valueString !== filterValue },
+			[FilterIds.IsEmpty]() { return !valueString },
+		}
 	}
 
 }

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -259,10 +259,10 @@ export default {
 
 					// if we should filter
 					if (filters !== null) {
-						filters.forEach(fil => {
-							this.addMagicFieldsValues(fil)
+						filters.forEach(filter => {
+							this.addMagicFieldsValues(filter)
 							if (filterStatus === null || filterStatus === true) {
-								filterStatus = column.isFilterFound(cell, fil)
+								filterStatus = column.isFilterFound(cell, filter)
 							}
 						})
 					}


### PR DESCRIPTION
During work on #2446 I've realized that we've just forgot to implement `isFilterFound` for `UsergroupColumn`. Also we have some boilerplate dupliction in every column class. Let's reafactor code a bit in order to detect earlier that filter is missing for column