### PR TITLE
fix: pin stylelint-config and vue version in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,11 @@
       "allowedVersions": "<4"
     },
     {
+      "matchPackageNames": ["pinia"],
+      "allowedVersions": "<3",
+      "description": "Pin to Vue 2-compatible major"
+    },
+    {
       "matchPackageNames": ["vueuse"],
       "allowedVersions": "<12"
     },
@@ -64,7 +69,7 @@
     },
     {
       "matchPackageNames": ["@nextcloud/stylelint-config"],
-      "allowedVersions": "3.1.1",
+      "allowedVersions": "<=3.1.1",
       "description": "Pin due to stylelint peer dependency conflict"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,11 @@
       "allowedVersions": "<=1.5.6"
     },
     {
+      "matchPackageNames": ["@nextcloud/stylelint-config"],
+      "allowedVersions": "3.1.1",
+      "description": "Pin due to stylelint peer dependency conflict"
+    },
+    {
       "matchPackageNames": ["@vue/tsconfig"],
       "allowedVersions": "<=0.5.1"
     },


### PR DESCRIPTION
For newer versions, we get the conflict:

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: tables@0.9.9
npm error Found: stylelint@16.19.1
npm error node_modules/stylelint
npm error   peer stylelint@">=14.0.0" from stylelint-config-html@1.1.0
npm error   node_modules/stylelint-config-html
npm error     stylelint-config-html@">=1.0.0" from stylelint-config-recommended-vue@1.5.0
npm error     node_modules/stylelint-config-recommended-vue
npm error   peer stylelint@"^16.16.0" from stylelint-config-recommended@16.0.0
npm error   node_modules/stylelint-config-recommended
npm error     stylelint-config-recommended@"^16.0.0" from stylelint-config-recommended-scss@15.0.1
npm error     node_modules/stylelint-config-recommended-scss
npm error     stylelint-config-recommended@">=6.0.0" from stylelint-config-recommended-vue@1.5.0
npm error     node_modules/stylelint-config-recommended-vue
npm error   4 more (stylelint-config-recommended-scss, ...)
npm error
npm error Could not resolve dependency:
npm error dev @nextcloud/stylelint-config@"^3.2.1" from the root project
npm error
npm error Conflicting peer dependency: stylelint@17.6.0
npm error node_modules/stylelint
npm error   peer stylelint@"^17.1.1" from @nextcloud/stylelint-config@3.2.1
npm error   node_modules/@nextcloud/stylelint-config
npm error     dev @nextcloud/stylelint-config@"^3.2.1" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /runner/cache/others/npm/_logs/2026-04-08T16_51_18_050Z-eresolve-report.txt
npm error A complete log of this run can be found in: /runner/cache/others/npm/_logs/2026-04-08T16_51_18_050Z-debug-0.log
```


```
npm warn Unknown env config "store". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: tables@1.0.5
npm error Found: vue@2.7.16
npm error node_modules/vue
npm error   vue@"^2.7.16" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vue@"^3.5.11" from pinia@3.0.4
npm error node_modules/pinia
npm error   pinia@"^3.0.4" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry this command with --force or --legacy-peer-deps to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /runner/cache/others/npm/_logs/2026-04-08T16_50_55_175Z-eresolve-report.txt
npm error A complete log of this run can be found in: /runner/cache/others/npm/_logs/2026-04-08T16_50_55_175Z-debug-0.log

```