### PR TITLE
Fix layout issues in application view caused by missing width constraint

### DIFF
--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -256,6 +256,8 @@ export default {
 
 .resource {
 	margin: 40px 0;
+	width: max-content;
+	min-width: var(--app-content-width, 100%);
 
 	&:deep(.row.first-row) {
 		margin-inline-start: 20px;


### PR DESCRIPTION
## Summary

When the Application view was built, the per-resource wrapper (.resource) was not given the same width constraint that the Table and View pages already have:

```
width: max-content;
min-width: var(--app-content-width, 100%);
```

This single missing rule causes two visual bugs that only appear in the Application view.

---
##  Bugs fixed

### Bug 1 — Title row wraps on narrow viewports

Without a max-content width on the container, the title row is constrained to the viewport width. On narrow screens, the title text wraps onto multiple lines, making the title row taller than expected. The search/create-row bar is positioned with a fixed top: 60px offset, so it ends up overlapping the wrapped title lines and — at very narrow widths — even the table rows below.

<img width="300" alt="grafik" src="https://github.com/user-attachments/assets/e7442581-56ac-466f-b991-ba40004c2a42" />

### Bug 2 — White header background does not extend on horizontal scroll

The sticky header backgrounds (title and options bar) inherit the container width, which is viewport-wide. When the table is wider than the viewport and the user scrolls horizontally, the white background ends at the right edge of the viewport, revealing the table content underneath the header.

<img width="300" alt="grafik" src="https://github.com/user-attachments/assets/8b99ce54-789a-449c-bf1a-bd12a7dd78c6" />

---
## Fix

Added the two missing CSS lines to .resource in src/pages/Context.vue:

```
.resource {
    width: max-content;
    min-width: var(--app-content-width, 100%);
    /* ... */
}
```

This is exactly how Table.vue and View.vue already handle the same layout. The fix aligns the Application view with the existing pattern in the codebase.