### PR TITLE
fix: Auto-focus input field for selecting a value via the column header

### DIFF
--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -37,6 +37,7 @@
 				</NcActionButton>
 				<NcActionCaption :name="t('tables', 'Search for value')" />
 				<NcActionInput
+					ref="filterInput"
 					:label-visible="false"
 					:label="t('tables', 'Keyword and submit')"
 					:value.sync="searchValue"
@@ -279,6 +280,13 @@ export default {
 	watch: {
 		localOpenState() {
 			this.reset()
+		},
+		selectValue(val) {
+			if (val) {
+				this.$nextTick(() => {
+					this.$refs.filterInput?.$el?.querySelector('input')?.focus()
+				})
+			}
 		},
 		localViewSetting() {
 			this.$emit('update:viewSetting', this.localViewSetting)


### PR DESCRIPTION
Before this change when clicking on "Select value" in the column header menu the opened dialog didn't auto-focus on the input field for direct typing but forces users to do an extra mouse click or keyboard tabbing.

This way the field is automatically focused after launching / rendering the dialog and field.