### PR TITLE
Direct leakage of backend exception details in general index endpoint

### DIFF
--- a/lib/Controller/ApiGeneralController.php
+++ b/lib/Controller/ApiGeneralController.php
@@ -47,7 +47,7 @@ class ApiGeneralController extends AOCSController {
 	 *
 	 * Tables and views incl. shares
 	 *
-	 * @return DataResponse<Http::STATUS_OK, TablesIndex, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, TablesIndex, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string, code: string}, array{}>
 	 *
 	 * 200: Index returned
 	 */
@@ -59,7 +59,7 @@ class ApiGeneralController extends AOCSController {
 			return new DataResponse([ 'tables' => $tables, 'views' => $views ]);
 		} catch (InternalError|Exception $e) {
 			$this->logger->error('An internal error or exception occurred: ' . $e->getMessage(), ['exception' => $e]);
-			$message = ['message' => $e->getMessage()];
+			$message = ['message' => 'An internal error occurred', 'code' => 'internal_error'];
 			return new DataResponse($message, Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}


### PR DESCRIPTION
## Summary

Security: Direct leakage of backend exception details in general index endpoint

## Problem

**Severity**: `Medium` | **File**: `lib/Controller/ApiGeneralController.php:L62`

The `index()` method catches `InternalError|Exception` and returns `$e->getMessage()` in the response body. This duplicates information-disclosure behavior and may reveal backend internals to authenticated users (or broader audiences depending on route exposure).

## Solution

Replace returned exception text with a generic message and a stable error code. Keep detailed error context in logs only. Consider reusing a centralized sanitizer in the error-handling layer to prevent regressions.

## Changes

- `lib/Controller/ApiGeneralController.php` (modified)