### PR TITLE
fix(datetime): parse stored values as UTC in edit form getters

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellDateTime.vue
+++ b/src/shared/components/ncTable/partials/TableCellDateTime.vue
@@ -123,15 +123,15 @@ export default {
 				const format = this.getDateFormat()
 
 				if (this.column.type === 'datetime-time') {
-					const timeMoment = Moment(this.value, format)
+					const timeMoment = Moment.utc(this.value, format)
 					if (timeMoment.isValid()) {
-						this.editDateTimeValue = timeMoment.toDate()
+						this.editDateTimeValue = timeMoment.local().toDate()
 					} else {
 						this.editDateTimeValue = new Date()
 					}
 				} else {
-					const parsedMoment = Moment(this.value, format)
-					this.editDateTimeValue = parsedMoment.isValid() ? parsedMoment.toDate() : null
+					const parsedMoment = Moment.utc(this.value, format)
+					this.editDateTimeValue = parsedMoment.isValid() ? parsedMoment.local().toDate() : null
 				}
 			} else if ((this.value === null || this.value === '') && this.column.datetimeDefault) {
 				if (this.column.datetimeDefault === 'now' || this.column.datetimeDefault === 'today') {

--- a/src/shared/components/ncTable/partials/rowTypePartials/DatetimeForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/DatetimeForm.vue
@@ -42,7 +42,7 @@ export default {
 		localValue: {
 			get() {
 				if (this.value !== null && this.value !== 'none') {
-					return Moment(this.value, 'YYYY-MM-DD HH:mm').toDate()
+					return Moment.utc(this.value, 'YYYY-MM-DD HH:mm').local().toDate()
 				} else if (this.value === null && this.column.datetimeDefault === 'now') {
 					const dt = Moment()
 					this.$emit('update:value', dt.format('YYYY-MM-DD HH:mm'))

--- a/src/shared/components/ncTable/partials/rowTypePartials/DatetimeForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/DatetimeForm.vue
@@ -45,7 +45,7 @@ export default {
 					return Moment.utc(this.value, 'YYYY-MM-DD HH:mm').local().toDate()
 				} else if (this.value === null && this.column.datetimeDefault === 'now') {
 					const dt = Moment()
-					this.$emit('update:value', dt.format('YYYY-MM-DD HH:mm'))
+					this.$emit('update:value', dt.clone().utc().format('YYYY-MM-DD HH:mm'))
 					return dt.toDate()
 				} else {
 					return null

--- a/src/shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue
@@ -50,7 +50,7 @@ export default {
 		localValue: {
 			get() {
 				if (this.value !== null && this.value !== 'none') {
-					return Moment(this.value, 'HH:mm').toDate()
+					return Moment.utc(this.value, 'HH:mm').local().toDate()
 				} else if (this.value === null && this.column.datetimeDefault === 'now') {
 					const dt = Moment()
 					this.$emit('update:value', dt.format('HH:mm'))

--- a/src/shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue
+++ b/src/shared/components/ncTable/partials/rowTypePartials/DatetimeTimeForm.vue
@@ -53,7 +53,7 @@ export default {
 					return Moment.utc(this.value, 'HH:mm').local().toDate()
 				} else if (this.value === null && this.column.datetimeDefault === 'now') {
 					const dt = Moment()
-					this.$emit('update:value', dt.format('HH:mm'))
+					this.$emit('update:value', dt.clone().utc().format('HH:mm'))
 					return dt.toDate()
 				} else {
 					return new Date()


### PR DESCRIPTION
## What this fixes
Every time a row with a datetime column is opened for editing and saved,
the time shifts by the current UTC offset (−2h in summer CEST, −1h in
winter CET). The shift is DST-aware — dates created before the March DST
switch shift by −1h, dates after by −2h.

## Root cause
Commit 78f8131a moved datetime handling from a backend `TimezoneHelper`
to frontend-side UTC conversion. The display formatters and form setters
were correctly updated to use `.utc()` / `.utc().local()`, but the form
getters (which load the stored value into the date picker) were missed.
They still parsed the stored UTC string as local time, causing an offset
drift on every open→save cycle.

## Fix
Update the three affected getters to use `Moment.utc(...).local().toDate()`
— matching the pattern already used by the setters and display formatters.

**Files changed:**
- `DatetimeForm.vue` — modal edit form getter
- `DatetimeTimeForm.vue` — time-only modal edit form getter
- `TableCellDateTime.vue` — inline edit getter (both datetime and time-only)

`DatetimeDateForm.vue` (date-only) is not affected — its setter never had
`.utc()` added, so getter and setter were already symmetric.

## Testing
Manually tested with Docker (Nextcloud 33, Europe/Zurich timezone):
- Datetime values remain stable across multiple open→save cycles
- Both modal edit and inline edit verified
- Summer (CEST, UTC+2) and winter (CET, UTC+1) dates tested

No unit tests added — the affected components (Vue form getters) are not
covered by the existing test suite. A Playwright E2E test for datetime
round-trip stability would be a useful follow-up.

Fixes #2479