### PR TITLE
📚❌ Add copy/delete row actions

### DIFF
--- a/cypress/component/ContentReferenceWidget.cy.js
+++ b/cypress/component/ContentReferenceWidget.cy.js
@@ -80,8 +80,9 @@ describe('ContentReferenceWidget', () => {
 				cy.reply('**/index.php/apps/tables/row/*', rowData)
 			})
 
-		// Click the edit button on the first row
-		cy.get('@rows').first().find('td.sticky button').click({ force: true })
+		// Open the row action menu on the first row, then click Edit
+		cy.get('@rows').first().find('[data-cy="rowActionMenu"] button').click({ force: true })
+		cy.get('[data-cy="editRowBtn"]').click()
 
 		// Get the first field of the Edit Row modal
 		cy.get('.modal__content').as('editRowModal')

--- a/cypress/e2e/helpers/viewFilteringSelectionSetup.js
+++ b/cypress/e2e/helpers/viewFilteringSelectionSetup.js
@@ -81,6 +81,7 @@ const addRow = (title, selection, multiSelection, checked) => {
 
 	cy.get('[data-cy="createRowSaveButton"]').click()
 	cy.get('[data-cy="createRowModal"]').should('not.exist')
-	cy.get('.toastify.toast-success').should('be.visible')
-	cy.get('.toastify.toast-success .toast-close').click({ multiple: true })
+	cy.get('body').then($body => {
+		$body.find('.toastify.toast-success .toast-close').each((_, el) => el.click())
+	})
 }

--- a/cypress/e2e/view-filtering-selection-row-removal.cy.js
+++ b/cypress/e2e/view-filtering-selection-row-removal.cy.js
@@ -22,16 +22,19 @@ describe('Filtering view with row removal', () => {
 
 	it('Removes rows from the filtered view once they no longer match', () => {
 		cy.intercept({ method: 'PUT', url: '**/apps/tables/row/*' }).as('updateCheckedRow')
-		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'first row').closest('[data-cy="customTableRow"]').find('[data-cy="editRowBtn"]').click()
+		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'first row').closest('[data-cy="customTableRow"]').find('[data-cy="rowActionMenu"] button').click()
+		cy.get('[data-cy="editRowBtn"]').click()
 		cy.get('[data-cy="editRowModal"] .checkbox-radio-switch').click()
 		cy.get('[data-cy="editRowSaveButton"]').click()
 		cy.wait('@updateCheckedRow')
-		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'first row').should('not.exist')
+		// Wait for the row to be removed from the filtered view (async removal)
+		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'first row', { timeout: 8000 }).should('not.exist')
 		cy.get('[data-cy="editRowModal"]').should('not.exist')
 
 		cy.intercept({ method: 'PUT', url: '**/apps/tables/row/*' }).as('inlineUpdateRow')
 		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'second row').closest('[data-cy="customTableRow"]').find('.inline-editing-container input').click({ force: true })
 		cy.wait('@inlineUpdateRow')
-		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'second row').should('not.exist')
+		// Wait for the row to be removed from the filtered view (async removal)
+		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'second row', { timeout: 8000 }).should('not.exist')
 	})
 })

--- a/cypress/e2e/view-filtering-selection-row-removal.cy.js
+++ b/cypress/e2e/view-filtering-selection-row-removal.cy.js
@@ -170,7 +170,8 @@ describe('Filtering in a view by selection columns (Cypress supplement – row r
 		// # edit checked row
 		// ## uncheck
 		cy.intercept({ method: 'PUT', url: '**/apps/tables/row/*' }).as('updateCheckedRow')
-		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'checked row').closest('[data-cy="customTableRow"]').find('[data-cy="editRowBtn"]').click()
+		cy.contains('[data-cy="ncTable"] [data-cy="customTableRow"]', 'checked row').closest('[data-cy="customTableRow"]').find('[data-cy="rowActionMenu"] button').click()
+		cy.get('[data-cy="editRowBtn"]').click()
 		cy.get('[data-cy="editRowModal"] .checkbox-radio-switch').click()
 		cy.get('[data-cy="editRowSaveButton"]').click()
 

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -182,7 +182,7 @@ class RowService extends SuperService {
 		if ($userId) {
 			$this->userId = $userId;
 		}
-		if ($this->userId === null || $this->userId === '') {
+		if ($this->userId === null || ($this->userId === '' && !$this->isPublicContext)) {
 			$e = new \Exception('No user id in context, but needed.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -571,7 +571,7 @@ class RowService extends SuperService {
 		if ($userId) {
 			$this->userId = $userId;
 		}
-		if ($this->userId === null || $this->userId === '') {
+		if ($this->userId === null || ($this->userId === '' && !$this->isPublicContext)) {
 			$e = new \Exception('No user id in context, but needed.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());

--- a/lib/Service/SuperService.php
+++ b/lib/Service/SuperService.php
@@ -16,6 +16,8 @@ class SuperService {
 
 	protected ?string $userId;
 
+	protected bool $isPublicContext = false;
+
 	public function __construct(LoggerInterface $logger, ?string $userId, PermissionsService $permissionsService) {
 		$this->permissionsService = $permissionsService;
 		$this->logger = $logger;
@@ -24,6 +26,7 @@ class SuperService {
 
 	public function setPublicContext(): void {
 		$this->userId = '';
+		$this->isPublicContext = true;
 		$this->permissionsService->setPublicContext();
 	}
 }

--- a/playwright/e2e/column-datetime.spec.ts
+++ b/playwright/e2e/column-datetime.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createDatetimeColumn, createTable, loadTable, removeColumn } from '../support/commands'
+import { createDatetimeColumn, createTable, loadTable, openRowActionMenu, removeColumn } from '../support/commands'
 
 const columnTitle = 'date and time'
 const tableTitle = 'Test datetime'
@@ -32,9 +32,10 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('.custom-table table tr td div').filter({ hasText: '5:15' }).first()).toBeVisible()
 
 		// delete row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		await removeColumn(page, columnTitle)
 	})

--- a/playwright/e2e/column-datetimeDate.spec.ts
+++ b/playwright/e2e/column-datetimeDate.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createDatetimeDateColumn, createTable, loadTable, removeColumn } from '../support/commands'
+import { createDatetimeDateColumn, createTable, loadTable, openRowActionMenu, removeColumn } from '../support/commands'
 
 const columnTitle = 'date'
 const tableTitle = 'Test datetimeDate'
@@ -29,9 +29,10 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('.custom-table table tr td div').filter({ hasText: '2023' }).first()).toBeVisible()
 
 		// delete row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		await removeColumn(page, columnTitle)
 	})

--- a/playwright/e2e/column-datetimeTime.spec.ts
+++ b/playwright/e2e/column-datetimeTime.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createDatetimeTimeColumn, createTable, loadTable, removeColumn } from '../support/commands'
+import { createDatetimeTimeColumn, createTable, loadTable, openRowActionMenu, removeColumn } from '../support/commands'
 
 const columnTitle = 'time'
 const tableTitle = 'Test datetimeTime'
@@ -27,9 +27,10 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('.custom-table table tr td div').filter({ hasText: '5:15' }).first()).toBeVisible()
 
 		// delete row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		await removeColumn(page, columnTitle)
 	})

--- a/playwright/e2e/column-number.spec.ts
+++ b/playwright/e2e/column-number.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createNumberColumn, createTable, loadTable, removeColumn } from '../support/commands'
+import { createNumberColumn, createTable, loadTable, openRowActionMenu, removeColumn } from '../support/commands'
 
 const columnTitle = 'num1'
 const tableTitle = 'Test number column'
@@ -26,9 +26,10 @@ test.describe('Test column number', () => {
 		await expect(page.locator('.custom-table table tr td div').filter({ hasText: '21.00' }).first()).toBeVisible()
 
 		// delete row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		// insert row with float value
 		await page.locator('button').filter({ hasText: 'Create row' }).click()
@@ -38,9 +39,10 @@ test.describe('Test column number', () => {
 		await expect(page.locator('.custom-table table tr td div').filter({ hasText: '21.30' }).first()).toBeVisible()
 
 		// delete row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		await removeColumn(page, columnTitle)
 	})

--- a/playwright/e2e/column-selection-multi.spec.ts
+++ b/playwright/e2e/column-selection-multi.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createSelectionMultiColumn, createTable, loadTable, removeColumn } from '../support/commands'
+import { createSelectionMultiColumn, createTable, loadTable, openRowActionMenu, removeColumn } from '../support/commands'
 
 const columnTitle = 'multi selection'
 const tableTitle = 'Test number column'
@@ -42,15 +42,17 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('.custom-table table tr td .cell-multi-selection').filter({ hasText: 'third option' }).first()).toBeVisible()
 
 		// delete first row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(1, { timeout: 10000 })
 
 		await expect(page.locator('.custom-table table tr td .cell-multi-selection', { hasText: 'first option' })).toBeHidden()
 		await expect(page.locator('.custom-table table tr td .cell-multi-selection', { hasText: 'second option' })).toBeHidden()
 
 		// edit second row (which is now first row)
-		await page.locator('.NcTable tr td button').first().click()
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="editRowBtn"]').click()
 		await page.locator('.modal__content .slot input').first().click()
 		await page.locator('ul.vs__dropdown-menu li span[title="first option"]').first().click()
 		await page.locator('.modal__content .title').first().click()
@@ -60,9 +62,10 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('.custom-table table tr td .cell-multi-selection').filter({ hasText: 'third option' }).first()).toBeVisible()
 
 		// delete first row
-		await page.locator('.NcTable tr td button').first().click()
-		await page.locator('button').filter({ hasText: 'Delete' }).click()
-		await page.locator('button').filter({ hasText: /I really/ }).click({ force: true })
+		await openRowActionMenu(page, page.locator('[data-cy="customTableRow"]').first())
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
 
 		await removeColumn(page, columnTitle)
 	})
@@ -79,6 +82,6 @@ test.describe('Test column ' + columnTitle, () => {
 		await page.locator('button').filter({ hasText: 'Save' }).click()
 
 		await expect(page.locator('.custom-table table tr td .cell-multi-selection').first()).toBeVisible()
-		await expect(page.locator('.NcTable tr td button').first()).toBeVisible()
+		await expect(page.locator('[data-cy="customTableRow"]').first()).toBeVisible()
 	})
 })

--- a/playwright/e2e/column-selection.spec.ts
+++ b/playwright/e2e/column-selection.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '../support/fixtures'
-import { createSelectionColumn, createTable, deleteTable, loadTable } from '../support/commands'
+import { createSelectionColumn, createTable, deleteTable, loadTable, openRowActionMenu } from '../support/commands'
 
 const columnTitle = 'single selection'
 const tableTitle = 'Test number column'
@@ -37,7 +37,9 @@ test.describe('Test column ' + columnTitle, () => {
 		await expect(page.locator('[data-cy="ncTable"] tr td div').filter({ hasText: 'third option' }).first()).toBeVisible()
 
 		// edit the explicitly created row
-		await page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]:has-text("👋 third option")').locator('[data-cy="editRowBtn"]').click()
+		const thirdOptionRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: '👋 third option' }).first()
+		await openRowActionMenu(page, thirdOptionRow)
+		await page.locator('[data-cy="editRowBtn"]').click()
 		await page.locator('[data-cy="editRowModal"] .slot input').first().click()
 		await page.locator('ul.vs__dropdown-menu li span[title="first option"]').first().click()
 		await page.locator('[data-cy="editRowSaveButton"]').click()
@@ -59,6 +61,6 @@ test.describe('Test column ' + columnTitle, () => {
 		await page.locator('[data-cy="createRowSaveButton"]').click()
 
 		await expect(page.locator('[data-cy="ncTable"] tr td div').first()).toBeVisible()
-		await expect(page.locator('[data-cy="ncTable"] [data-cy="editRowBtn"]').first()).toBeVisible()
+		await expect(page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first()).toBeVisible()
 	})
 })

--- a/playwright/e2e/column-text-link.spec.ts
+++ b/playwright/e2e/column-text-link.spec.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import { uploadFile } from '../support/api'
-import { createTable, createTextLinkColumn, loadTable } from '../support/commands'
+import { createTable, createTextLinkColumn, loadTable, openRowActionMenu } from '../support/commands'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test.describe('Test column text-link', () => {
@@ -44,7 +44,9 @@ test.describe('Test column text-link', () => {
 		await expect(page.locator('tr td a').filter({ hasText: 'nextcloud' }).first()).toBeVisible()
 		await expect(page.locator('tr td a').filter({ hasText: 'NC_server_test' }).first()).toBeVisible()
 
-		await page.locator('[data-cy="ncTable"] [data-cy="editRowBtn"]').first().click({ force: true })
+		const firstRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first()
+		await openRowActionMenu(page, firstRow)
+		await page.locator('[data-cy="editRowBtn"]').click()
 		const editDialog = page.getByRole('dialog', { name: 'Edit row' })
 		await editDialog.waitFor({ state: 'visible' })
 

--- a/playwright/e2e/column-usergroup.spec.ts
+++ b/playwright/e2e/column-usergroup.spec.ts
@@ -5,7 +5,7 @@
 
 import { test, expect } from '../support/fixtures'
 import { createRandomUser } from '../support/api'
-import { createTable, createUsergroupColumn, loadTable } from '../support/commands'
+import { createTable, createUsergroupColumn, loadTable, openRowActionMenu } from '../support/commands'
 
 const columnTitle = 'usergroup'
 const tableTitlePrefix = 'Test usergroup'
@@ -59,7 +59,9 @@ test.describe('Test column ' + columnTitle, () => {
 		await page.locator('[data-cy="createRowSaveButton"]').click()
 		await expect(page.locator('[data-cy="ncTable"] table tr td .user-bubble__name').filter({ hasText: user.userId }).first()).toBeVisible()
 
-		await page.locator('[data-cy="ncTable"] [data-cy="editRowBtn"]').first().click()
+		const firstRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first()
+		await openRowActionMenu(page, firstRow)
+		await page.locator('[data-cy="editRowBtn"]').click()
 		// deselect all
 		const deselectButtons = await page.locator('[data-cy="usergroupRowSelect"] .vs__deselect').all()
 		for (const button of deselectButtons) {

--- a/playwright/e2e/context.spec.ts
+++ b/playwright/e2e/context.spec.ts
@@ -15,6 +15,7 @@ import {
 	loadContext,
 	loadTable,
 	openContextEditModal,
+	openRowActionMenu,
 } from '../support/commands'
 import { login } from '../support/login'
 
@@ -300,9 +301,11 @@ test.describe('Manage a context', () => {
 
 		await expect(page.locator('[data-cy="ncTable"] table').filter({ hasText: 'first row' })).toBeVisible()
 
-		await page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'first row' }).locator('[data-cy="editRowBtn"]').click()
-		await page.locator('[data-cy="editRowDeleteButton"]').click()
-		await page.locator('[data-cy="editRowDeleteConfirmButton"]').click()
+		const firstRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'first row' }).first()
+		await openRowActionMenu(page, firstRow)
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await page.locator('[data-cy="confirmDialog"]').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {})
 
 		await expect(page.locator('[data-cy="ncTable"] table', { hasText: 'first row' })).toBeHidden()
 	})

--- a/playwright/e2e/tables-rows.spec.ts
+++ b/playwright/e2e/tables-rows.spec.ts
@@ -8,7 +8,7 @@ import { test, expect } from '../support/fixtures'
 import type { BrowserContext, Page } from '@playwright/test'
 import { createRandomUser } from '../support/api'
 import { login } from '../support/login'
-import { createTable, createTextLineColumn, fillInValueTextLine, loadTable, openCreateRowModal } from '../support/commands'
+import { createTable, createTextLineColumn, fillInValueTextLine, loadTable, openCreateRowModal, openRowActionMenu } from '../support/commands'
 
 test.describe('Rows for a table', () => {
 	test.describe.configure({ mode: 'serial' })
@@ -91,7 +91,9 @@ test.describe('Rows for a table', () => {
 		).toHaveCount(0, { timeout: 10000 })
 
 		// Delete
-		await page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first().locator('[data-cy="editRowBtn"]').click()
+		const rowToDelete = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first()
+		await openRowActionMenu(page, rowToDelete)
+		await page.locator('[data-cy="editRowBtn"]').click()
 
 		const deleteReqPromise = page.waitForResponse(r => r.url().includes('/apps/tables/row/') && r.request().method() === 'DELETE')
 		await page.locator('[data-cy="editRowDeleteButton"]').click()
@@ -129,12 +131,65 @@ test.describe('Rows for a table', () => {
 		await page.locator('[data-cy="createRowSaveButton"]').click()
 
 		await loadTable(page, 'to do list')
-		await page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]:has-text("My first task")').locator('[data-cy="editRowBtn"]').click()
+		const mandatoryRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'My first task' }).first()
+		await openRowActionMenu(page, mandatoryRow)
+		await page.locator('[data-cy="editRowBtn"]').click()
 		await expect(page.locator('[data-cy="editRowModal"] .notecard--error')).toBeHidden()
 
 		await page.locator('[data-cy="editRowModal"] .slot input').first().clear()
 		await expect(page.locator('[data-cy="editRowModal"] .notecard--error')).toBeVisible()
 		await expect(page.locator('[data-cy="editRowSaveButton"]')).toBeDisabled()
+	})
+
+	test('Delete row via row action menu', async () => {
+		await page.goto('/index.php/apps/tables')
+		await createTable(page, 'Row delete menu table')
+		await createTextLineColumn(page, 'title', '', '', true)
+
+		await openCreateRowModal(page)
+		await fillInValueTextLine(page, 'title', 'Row to delete')
+		await page.locator('[data-cy="createRowSaveButton"]').click()
+		await expect(page.locator('[data-cy="createRowModal"]')).toBeHidden()
+
+		const rowToDelete = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'Row to delete' }).first()
+		await expect(rowToDelete).toBeVisible({ timeout: 10000 })
+
+		const deleteReqPromise = page.waitForResponse(r => r.url().includes('/apps/tables/row/') && r.request().method() === 'DELETE')
+		await openRowActionMenu(page, rowToDelete)
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await deleteReqPromise
+
+		await expect(page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]')).toHaveCount(0, { timeout: 10000 })
+	})
+
+	test('Copy row via row action menu', async () => {
+		await page.goto('/index.php/apps/tables')
+		await createTable(page, 'Row copy menu table')
+		await createTextLineColumn(page, 'title', '', '', true)
+
+		await openCreateRowModal(page)
+		await fillInValueTextLine(page, 'title', 'Original row')
+		await page.locator('[data-cy="createRowSaveButton"]').click()
+		await expect(page.locator('[data-cy="createRowModal"]')).toBeHidden()
+
+		const originalRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'Original row' }).first()
+		await expect(originalRow).toBeVisible({ timeout: 10000 })
+
+		// Open copy dialog via the row action menu
+		await openRowActionMenu(page, originalRow)
+		await page.locator('[data-cy="copyRowBtn"]').click()
+
+		// Verify create modal opens with pre-filled value
+		await expect(page.locator('[data-cy="createRowModal"]')).toBeVisible({ timeout: 10000 })
+		await expect(page.locator('[data-cy="createRowModal"] input').first()).toHaveValue('Original row')
+
+		// Save the copy
+		await page.locator('[data-cy="createRowSaveButton"]').click()
+		await expect(page.locator('[data-cy="createRowModal"]')).toBeHidden()
+
+		// Both original and copy should be visible
+		await expect(page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').filter({ hasText: 'Original row' })).toHaveCount(2, { timeout: 10000 })
 	})
 
 	test('Inline Edit', async () => {

--- a/playwright/e2e/tables-sharing-link.spec.ts
+++ b/playwright/e2e/tables-sharing-link.spec.ts
@@ -201,8 +201,11 @@ test.describe('Public link sharing', () => {
 		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Test row for editing')).toBeVisible()
 
 		// Verify edit button exists and edit the row
-		await expect(publicPage.locator('[data-cy="editRowBtn"]').last()).toBeVisible()
-		await publicPage.locator('[data-cy="editRowBtn"]').last().click()
+		const lastRow = publicPage.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').last()
+		await lastRow.hover()
+		await lastRow.locator('[data-cy="rowActionMenu"] button').click()
+		await expect(publicPage.locator('[data-cy="editRowBtn"]')).toBeVisible()
+		await publicPage.locator('[data-cy="editRowBtn"]').click()
 		await expect(publicPage.locator('[data-cy="editRowModal"]')).toBeVisible()
 		await publicPage.locator('[data-cy="editRowModal"]').getByRole('textbox').first().fill('Updated row')
 		await publicPage.locator('[data-cy="editRowSaveButton"]').click()
@@ -210,7 +213,11 @@ test.describe('Public link sharing', () => {
 		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Test row for editing')).toHaveCount(0)
 
 		// Delete the row
-		await publicPage.locator('[data-cy="editRowBtn"]').last().click()
+		const updatedRow = publicPage.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').last()
+		await updatedRow.hover()
+		await updatedRow.locator('[data-cy="rowActionMenu"] button').click()
+		await expect(publicPage.locator('[data-cy="editRowBtn"]')).toBeVisible()
+		await publicPage.locator('[data-cy="editRowBtn"]').click()
 		await expect(publicPage.locator('[data-cy="editRowModal"]')).toBeVisible()
 		await publicPage.locator('[data-cy="editRowDeleteButton"]').click()
 		await publicPage.locator('[data-cy="editRowDeleteConfirmButton"]').click()

--- a/playwright/e2e/view-mandatory-state.spec.ts
+++ b/playwright/e2e/view-mandatory-state.spec.ts
@@ -8,7 +8,7 @@ import { test, expect } from '../support/fixtures'
 import type { BrowserContext, Page } from '@playwright/test'
 import { createRandomUser } from '../support/api'
 import { login } from '../support/login'
-import { createTable, createTextLineColumn, fillInValueTextLine, loadTable } from '../support/commands'
+import { createTable, createTextLineColumn, fillInValueTextLine, loadTable, openRowActionMenu } from '../support/commands'
 
 const tableTitle = 'Mandatory test table'
 
@@ -131,7 +131,9 @@ test.describe('Mandatory Column Functionality', () => {
 		await expect(page.locator('.icon-loading').first()).toBeHidden()
 
 		// Now open edit row dialog
-		await page.locator('[data-cy="editRowBtn"]').first().click()
+		const firstRow = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').first()
+		await openRowActionMenu(page, firstRow)
+		await page.locator('[data-cy="editRowBtn"]').click()
 		await expect(page.locator('[data-cy="editRowModal"]')).toBeVisible()
 
 		// should show error when mandatory field is empty

--- a/playwright/e2e/view.spec.ts
+++ b/playwright/e2e/view.spec.ts
@@ -8,7 +8,7 @@ import { test, expect } from '../support/fixtures'
 import type { BrowserContext, Page } from '@playwright/test'
 import { createRandomUser } from '../support/api'
 import { login } from '../support/login'
-import { createSelectionColumn, createTable, createTextLineColumn, fillInValueSelection, fillInValueTextLine, loadTable } from '../support/commands'
+import { createSelectionColumn, createTable, createTextLineColumn, fillInValueSelection, fillInValueTextLine, loadTable, openRowActionMenu } from '../support/commands'
 
 const firstTitle = 'Test view'
 const secondTitle = 'Test view 2'
@@ -192,14 +192,14 @@ test.describe('Interact with views', () => {
 		await expect(page.locator('.icon-loading').first()).toBeHidden()
 
 		// Delete the first row
-		await page.locator('[data-cy="customTableRow"]').first().locator('[data-cy="editRowBtn"]').click()
-		await page.locator('[data-cy="editRowModal"] [data-cy="editRowDeleteButton"]').click()
-		await page.locator('[data-cy="editRowModal"] [data-cy="editRowDeleteConfirmButton"]').click()
+		const rowCountBefore = await page.locator('[data-cy="customTableRow"]').count()
+		const firstRow = page.locator('[data-cy="customTableRow"]').first()
+		await openRowActionMenu(page, firstRow)
+		await page.locator('[data-cy="deleteRowBtn"]').click()
+		await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
+		await page.locator('[data-cy="confirmDialog"]').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {})
 
-		await expect(page.locator('[data-cy="editRowModal"]')).toBeHidden()
-
-		// Verify one row was deleted by checking the count decreased
-		const count = await page.locator('[data-cy="customTableRow"]').count()
-		expect(count).toBeLessThan(4)
+		// Verify one row was deleted — toHaveCount retries until the DOM settles
+		await expect(page.locator('[data-cy="customTableRow"]')).toHaveCount(rowCountBefore - 1, { timeout: 10000 })
 	})
 })

--- a/playwright/support/commands.ts
+++ b/playwright/support/commands.ts
@@ -202,30 +202,25 @@ export async function deleteTable(page: Page, title: string) {
 	).not.toBeVisible()
 }
 
+export async function openRowActionMenu(page: Page, rowLocator: Locator) {
+	await rowLocator.hover()
+	await rowLocator.locator('[data-cy="rowActionMenu"] button').click()
+}
+
 export async function deleteRow(page: Page, rowIndex: number) {
 	const deleteResponse = page.waitForResponse(
 		(response) =>
 			/\/apps\/tables\/(row|view\/\d+\/row)\//.test(response.url())
       && response.request().method() === 'DELETE',
 	).catch(() => null)
-	await page
-		.locator('[data-cy="ncTable"] [data-cy="editRowBtn"]')
-		.nth(rowIndex)
-		.click()
-	await page.locator('[data-cy="editRowDeleteButton"]').click({ force: true })
-	const confirmDeleteButton = page.locator('[data-cy="editRowDeleteConfirmButton"]')
-	if (await confirmDeleteButton.isVisible().catch(() => false)) {
-		await confirmDeleteButton.click({ force: true })
-	}
+	const row = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').nth(rowIndex)
+	await openRowActionMenu(page, row)
+	const deleteBtn = page.locator('[data-cy="deleteRowBtn"]')
+	await deleteBtn.waitFor({ state: 'visible', timeout: 5000 })
+	await deleteBtn.click()
+	await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
 	await deleteResponse
-	await page
-		.locator('[data-cy="editRowModal"]')
-		.waitFor({ state: 'hidden', timeout: 10000 })
-		.catch(async () => {
-			if (await page.locator('[data-cy="editRowModal"]').isVisible().catch(() => false)) {
-				await page.locator('[data-cy="editRowModal"] button[aria-label="Close"]').click().catch(() => {})
-			}
-		})
+	await page.locator('[data-cy="confirmDialog"]').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {})
 }
 
 export async function createView(page: Page, title: string) {

--- a/playwright/support/commands.ts
+++ b/playwright/support/commands.ts
@@ -204,30 +204,25 @@ export async function deleteTable(page: Page, title: string) {
 	).not.toBeVisible()
 }
 
+export async function openRowActionMenu(page: Page, rowLocator: Locator) {
+	await rowLocator.hover()
+	await rowLocator.locator('[data-cy="rowActionMenu"] button').click()
+}
+
 export async function deleteRow(page: Page, rowIndex: number) {
 	const deleteResponse = page.waitForResponse(
 		(response) =>
 			/\/apps\/tables\/(row|view\/\d+\/row)\//.test(response.url())
       && response.request().method() === 'DELETE',
 	).catch(() => null)
-	await page
-		.locator('[data-cy="ncTable"] [data-cy="editRowBtn"]')
-		.nth(rowIndex)
-		.click()
-	await page.locator('[data-cy="editRowDeleteButton"]').click({ force: true })
-	const confirmDeleteButton = page.locator('[data-cy="editRowDeleteConfirmButton"]')
-	if (await confirmDeleteButton.isVisible().catch(() => false)) {
-		await confirmDeleteButton.click({ force: true })
-	}
+	const row = page.locator('[data-cy="ncTable"] [data-cy="customTableRow"]').nth(rowIndex)
+	await openRowActionMenu(page, row)
+	const deleteBtn = page.locator('[data-cy="deleteRowBtn"]')
+	await deleteBtn.waitFor({ state: 'visible', timeout: 5000 })
+	await deleteBtn.click()
+	await page.locator('[data-cy="confirmDialog"]').getByRole('button', { name: 'Confirm' }).click()
 	await deleteResponse
-	await page
-		.locator('[data-cy="editRowModal"]')
-		.waitFor({ state: 'hidden', timeout: 10000 })
-		.catch(async () => {
-			if (await page.locator('[data-cy="editRowModal"]').isVisible().catch(() => false)) {
-				await page.locator('[data-cy="editRowModal"] button[aria-label="Close"]').click().catch(() => {})
-			}
-		})
+	await page.locator('[data-cy="confirmDialog"]').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {})
 }
 
 export async function createView(page: Page, title: string) {

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -25,6 +25,7 @@
 		@create-row="createRow"
 		@edit-row="editRow"
 		@copy-row="copyRow"
+		@delete-row="deleteRow"
 		@delete-selected-rows="deleteSelectedRows">
 		<template #actions>
 			<slot name="actions" />
@@ -133,6 +134,9 @@ export default {
 		},
 		copyRow(rowId) {
 			emit('tables:row:copy', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, elementId: this.element.id })
+		},
+		deleteRow(rowId) {
+			emit('tables:row:delete', { rows: [rowId], isView: this.isView, elementId: this.element.id })
 		},
 		deleteSelectedRows(rows) {
 			emit('tables:row:delete', { rows, isView: this.isView, elementId: this.element.id })

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -24,6 +24,7 @@
 		@delete-column="deleteColumn"
 		@create-row="createRow"
 		@edit-row="editRow"
+		@copy-row="copyRow"
 		@delete-selected-rows="deleteSelectedRows">
 		<template #actions>
 			<slot name="actions" />
@@ -129,6 +130,9 @@ export default {
 		},
 		editRow(rowId) {
 			emit('tables:row:edit', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, element: this.element })
+		},
+		copyRow(rowId) {
+			emit('tables:row:copy', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, elementId: this.element.id })
 		},
 		deleteSelectedRows(rows) {
 			emit('tables:row:delete', { rows, isView: this.isView, elementId: this.element.id })

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -26,6 +26,7 @@
 		@create-row="createRow"
 		@edit-row="editRow"
 		@copy-row="copyRow"
+		@delete-row="deleteRow"
 		@delete-selected-rows="deleteSelectedRows"
 		@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 		<template #actions="slotProps">
@@ -139,6 +140,9 @@ export default {
 		},
 		copyRow(rowId) {
 			emit('tables:row:copy', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, elementId: this.element.id })
+		},
+		deleteRow(rowId) {
+			emit('tables:row:delete', { rows: [rowId], isView: this.isView, elementId: this.element.id })
 		},
 		deleteSelectedRows(rows) {
 			emit('tables:row:delete', { rows, isView: this.isView, elementId: this.element.id })

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -25,6 +25,7 @@
 		@delete-column="deleteColumn"
 		@create-row="createRow"
 		@edit-row="editRow"
+		@copy-row="copyRow"
 		@delete-selected-rows="deleteSelectedRows"
 		@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 		<template #actions="slotProps">
@@ -135,6 +136,9 @@ export default {
 		},
 		editRow(rowId) {
 			emit('tables:row:edit', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, element: this.element })
+		},
+		copyRow(rowId) {
+			emit('tables:row:copy', { row: this.rows.find(r => r.id === rowId), columns: this.columns, isView: this.isView, elementId: this.element.id })
 		},
 		deleteSelectedRows(rows) {
 			emit('tables:row:delete', { rows, isView: this.isView, elementId: this.element.id })

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -46,7 +46,8 @@
 			:element-id="element.id"
 			:is-form-mode="isFormMode"
 			:show-modal="showCreateRow"
-			@close="showCreateRow = false" />
+			:prefill-data="prefillData"
+			@close="showCreateRow = false; prefillData = null" />
 		<DeleteRows
 			v-if="rowsToDelete"
 			:rows-to-delete="rowsToDelete?.rows"
@@ -110,6 +111,7 @@ export default {
 	data() {
 		return {
 			showCreateRow: false,
+			prefillData: null,
 			editRow: null,
 			rowsToDelete: null,
 		}
@@ -125,6 +127,10 @@ export default {
 		subscribe('tables:row:create', () => {
 			this.showCreateRow = true
 		})
+		subscribe('tables:row:copy', rowInfo => {
+			this.prefillData = rowInfo.row?.data
+			this.showCreateRow = true
+		})
 		subscribe('tables:row:edit', rowInfo => {
 			this.editRow = rowInfo
 		})
@@ -135,6 +141,7 @@ export default {
 
 	unmounted() {
 		unsubscribe('tables:row:create')
+		unsubscribe('tables:row:copy')
 		unsubscribe('tables:row:edit')
 		unsubscribe('tables:row:delete')
 	},

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -80,6 +80,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		prefillData: {
+			type: Array,
+			default: null,
+		},
 	},
 	data() {
 		return {
@@ -112,6 +116,13 @@ export default {
 	watch: {
 		showModal() {
 			if (this.showModal) {
+				if (this.prefillData) {
+					const prefilled = {}
+					this.prefillData.forEach(item => {
+						prefilled[item.columnId] = item.value
+					})
+					this.row = prefilled
+				}
 				this.$nextTick(() => {
 					this.$el.querySelector('input')?.focus()
 				})

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -76,6 +76,10 @@ export default {
 			type: Number,
 			default: null,
 		},
+		prefillData: {
+			type: Array,
+			default: null,
+		},
 	},
 	data() {
 		return {
@@ -99,6 +103,13 @@ export default {
 	watch: {
 		showModal() {
 			if (this.showModal) {
+				if (this.prefillData) {
+					const prefilled = {}
+					this.prefillData.forEach(item => {
+						prefilled[item.columnId] = item.value
+					})
+					this.row = prefilled
+				}
 				this.$nextTick(() => {
 					this.$el.querySelector('input')?.focus()
 				})

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -302,6 +302,10 @@ export default {
 		justify-content: end;
 	}
 
+	:where(.justify-between) {
+		justify-content: space-between;
+	}
+
 	:where(.slot.fix-col-2) {
 		min-width: 50%;
 	}

--- a/src/modules/modals/Modals.vue
+++ b/src/modules/modals/Modals.vue
@@ -16,6 +16,7 @@
 		<CreateRow :columns="columnsForRow?.columns"
 			:is-view="columnsForRow?.isView"
 			:element-id="columnsForRow?.elementId"
+			:prefill-data="columnsForRow?.prefillData ?? null"
 			:show-modal="columnsForRow !== null"
 			@close="columnsForRow = null" />
 		<EditRow :columns="editRow?.columns"
@@ -147,6 +148,7 @@ export default {
 
 		// rows
 		subscribe('tables:row:create', columnsInfo => { this.columnsForRow = columnsInfo })
+		subscribe('tables:row:copy', rowInfo => { this.columnsForRow = { columns: rowInfo.columns, isView: rowInfo.isView, elementId: rowInfo.elementId, prefillData: rowInfo.row?.data } })
 		subscribe('tables:row:edit', rowInfo => { this.editRow = rowInfo })
 		subscribe('tables:row:delete', tableInfo => {
 			this.rowsToDelete = tableInfo
@@ -169,6 +171,7 @@ export default {
 		unsubscribe('tables:column:edit', columnInfo => { this.columnToEdit = columnInfo })
 		unsubscribe('tables:column:delete', columnInfo => { this.columnToDelete = columnInfo })
 		unsubscribe('tables:row:create', columnsInfo => { this.columnsForRow = columnsInfo })
+		unsubscribe('tables:row:copy', rowInfo => { this.columnsForRow = { columns: rowInfo.columns, isView: rowInfo.isView, elementId: rowInfo.elementId, prefillData: rowInfo.row?.data } })
 		unsubscribe('tables:row:edit', rowInfo => { this.editRow = rowInfo })
 		unsubscribe('tables:row:delete', tableInfo => {
 			this.rowsToDelete = tableInfo

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -56,6 +56,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				:config="config" @create-row="$emit('create-row')"
 				@edit-row="rowId => $emit('edit-row', rowId)"
 				@copy-row="rowId => $emit('copy-row', rowId)"
+				@delete-row="rowId => $emit('delete-row', rowId)"
 				@create-column="$emit('create-column')"
 				@edit-column="col => $emit('edit-column', col)"
 				@delete-column="col => $emit('delete-column', col)"

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -55,6 +55,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				:rows="rows" :is-view="isView" :element-id="elementId" :view-setting.sync="localViewSetting"
 				:config="config" @create-row="$emit('create-row')"
 				@edit-row="rowId => $emit('edit-row', rowId)"
+				@copy-row="rowId => $emit('copy-row', rowId)"
 				@create-column="$emit('create-column')"
 				@edit-column="col => $emit('edit-column', col)"
 				@delete-column="col => $emit('delete-column', col)"

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -56,6 +56,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				:rows="getSearchedAndFilteredAndSortedRows" :is-view="isView" :element-id="elementId" :view-setting.sync="localViewSetting"
 				:config="config" @create-row="$emit('create-row')"
 				@edit-row="rowId => $emit('edit-row', rowId)"
+				@copy-row="rowId => $emit('copy-row', rowId)"
 				@create-column="$emit('create-column')"
 				@edit-column="col => $emit('edit-column', col)"
 				@delete-column="col => $emit('delete-column', col)"

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -57,6 +57,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				:config="config" @create-row="$emit('create-row')"
 				@edit-row="rowId => $emit('edit-row', rowId)"
 				@copy-row="rowId => $emit('copy-row', rowId)"
+				@delete-row="rowId => $emit('delete-row', rowId)"
 				@create-column="$emit('create-column')"
 				@edit-column="col => $emit('edit-column', col)"
 				@delete-column="col => $emit('delete-column', col)"

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -28,19 +28,36 @@
 				:is-view="isView"
 				:can-edit="config.canEditRows" />
 		</td>
-		<td v-if="config.showActions" :class="{sticky: config.showActions}">
-			<NcButton v-if="config.canEditRows || config.canDeleteRows" type="primary" :aria-label="t('tables', 'Edit row')" data-cy="editRowBtn" @click="$emit('edit-row', row.id)">
-				<template #icon>
-					<Fullscreen :size="20" />
-				</template>
-			</NcButton>
+		<td v-if="config.showActions && (config.canEditRows || config.canDeleteRows || config.canCreateRows)"
+			:class="{sticky: config.showActions}">
+			<NcActions data-cy="rowActionMenu">
+				<NcActionButton v-if="config.canEditRows || config.canDeleteRows"
+					data-cy="editRowBtn"
+					:close-after-click="true"
+					@click="$emit('edit-row', row.id)">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					{{ t('tables', 'Edit row') }}
+				</NcActionButton>
+				<NcActionButton v-if="config.canCreateRows"
+					data-cy="copyRowBtn"
+					:close-after-click="true"
+					@click="$emit('copy-row', row.id)">
+					<template #icon>
+						<ContentCopy :size="20" />
+					</template>
+					{{ t('tables', 'Copy row') }}
+				</NcActionButton>
+			</NcActions>
 		</td>
 	</tr>
 </template>
 
 <script>
-import { NcCheckboxRadioSwitch, NcButton } from '@nextcloud/vue'
-import Fullscreen from 'vue-material-design-icons/Fullscreen.vue'
+import { NcCheckboxRadioSwitch, NcActions, NcActionButton } from '@nextcloud/vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Pencil from 'vue-material-design-icons/PencilOutline.vue'
 import TableCellHtml from './TableCellHtml.vue'
 import TableCellProgress from './TableCellProgress.vue'
 import TableCellLink from './TableCellLink.vue'
@@ -69,8 +86,10 @@ export default {
 		TableCellLink,
 		TableCellProgress,
 		TableCellHtml,
-		NcButton,
-		Fullscreen,
+		NcActions,
+		NcActionButton,
+		ContentCopy,
+		Pencil,
 		NcCheckboxRadioSwitch,
 		TableCellDateTime,
 		TableCellTextLine,

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -44,6 +44,15 @@
 					</template>
 					{{ t('tables', 'Copy row') }}
 				</NcActionButton>
+				<NcActionButton v-if="config.canDeleteRows"
+					data-cy="deleteRowBtn"
+					:close-after-click="true"
+					@click="$emit('delete-row', row.id)">
+					<template #icon>
+						<TrashCanOutline :size="20" />
+					</template>
+					{{ t('tables', 'Delete row') }}
+				</NcActionButton>
 			</NcActions>
 		</td>
 	</tr>
@@ -53,6 +62,7 @@
 import { NcCheckboxRadioSwitch, NcActions, NcActionButton } from '@nextcloud/vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import Pencil from 'vue-material-design-icons/PencilOutline.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import TableCellHtml from './TableCellHtml.vue'
 import TableCellProgress from './TableCellProgress.vue'
 import TableCellLink from './TableCellLink.vue'
@@ -85,6 +95,7 @@ export default {
 		NcActionButton,
 		ContentCopy,
 		Pencil,
+		TrashCanOutline,
 		NcCheckboxRadioSwitch,
 		TableCellDateTime,
 		TableCellTextLine,

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -23,19 +23,36 @@
 				:is-view="isView"
 				:can-edit="config.canEditRows" />
 		</td>
-		<td v-if="config.showActions" :class="{sticky: config.showActions}">
-			<NcButton v-if="config.canEditRows || config.canDeleteRows" type="primary" :aria-label="t('tables', 'Edit row')" data-cy="editRowBtn" @click="$emit('edit-row', row.id)">
-				<template #icon>
-					<Fullscreen :size="20" />
-				</template>
-			</NcButton>
+		<td v-if="config.showActions && (config.canEditRows || config.canDeleteRows || config.canCreateRows)"
+			:class="{sticky: config.showActions}">
+			<NcActions data-cy="rowActionMenu">
+				<NcActionButton v-if="config.canEditRows || config.canDeleteRows"
+					data-cy="editRowBtn"
+					:close-after-click="true"
+					@click="$emit('edit-row', row.id)">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					{{ t('tables', 'Edit row') }}
+				</NcActionButton>
+				<NcActionButton v-if="config.canCreateRows"
+					data-cy="copyRowBtn"
+					:close-after-click="true"
+					@click="$emit('copy-row', row.id)">
+					<template #icon>
+						<ContentCopy :size="20" />
+					</template>
+					{{ t('tables', 'Copy row') }}
+				</NcActionButton>
+			</NcActions>
 		</td>
 	</tr>
 </template>
 
 <script>
-import { NcCheckboxRadioSwitch, NcButton } from '@nextcloud/vue'
-import Fullscreen from 'vue-material-design-icons/Fullscreen.vue'
+import { NcCheckboxRadioSwitch, NcActions, NcActionButton } from '@nextcloud/vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Pencil from 'vue-material-design-icons/PencilOutline.vue'
 import TableCellHtml from './TableCellHtml.vue'
 import TableCellProgress from './TableCellProgress.vue'
 import TableCellLink from './TableCellLink.vue'
@@ -64,8 +81,10 @@ export default {
 		TableCellLink,
 		TableCellProgress,
 		TableCellHtml,
-		NcButton,
-		Fullscreen,
+		NcActions,
+		NcActionButton,
+		ContentCopy,
+		Pencil,
 		NcCheckboxRadioSwitch,
 		TableCellDateTime,
 		TableCellTextLine,

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -49,6 +49,15 @@
 					</template>
 					{{ t('tables', 'Copy row') }}
 				</NcActionButton>
+				<NcActionButton v-if="config.canDeleteRows"
+					data-cy="deleteRowBtn"
+					:close-after-click="true"
+					@click="$emit('delete-row', row.id)">
+					<template #icon>
+						<TrashCanOutline :size="20" />
+					</template>
+					{{ t('tables', 'Delete row') }}
+				</NcActionButton>
 			</NcActions>
 		</td>
 	</tr>
@@ -58,6 +67,7 @@
 import { NcCheckboxRadioSwitch, NcActions, NcActionButton } from '@nextcloud/vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import Pencil from 'vue-material-design-icons/PencilOutline.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import TableCellHtml from './TableCellHtml.vue'
 import TableCellProgress from './TableCellProgress.vue'
 import TableCellLink from './TableCellLink.vue'
@@ -90,6 +100,7 @@ export default {
 		NcActionButton,
 		ContentCopy,
 		Pencil,
+		TrashCanOutline,
 		NcCheckboxRadioSwitch,
 		TableCellDateTime,
 		TableCellTextLine,

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -31,7 +31,7 @@
 		<td v-if="config.showActions && (config.canEditRows || config.canDeleteRows || config.canCreateRows)"
 			:class="{sticky: config.showActions}">
 			<NcActions data-cy="rowActionMenu">
-				<NcActionButton v-if="config.canEditRows || config.canDeleteRows"
+				<NcActionButton v-if="config.canEditRows"
 					data-cy="editRowBtn"
 					:close-after-click="true"
 					@click="$emit('edit-row', row.id)">

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -38,7 +38,8 @@
 					:element-id="elementId"
 					:is-view="isView"
 					@update-row-selection="updateRowSelection"
-					@edit-row="rowId => $emit('edit-row', rowId)" />
+					@edit-row="rowId => $emit('edit-row', rowId)"
+					@copy-row="rowId => $emit('copy-row', rowId)" />
 			</transition-group>
 		</table>
 		<div v-if="totalPages > 1" class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -39,7 +39,8 @@
 					:is-view="isView"
 					@update-row-selection="updateRowSelection"
 					@edit-row="rowId => $emit('edit-row', rowId)"
-					@copy-row="rowId => $emit('copy-row', rowId)" />
+					@copy-row="rowId => $emit('copy-row', rowId)"
+					@delete-row="rowId => $emit('delete-row', rowId)" />
 			</transition-group>
 		</table>
 		<div v-if="totalPages > 1" class="pagination-footer" :class="{'large-width': !appNavCollapsed || isMobile}">

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -45,7 +45,8 @@
 					:pinned-column-id="pinnedColumnId"
 					:column-widths="columnWidths"
 					@update-row-selection="updateRowSelection"
-					@edit-row="rowId => $emit('edit-row', rowId)" />
+					@edit-row="rowId => $emit('edit-row', rowId)"
+					@copy-row="rowId => $emit('copy-row', rowId)" />
 			</transition-group>
 		</table>
 	</div>

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -46,7 +46,8 @@
 					:column-widths="columnWidths"
 					@update-row-selection="updateRowSelection"
 					@edit-row="rowId => $emit('edit-row', rowId)"
-					@copy-row="rowId => $emit('copy-row', rowId)" />
+					@copy-row="rowId => $emit('copy-row', rowId)"
+					@delete-row="rowId => $emit('delete-row', rowId)" />
 			</transition-group>
 		</table>
 	</div>

--- a/src/shared/modals/DialogConfirmation.vue
+++ b/src/shared/modals/DialogConfirmation.vue
@@ -23,6 +23,7 @@
 </template>
 
 <script>
+import { translate as t } from '@nextcloud/l10n'
 import { NcDialog, NcButton } from '@nextcloud/vue'
 
 export default {

--- a/src/views/ContentReferenceWidget.vue
+++ b/src/views/ContentReferenceWidget.vue
@@ -21,14 +21,31 @@
 				:rows="filteredRows"
 				:columns="richObject.columns"
 				v-bind="tablePermissions"
-				@edit-row="editRow" />
+				@edit-row="editRow"
+				@copy-row="copyRow"
+				@delete-row="deleteRow" />
 		</div>
+		<CreateRow
+			:columns="richObject.columns"
+			:is-view="Boolean(richObject.type)"
+			:element-id="richObject.id"
+			:show-modal="showCopyRow"
+			:prefill-data="copyPrefillData"
+			@close="showCopyRow = false; copyPrefillData = null" />
+		<DeleteRows
+			v-if="rowToDelete !== null"
+			:rows-to-delete="[rowToDelete]"
+			:element-id="richObject.id"
+			:is-view="Boolean(richObject.type)"
+			@cancel="rowToDelete = null" />
 	</div>
 </template>
 
 <script>
 import NcTable from '../shared/components/ncTable/NcTable.vue'
 import Options from '../shared/components/ncTable/sections/Options.vue'
+import CreateRow from '../modules/modals/CreateRow.vue'
+import DeleteRows from '../modules/modals/DeleteRows.vue'
 import permissionsMixin from '../shared/components/ncTable/mixins/permissionsMixin.js'
 import { NcLoadingIcon } from '@nextcloud/vue'
 import { useResizeObserver } from '@vueuse/core'
@@ -41,6 +58,8 @@ export default {
 	components: {
 		NcTable,
 		Options,
+		CreateRow,
+		DeleteRows,
 		NcLoadingIcon,
 	},
 
@@ -65,6 +84,9 @@ export default {
 		return {
 			searchExp: null,
 			localRows: [], // Keep as fallback only
+			showCopyRow: false,
+			copyPrefillData: null,
+			rowToDelete: null,
 			tablesStore: null,
 			dataStore: null,
 		}
@@ -84,7 +106,7 @@ export default {
 				canSelectRows: false,
 				canHideColumns: false,
 				canFilter: false,
-				showActions: this.canManageElement(this.richObject),
+				showActions: this.canCreateRowInElement(this.richObject) || this.canUpdateData(this.richObject) || this.canDeleteData(this.richObject),
 			}
 		},
 		filteredRows() {
@@ -180,11 +202,17 @@ export default {
 				isView: Boolean(this.richObject.type),
 				element: this.richObject,
 			}, async () => {
-				// Reload rows from the backend to get the latest data
 				await this.dataStore.loadRowsFromBE({
 					tableId: this.richObject.id,
 				})
 			})
+		},
+		copyRow(rowId) {
+			this.copyPrefillData = this.getRow(rowId)?.data
+			this.showCopyRow = true
+		},
+		deleteRow(rowId) {
+			this.rowToDelete = rowId
 		},
 		getRow(rowId) {
 			return this.rows.find(row => row.id === rowId)


### PR DESCRIPTION
* Alternative approach to @juliusknorr's #1713 
  * follow-up is opening the edit dialog on the original PR (see link above)
  * this PR opens a create dialog but pre-populated with the row values
* Any of the two would resolve one of the release stretch goals
* PR changes the edit Icon-Button into a 3-dot menu with edit/delete/copy + respective icons and updates the cypress tests