### PR TITLE
feat: add permissions for public link shares

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -53,6 +53,7 @@ Have a good time and manage whatever you want.
 	<repair-steps>
 		<pre-migration>
 			<step>OCA\Tables\Migration\FixContextsDefaults</step>
+            <step>OCA\Tables\Migration\ResetPublicSharePermissions</step>
 		</pre-migration>
 		<post-migration>
 			<step>OCA\Tables\Migration\NewDbStructureRepairStep</step>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -97,6 +97,7 @@ return [
 		['name' => 'share#show', 'url' => '/share/{id}', 'verb' => 'GET'],
 		['name' => 'share#create', 'url' => '/share', 'verb' => 'POST'],
 		['name' => 'share#updatePermission', 'url' => '/share/{id}/permission', 'verb' => 'PUT'],
+		['name' => 'share#updatePermissions', 'url' => '/share/{id}/permissions', 'verb' => 'PUT'],
 		['name' => 'share#updateDisplayMode', 'url' => '/share/{id}/display-mode', 'verb' => 'PUT'],
 		['name' => 'share#destroy', 'url' => '/share/{id}', 'verb' => 'DELETE'],
 

--- a/cypress/e2e/helpers/viewFilteringSelectionSetup.js
+++ b/cypress/e2e/helpers/viewFilteringSelectionSetup.js
@@ -81,4 +81,6 @@ const addRow = (title, selection, multiSelection, checked) => {
 
 	cy.get('[data-cy="createRowSaveButton"]').click()
 	cy.get('[data-cy="createRowModal"]').should('not.exist')
+	cy.get('.toastify.toast-success').should('be.visible')
+	cy.get('.toastify.toast-success .toast-close').click({ multiple: true })
 }

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -672,7 +672,7 @@ class Api1Controller extends ApiController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function updateSharePermissions(int $shareId, string $permissionType, bool $permissionValue): DataResponse {
 		try {
-			return new DataResponse($this->shareService->updatePermission($shareId, $permissionType, $permissionValue)->jsonSerialize());
+			return new DataResponse($this->shareService->updatePermission($shareId, [$permissionType => $permissionValue])->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];

--- a/lib/Controller/PublicRowOCSController.php
+++ b/lib/Controller/PublicRowOCSController.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 namespace OCA\Tables\Controller;
 
 use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Db\Row2Mapper;
 use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
 use OCA\Tables\Helper\ConversionHelper;
 use OCA\Tables\Middleware\Attribute\AssertShareAccessIsAccessible;
+use OCA\Tables\Model\RowDataInput;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\RowService;
 use OCA\Tables\Service\ShareService;
@@ -37,11 +39,13 @@ class PublicRowOCSController extends AOCSController {
 	public function __construct(
 		protected ShareService $shareService,
 		protected RowService $rowService,
+		protected Row2Mapper $row2Mapper,
 		IRequest $request,
 		LoggerInterface $logger,
 		IL10N $l,
 	) {
 		parent::__construct($request, $logger, $l, '');
+		$this->rowService->setPublicContext();
 	}
 
 	/**
@@ -68,6 +72,10 @@ class PublicRowOCSController extends AOCSController {
 			$shareToken = new ShareToken($token);
 			$share = $this->shareService->findByToken($shareToken);
 
+			if (!$share->getPermissionRead()) {
+				return $this->handlePermissionError(new PermissionError('No read permission on this share'));
+			}
+
 			$limit = $limit !== null ? max(0, min(500, $limit)) : null;
 			$offset = $offset !== null ? max(0, $offset) : null;
 
@@ -88,6 +96,154 @@ class PublicRowOCSController extends AOCSController {
 			return $this->handleNotFoundError($e);
 		} catch (BadRequestError $e) {
 			return $this->handleBadRequestError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Create a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param string|array<string, mixed> $data An array containing the column identifiers and their values
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row created
+	 * 400: Invalid request parameters
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'POST', url: '/api/2/public/{token}/rows', requirements: ['token' => '[a-zA-Z0-9]{16}'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function createRow(string $token, mixed $data): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionCreate()) {
+				return $this->handlePermissionError(new PermissionError('No create permission on this share'));
+			}
+
+			if (is_string($data)) {
+				$data = json_decode($data, true);
+			}
+			if (!is_array($data)) {
+				return $this->handleBadRequestError(new BadRequestError('Invalid data input'));
+			}
+
+			$newRowData = new RowDataInput();
+			foreach ($data as $key => $value) {
+				$newRowData->add((int)$key, $value);
+			}
+
+			$tableId = $share->getNodeType() === 'table' ? $share->getNodeId() : null;
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+
+			$row = $this->rowService->create($tableId, $viewId, $newRowData);
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (BadRequestError $e) {
+			return $this->handleBadRequestError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Update a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param int $rowId The row identifier
+	 * @param string|array<string, mixed> $data An array containing the column identifiers and their values
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row updated
+	 * 400: Invalid request parameters
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'PUT', url: '/api/2/public/{token}/rows/{rowId}', requirements: ['token' => '[a-zA-Z0-9]{16}', 'rowId' => '\d+'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function updateRow(string $token, int $rowId, mixed $data): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionUpdate()) {
+				return $this->handlePermissionError(new PermissionError('No update permission on this share'));
+			}
+
+			if (is_string($data)) {
+				$data = json_decode($data, true);
+			}
+			if (!is_array($data)) {
+				return $this->handleBadRequestError(new BadRequestError('Invalid data input'));
+			}
+
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+			$tableId = $share->getNodeType() === 'table' ? $share->getNodeId() : null;
+
+			$row = $this->rowService->updateSet($rowId, $viewId, $data, '', $tableId);
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (BadRequestError $e) {
+			return $this->handleBadRequestError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Delete a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param int $rowId The row identifier
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row deleted
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'DELETE', url: '/api/2/public/{token}/rows/{rowId}', requirements: ['token' => '[a-zA-Z0-9]{16}', 'rowId' => '\d+'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function deleteRow(string $token, int $rowId): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionDelete()) {
+				return $this->handlePermissionError(new PermissionError('No delete permission on this share'));
+			}
+
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+
+			$row = $this->rowService->delete($rowId, $viewId, '');
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
 		}
 	}
 }

--- a/lib/Controller/PublicRowOCSController.php
+++ b/lib/Controller/PublicRowOCSController.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 namespace OCA\Tables\Controller;
 
 use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Db\Row2Mapper;
 use OCA\Tables\Errors\BadRequestError;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
 use OCA\Tables\Errors\PermissionError;
 use OCA\Tables\Helper\ConversionHelper;
 use OCA\Tables\Middleware\Attribute\AssertShareAccessIsAccessible;
+use OCA\Tables\Model\RowDataInput;
 use OCA\Tables\ResponseDefinitions;
 use OCA\Tables\Service\RowService;
 use OCA\Tables\Service\ShareService;
@@ -37,11 +39,13 @@ class PublicRowOCSController extends AOCSController {
 	public function __construct(
 		protected ShareService $shareService,
 		protected RowService $rowService,
+		protected Row2Mapper $row2Mapper,
 		IRequest $request,
 		LoggerInterface $logger,
 		IL10N $l,
 	) {
 		parent::__construct($request, $logger, $l, '');
+		$this->rowService->setPublicContext();
 	}
 
 	/**
@@ -68,6 +72,10 @@ class PublicRowOCSController extends AOCSController {
 			$shareToken = new ShareToken($token);
 			$share = $this->shareService->findByToken($shareToken);
 
+			if (!$share->getPermissionRead()) {
+				return $this->handlePermissionError(new PermissionError('No read permission on this share'));
+			}
+
 			$limit = $limit !== null ? max(0, min(500, $limit)) : null;
 			$offset = $offset !== null ? max(0, $offset) : null;
 
@@ -88,6 +96,167 @@ class PublicRowOCSController extends AOCSController {
 			return $this->handleNotFoundError($e);
 		} catch (BadRequestError $e) {
 			return $this->handleBadRequestError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Create a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param string|array<string, mixed> $data An array containing the column identifiers and their values
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row created
+	 * 400: Invalid request parameters
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'POST', url: '/api/2/public/{token}/rows', requirements: ['token' => '[a-zA-Z0-9]{16}'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function createRow(string $token, mixed $data): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionCreate()) {
+				return $this->handlePermissionError(new PermissionError('No create permission on this share'));
+			}
+
+			if (is_string($data)) {
+				$data = json_decode($data, true);
+			}
+			if (!is_array($data)) {
+				return $this->handleBadRequestError(new BadRequestError('Invalid data input'));
+			}
+
+			$newRowData = new RowDataInput();
+			foreach ($data as $key => $value) {
+				$newRowData->add((int)$key, $value);
+			}
+
+			$tableId = $share->getNodeType() === 'table' ? $share->getNodeId() : null;
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+
+			if ($viewId === null && $tableId === null) {
+				throw new InternalError('Cannot create row without table or view provided');
+			}
+
+			$row = $this->rowService->create($tableId, $viewId, $newRowData);
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (BadRequestError $e) {
+			return $this->handleBadRequestError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Update a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param int $rowId The row identifier
+	 * @param string|array<string, mixed> $data An array containing the column identifiers and their values
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row updated
+	 * 400: Invalid request parameters
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'PUT', url: '/api/2/public/{token}/rows/{rowId}', requirements: ['token' => '[a-zA-Z0-9]{16}', 'rowId' => '\d+'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function updateRow(string $token, int $rowId, mixed $data): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionUpdate()) {
+				return $this->handlePermissionError(new PermissionError('No update permission on this share'));
+			}
+
+			if (is_string($data)) {
+				$data = json_decode($data, true);
+			}
+			if (!is_array($data)) {
+				return $this->handleBadRequestError(new BadRequestError('Invalid data input'));
+			}
+
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+			$tableId = $share->getNodeType() === 'table' ? $share->getNodeId() : null;
+
+			if ($viewId === null && $tableId === null) {
+				throw new InternalError('Cannot update row without table or view provided');
+			}
+
+			$row = $this->rowService->updateSet($rowId, $viewId, $data, '', $tableId);
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (BadRequestError $e) {
+			return $this->handleBadRequestError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
+		}
+	}
+
+	/**
+	 * [api v2] Delete a row in a link share
+	 *
+	 * @param string $token The share token
+	 * @param int $rowId The row identifier
+	 * @return DataResponse<Http::STATUS_OK, TablesPublicRow, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Row deleted
+	 * 403: No permissions
+	 * 404: Not found
+	 * 500: Internal error
+	 */
+	#[PublicPage]
+	#[AssertShareAccessIsAccessible]
+	#[ApiRoute(verb: 'DELETE', url: '/api/2/public/{token}/rows/{rowId}', requirements: ['token' => '[a-zA-Z0-9]{16}', 'rowId' => '\d+'])]
+	#[OpenAPI]
+	#[AnonRateLimit(limit: 20, period: 30)]
+	public function deleteRow(string $token, int $rowId): DataResponse {
+		try {
+			$shareToken = new ShareToken($token);
+			$share = $this->shareService->findByToken($shareToken);
+			$this->row2Mapper->setUserId('public-' . $token);
+
+			if (!$share->getPermissionDelete()) {
+				return $this->handlePermissionError(new PermissionError('No delete permission on this share'));
+			}
+
+			$viewId = $share->getNodeType() === 'view' ? $share->getNodeId() : null;
+			$tableId = $share->getNodeType() === 'table' ? $share->getNodeId() : null;
+
+			if ($viewId === null && $tableId === null) {
+				throw new InternalError('Cannot delete row without table or view provided');
+			}
+
+			$row = $this->rowService->delete($rowId, $viewId, '', $tableId);
+			return new DataResponse($this->rowService->formatRowsForPublicShare([$row])[0]);
+		} catch (PermissionError $e) {
+			return $this->handlePermissionError($e);
+		} catch (NotFoundError $e) {
+			return $this->handleNotFoundError($e);
+		} catch (InternalError|\Exception $e) {
+			return $this->handleError($e);
 		}
 	}
 }

--- a/lib/Controller/PublicSharePageController.php
+++ b/lib/Controller/PublicSharePageController.php
@@ -71,6 +71,12 @@ class PublicSharePageController extends AuthPublicShareController {
 		$this->initialState->provideInitialState('shareToken', (string)$this->shareToken);
 		$this->initialState->provideInitialState('nodeType', $this->share->getNodeType());
 		$this->initialState->provideInitialState('nodeData', $nodeData);
+		$this->initialState->provideInitialState('sharePermissions', [
+			'read' => $this->share->getPermissionRead(),
+			'create' => $this->share->getPermissionCreate(),
+			'update' => $this->share->getPermissionUpdate(),
+			'delete' => $this->share->getPermissionDelete(),
+		]);
 
 		if (class_exists(LoadEditor::class)) {
 			$this->eventDispatcher->dispatchTyped(new LoadEditor());

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -85,7 +85,25 @@ class ShareController extends Controller {
 	#[NoAdminRequired]
 	public function updatePermission(int $id, string $permission, bool $value): DataResponse {
 		return $this->handleError(function () use ($id, $permission, $value) {
-			return $this->service->updatePermission($id, $permission, $value);
+			return $this->service->updatePermission($id, [$permission => $value]);
+		});
+	}
+
+	#[NoAdminRequired]
+	public function updatePermissions(
+		int $id,
+		bool $permissionRead = false,
+		bool $permissionCreate = false,
+		bool $permissionUpdate = false,
+		bool $permissionDelete = false,
+	): DataResponse {
+		return $this->handleError(function () use ($id, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete) {
+			return $this->service->updatePermission($id, [
+				'read' => $permissionRead,
+				'create' => $permissionCreate,
+				'update' => $permissionUpdate && $permissionRead,
+				'delete' => $permissionDelete && $permissionRead,
+			]);
 		});
 	}
 

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -89,6 +89,28 @@ class ShareController extends Controller {
 		});
 	}
 
+	#[NoAdminRequired]
+	public function updatePermissions(
+		int $id,
+		bool $permissionRead = false,
+		bool $permissionCreate = false,
+		bool $permissionUpdate = false,
+		bool $permissionDelete = false,
+	): DataResponse {
+		return $this->handleError(function () use ($id, $permissionRead, $permissionCreate, $permissionUpdate, $permissionDelete) {
+			$permissions = [
+				'read' => $permissionRead,
+				'create' => $permissionCreate,
+				'update' => $permissionUpdate && $permissionRead,
+				'delete' => $permissionDelete && $permissionRead,
+			];
+			foreach ($permissions as $permission => $value) {
+				$this->service->updatePermission($id, $permission, $value);
+			}
+			return $this->service->find($id);
+		});
+	}
+
 	/**
 	 * @psalm-param int<0, 2> $displayMode
 	 * @psalm-param ("default"|"self") $target

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -122,6 +122,10 @@ class Row2Mapper {
 		return $rowSleeve->getTableId();
 	}
 
+	public function setUserId(string $userId): void {
+		$this->userId = $userId;
+	}
+
 	/**
 	 * @return int[]
 	 * @throws InternalError

--- a/lib/Migration/ResetPublicSharePermissions.php
+++ b/lib/Migration/ResetPublicSharePermissions.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Migration;
+
+use OCA\Tables\AppInfo\Application;
+use OCA\Tables\Constants\ShareReceiverType;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class ResetPublicSharePermissions implements IRepairStep {
+
+	public function __construct(
+		protected IConfig $config,
+		protected IDBConnection $dbc,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Reset public link share permissions to read-only for versions before 2.0.2';
+	}
+
+	public function run(IOutput $output): void {
+		$appVersion = $this->config->getAppValue(Application::APP_ID, 'installed_version', '0.0');
+		if (\version_compare($appVersion, '2.0.2', '>=')) {
+			$output->info('Not applicable, skipping.');
+			return;
+		}
+
+		$qb = $this->dbc->getQueryBuilder();
+		$qb->update('tables_shares')
+			->set('permission_read', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
+			->set('permission_create', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->set('permission_update', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->set('permission_delete', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->set('permission_manage', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('receiver_type', $qb->createNamedParameter(ShareReceiverType::LINK, IQueryBuilder::PARAM_STR)))
+			->executeStatement();
+
+		$output->info('Reset public link share permissions to read-only.');
+	}
+}

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -45,6 +45,8 @@ class PermissionsService {
 
 	protected bool $isCli = false;
 
+	private bool $isPublicContext = false;
+
 	private ContextMapper $contextMapper;
 
 	public function __construct(
@@ -549,6 +551,11 @@ class PermissionsService {
 		);
 	}
 
+	public function setPublicContext(): void {
+		$this->userId = '';
+		$this->isPublicContext = true;
+	}
+
 	private function hasPermission(int $existingPermissions, string $permissionName): bool {
 		$constantName = 'PERMISSION_' . strtoupper($permissionName);
 		try {
@@ -634,7 +641,7 @@ class PermissionsService {
 		}
 
 		if ($userId === '') {
-			return true;
+			return $this->isCli || $this->isPublicContext;
 		}
 
 		if ($this->userIsElementOwner($element, $userId, $nodeType)) {

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -178,7 +178,7 @@ class RowService extends SuperService {
 	 * @throws InternalError
 	 */
 	public function create(?int $tableId, ?int $viewId, RowDataInput|array $data): Row2 {
-		if ($this->userId === null || $this->userId === '') {
+		if ($this->userId === null) {
 			$e = new \Exception('No user id in context, but needed.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
@@ -685,7 +685,7 @@ class RowService extends SuperService {
 	 * @throws PermissionError
 	 * @noinspection DuplicatedCode
 	 */
-	public function delete(int $id, ?int $viewId, string $userId): Row2 {
+	public function delete(int $id, ?int $viewId, string $userId, ?int $tableId = null): Row2 {
 		try {
 			$item = $this->getRowById($id);
 		} catch (InternalError $e) {
@@ -720,6 +720,12 @@ class RowService extends SuperService {
 				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
 			}
 		} else {
+			if ($tableId !== null && $tableId !== $item->getTableId()) {
+				$e = new \Exception('Row does not belong to table with id ' . $tableId);
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+			}
+
 			// security
 			if (!$this->permissionsService->canReadRowsByElementId($item->getTableId(), 'table', $userId)) {
 				$e = new \Exception('Row not found.');

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -175,7 +175,7 @@ class RowService extends SuperService {
 	 * @throws InternalError
 	 */
 	public function create(?int $tableId, ?int $viewId, RowDataInput|array $data): Row2 {
-		if ($this->userId === null || $this->userId === '') {
+		if ($this->userId === null) {
 			$e = new \Exception('No user id in context, but needed.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -327,15 +327,46 @@ class ShareService extends SuperService {
 	}
 
 	/**
+	 * @throws InternalError
+	 * @throws NotFoundError
+	 * @throws PermissionError
+	 */
+	private function applyPermissions(Share $item, array $permissions): Share {
+		$time = new DateTime();
+		if (isset($permissions['read'])) {
+			$item->setPermissionRead($permissions['read']);
+		}
+		if (isset($permissions['create'])) {
+			$item->setPermissionCreate($permissions['create']);
+		}
+		if (isset($permissions['update'])) {
+			$item->setPermissionUpdate($permissions['update']);
+		}
+		if (isset($permissions['delete'])) {
+			$item->setPermissionDelete($permissions['delete']);
+		}
+		if (isset($permissions['manage'])) {
+			$item->setPermissionManage($permissions['manage']);
+		}
+		$item->setLastEditAt($time->format('Y-m-d H:i:s'));
+
+		try {
+			return $this->mapper->update($item);
+		} catch (Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		}
+	}
+
+	/**
 	 * @param int $id
-	 * @param string $permission
-	 * @param bool $value
+	 * @param array $permissions
 	 * @return Share
 	 * @throws InternalError
 	 * @throws NotFoundError
 	 * @throws PermissionError
 	 */
-	public function updatePermission(int $id, string $permission, bool $value): Share {
+	public function updatePermission(int $id, array $permissions): Share {
 		try {
 			$item = $this->mapper->find($id);
 		} catch (DoesNotExistException $e) {
@@ -351,36 +382,8 @@ class ShareService extends SuperService {
 			throw new PermissionError('PermissionError: can not update share with id ' . $id);
 		}
 
-		$time = new DateTime();
+		$share = $this->applyPermissions($item, $permissions);
 
-		if ($permission === 'read') {
-			$item->setPermissionRead($value);
-		}
-
-		if ($permission === 'create') {
-			$item->setPermissionCreate($value);
-		}
-
-		if ($permission === 'update') {
-			$item->setPermissionUpdate($value);
-		}
-
-		if ($permission === 'delete') {
-			$item->setPermissionDelete($value);
-		}
-
-		if ($permission === 'manage') {
-			$item->setPermissionManage($value);
-		}
-
-		$item->setLastEditAt($time->format('Y-m-d H:i:s'));
-
-		try {
-			$share = $this->mapper->update($item);
-		} catch (Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
-		}
 		return $this->addReceiverDisplayName($share);
 	}
 

--- a/lib/Service/SuperService.php
+++ b/lib/Service/SuperService.php
@@ -21,4 +21,9 @@ class SuperService {
 		$this->logger = $logger;
 		$this->userId = $userId;
 	}
+
+	public function setPublicContext(): void {
+		$this->userId = '';
+		$this->permissionsService->setPublicContext();
+	}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -13036,6 +13036,714 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "public_rowocs-create-row",
+                "summary": "[api v2] Create a row in a link share",
+                "tags": [
+                    "public_rowocs"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "data"
+                                ],
+                                "properties": {
+                                    "data": {
+                                        "description": "An array containing the column identifiers and their values",
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "The share token",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9]{16}$"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Row created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/PublicRow"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/tables/api/2/public/{token}/rows/{rowId}": {
+            "put": {
+                "operationId": "public_rowocs-update-row",
+                "summary": "[api v2] Update a row in a link share",
+                "tags": [
+                    "public_rowocs"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "data"
+                                ],
+                                "properties": {
+                                    "data": {
+                                        "description": "An array containing the column identifiers and their values",
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "The share token",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9]{16}$"
+                        }
+                    },
+                    {
+                        "name": "rowId",
+                        "in": "path",
+                        "description": "The row identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Row updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/PublicRow"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "public_rowocs-delete-row",
+                "summary": "[api v2] Delete a row in a link share",
+                "tags": [
+                    "public_rowocs"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "description": "The share token",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-zA-Z0-9]{16}$"
+                        }
+                    },
+                    {
+                        "name": "rowId",
+                        "in": "path",
+                        "description": "The row identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Row deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/PublicRow"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/ocs/v2.php/apps/tables/api/2/{nodeCollection}/{nodeId}/share": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3208,6 +3208,17 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
     "node_modules/@nextcloud/dialogs/node_modules/@vue/devtools-shared": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
@@ -3392,6 +3403,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nextcloud/dialogs/node_modules/readdirp": {
@@ -6092,6 +6126,34 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
     },
     "node_modules/@vue/eslint-config-typescript": {
       "version": "13.0.0",
@@ -13853,6 +13915,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -15426,6 +15496,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rollup-plugin-license/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rollup-plugin-node-externals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,6 +3209,17 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@nextcloud/dialogs/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
     "node_modules/@nextcloud/dialogs/node_modules/@vue/devtools-shared": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
@@ -3393,6 +3404,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nextcloud/dialogs/node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nextcloud/dialogs/node_modules/readdirp": {
@@ -4754,9 +4788,6 @@
       "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -6165,6 +6196,34 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
     },
     "node_modules/@vue/eslint-config-typescript": {
       "version": "13.0.0",
@@ -13926,6 +13985,14 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -15581,6 +15648,21 @@
         }
       }
     },
+    "node_modules/rollup-plugin-license/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rollup-plugin-node-externals": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.1.1.tgz",
@@ -15611,9 +15693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/playwright/e2e/tables-sharing-link.spec.ts
+++ b/playwright/e2e/tables-sharing-link.spec.ts
@@ -23,32 +23,76 @@ async function setupPublicShareTable(page: Page, title: string) {
 	await loadTable(page, title)
 }
 
+async function createPublicLinkShare(page: Page, options: { password?: string, permissions?: { read?: boolean, create?: boolean, update?: boolean, delete?: boolean } } = {}) {
+	const menuButton = page.locator('[data-cy="customTableAction"] button').first()
+	await menuButton.waitFor({ state: 'visible' })
+	await menuButton.hover()
+	await menuButton.click({ force: true })
+	await page.locator('[data-cy="dataTableShareBtn"]').click()
+	await expect(page.getByText('Public links')).toBeVisible()
+
+	const createShareReqPromise = page.waitForResponse(r => r.url().includes('/apps/tables/api/2/tables/') && r.url().includes('/share') && r.request().method() === 'POST')
+
+	await page.locator('[data-cy="sharingEntryLinkCreateButton"]').click()
+
+	if (options.password) {
+		await page.locator('[data-cy="sharingEntryLinkPasswordCheck"]').click()
+		await page.locator('[data-cy="sharingEntryLinkPasswordInput"] input').fill(options.password)
+	}
+
+	await page.locator('[data-cy="sharingEntryLinkCreateFormCreateButton"]').click()
+
+	const interception = await createShareReqPromise
+	expect(interception.status()).toBe(200)
+	const body = await interception.json()
+	const shareToken = body.ocs.data.shareToken
+	expect(typeof shareToken).toBe('string')
+
+	if (options.permissions) {
+		await setSharePermissions(page, options.permissions)
+	}
+
+	return shareToken as string
+}
+
+async function setSharePermissions(page: Page, permissions: { read?: boolean, create?: boolean, update?: boolean, delete?: boolean }) {
+	const isCanEdit = permissions.read && permissions.create && permissions.update && permissions.delete
+	const isViewOnly = permissions.read && !permissions.create && !permissions.update && !permissions.delete
+
+	await page.locator('.share-permission-select .action-item__menutoggle').click()
+
+	if (isCanEdit) {
+		await page.locator('button[role="menuitemradio"]').filter({ hasText: 'Can edit' }).click()
+	} else if (isViewOnly) {
+		await page.locator('button[role="menuitemradio"]').filter({ hasText: 'View only' }).click()
+	} else {
+		await page.locator('button[role="menuitemradio"]').filter({ hasText: 'Custom permissions' }).click()
+		for (const [key, value] of Object.entries(permissions)) {
+			if (value === undefined) continue
+			const checkbox = page.locator(`[data-cy="sharePermission${key.charAt(0).toUpperCase() + key.slice(1)}"] input[type="checkbox"]`)
+			const isChecked = await checkbox.isChecked()
+			if (isChecked !== value) {
+				await checkbox.click({ force: true })
+				await page.waitForResponse(r => r.url().includes('/share/') && r.url().includes('/permissions') && r.request().method() === 'PUT')
+				await page.waitForResponse(r => r.url().includes('/apps/tables/share/') && r.request().method() === 'GET')
+			}
+		}
+		return
+	}
+
+	await page.waitForResponse(r => r.url().includes('/share/') && r.url().includes('/permissions') && r.request().method() === 'PUT')
+}
+
 test.describe('Public link sharing', () => {
 
 	test('Create, access and delete a public link share', async ({ userPage: { page } }) => {
 		const tableTitle = 'Public Share Test Table 1'
 		await setupPublicShareTable(page, tableTitle)
-
-		const menuButton1 = page.locator('[data-cy="customTableAction"] button').first()
-		await menuButton1.waitFor({ state: 'visible' })
-		await menuButton1.hover()
-		await menuButton1.click({ force: true })
-		await page.locator('[data-cy="dataTableShareBtn"]').click()
-		await expect(page.getByText('Public links')).toBeVisible()
-
-		const createShareReqPromise = page.waitForResponse(r => r.url().includes('/apps/tables/api/2/tables/') && r.url().includes('/share') && r.request().method() === 'POST')
-		await page.locator('[data-cy="sharingEntryLinkCreateButton"]').click()
-		await page.locator('[data-cy="sharingEntryLinkCreateFormCreateButton"]').click()
-
-		const interception = await createShareReqPromise
-		expect(interception.status()).toBe(200)
-		const body = await interception.json()
-		const shareToken = body.ocs.data.shareToken
-		expect(typeof shareToken).toBe('string')
+		const origin = new URL(page.url()).origin
+		const shareToken = await createPublicLinkShare(page)
 
 		const publicContext = await page.context().browser()!.newContext()
 		const publicPage = await publicContext.newPage()
-		const origin = new URL(page.url()).origin
 		await publicPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
 		await expect(publicPage.locator('[data-cy="publicTableElement"]')).toBeVisible({ timeout: 15000 })
 		await expect(publicPage.locator('h1').filter({ hasText: tableTitle })).toBeVisible({ timeout: 15000 })
@@ -82,35 +126,11 @@ test.describe('Public link sharing', () => {
 		const tableTitle = 'Public Share Test Table 2'
 		await setupPublicShareTable(page, tableTitle)
 		const password = 'extremelySafePassword123'
-
-		const menuButton3 = page.locator('[data-cy="customTableAction"] button').first()
-		await menuButton3.waitFor({ state: 'visible' })
-		await menuButton3.hover()
-		await menuButton3.click({ force: true })
-		await page.locator('[data-cy="dataTableShareBtn"]').click()
-		await expect(page.getByText('Public links')).toBeVisible()
-
-		const createShareReqPromise = page.waitForResponse(r => r.url().includes('/apps/tables/api/2/tables/') && r.url().includes('/share') && r.request().method() === 'POST')
-
-		// Open create form
-		await page.locator('[data-cy="sharingEntryLinkCreateButton"]').click()
-
-		// Set password
-		await page.locator('[data-cy="sharingEntryLinkPasswordCheck"]').click()
-		await page.locator('[data-cy="sharingEntryLinkPasswordInput"] input').fill(password)
-
-		// Create
-		await page.locator('[data-cy="sharingEntryLinkCreateFormCreateButton"]').click()
-
-		const interception = await createShareReqPromise
-		expect(interception.status()).toBe(200)
-		const body = await interception.json()
-		const shareToken = body.ocs.data.shareToken
-		expect(typeof shareToken).toBe('string')
+		const origin = new URL(page.url()).origin
+		const shareToken = await createPublicLinkShare(page, { password })
 
 		const publicContext = await page.context().browser()!.newContext()
 		const publicPage = await publicContext.newPage()
-		const origin = new URL(page.url()).origin
 		await publicPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
 
 		// Password Gate
@@ -140,5 +160,91 @@ test.describe('Public link sharing', () => {
 		await verifyPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
 		await expect(verifyPage.locator('h2').filter({ hasText: 'Share not found' })).toBeVisible()
 		await verifyContext.close()
+	})
+
+	test('View only public share has no create/edit/delete buttons', async ({ userPage: { page } }) => {
+		const tableTitle = 'Public Share Permissions - View only'
+		await setupPublicShareTable(page, tableTitle)
+		const origin = new URL(page.url()).origin
+		const shareToken = await createPublicLinkShare(page)
+
+		const publicContext = await page.context().browser()!.newContext()
+		const publicPage = await publicContext.newPage()
+		await publicPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
+		await expect(publicPage.locator('[data-cy="publicTableElement"]')).toBeVisible({ timeout: 15000 })
+		await expect(publicPage.getByRole('button', { name: /Create row/i })).toHaveCount(0)
+		await expect(publicPage.locator('[data-cy="editRowBtn"]')).toHaveCount(0)
+		await publicContext.close()
+	})
+
+	test('Can edit public share allows create, edit and delete rows', async ({ userPage: { page } }) => {
+		const tableTitle = 'Public Share Permissions Test - Can edit'
+		await setupPublicShareTable(page, tableTitle)
+		const origin = new URL(page.url()).origin
+		const shareToken = await createPublicLinkShare(page, {
+			permissions: { read: true, create: true, update: true, delete: true },
+		})
+
+		const publicContext = await page.context().browser()!.newContext()
+		const publicPage = await publicContext.newPage()
+		await publicPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
+		await expect(publicPage.locator('[data-cy="publicTableElement"]')).toBeVisible({ timeout: 15000 })
+
+		// Verify create button exists
+		await expect(publicPage.getByRole('button', { name: /Create row/i })).toBeVisible()
+
+		// Create a row
+		await publicPage.getByRole('button', { name: /Create row/i }).click()
+		await expect(publicPage.locator('[data-cy="createRowModal"]')).toBeVisible()
+		await publicPage.locator('[data-cy="createRowModal"]').getByRole('textbox').first().fill('Test row for editing')
+		await publicPage.locator('[data-cy="createRowSaveButton"]').click()
+		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Test row for editing')).toBeVisible()
+
+		// Verify edit button exists and edit the row
+		await expect(publicPage.locator('[data-cy="editRowBtn"]').last()).toBeVisible()
+		await publicPage.locator('[data-cy="editRowBtn"]').last().click()
+		await expect(publicPage.locator('[data-cy="editRowModal"]')).toBeVisible()
+		await publicPage.locator('[data-cy="editRowModal"]').getByRole('textbox').first().fill('Updated row')
+		await publicPage.locator('[data-cy="editRowSaveButton"]').click()
+		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Updated row')).toBeVisible()
+		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Test row for editing')).toHaveCount(0)
+
+		// Delete the row
+		await publicPage.locator('[data-cy="editRowBtn"]').last().click()
+		await expect(publicPage.locator('[data-cy="editRowModal"]')).toBeVisible()
+		await publicPage.locator('[data-cy="editRowDeleteButton"]').click()
+		await publicPage.locator('[data-cy="editRowDeleteConfirmButton"]').click()
+		await expect(publicPage.locator('[data-cy="editRowModal"]')).toBeHidden()
+		await expect(publicPage.locator('[data-cy="ncTable"]').getByText('Updated row')).toHaveCount(0)
+
+		await publicContext.close()
+	})
+
+	test('Create only public share shows form mode and allows submitting', async ({ userPage: { page } }) => {
+		const tableTitle = 'Public Share Permissions Test - Create only'
+		await setupPublicShareTable(page, tableTitle)
+		const origin = new URL(page.url()).origin
+		const shareToken = await createPublicLinkShare(page, {
+			permissions: { read: false, create: true, update: false, delete: false },
+		})
+
+		const publicContext = await page.context().browser()!.newContext()
+		const publicPage = await publicContext.newPage()
+		await publicPage.goto(`${origin}/index.php/apps/tables/s/${shareToken}`)
+
+		await expect(publicPage.getByText('This is a public form.')).toBeVisible({ timeout: 15000 })
+		await expect(publicPage.getByRole('button', { name: /Fill form/i })).toBeVisible()
+		await expect(publicPage.locator('[data-cy="ncTable"] table')).toHaveCount(0)
+
+		await publicPage.getByRole('button', { name: /Fill form/i }).click()
+		await expect(publicPage.locator('[data-cy="createRowModal"]')).toBeVisible()
+		await publicPage.locator('[data-cy="createRowModal"]').getByRole('textbox').first().fill('Form submission')
+		await publicPage.locator('[data-cy="createRowSaveButton"]').click()
+		await expect(publicPage.locator('.toastify.toast-success')).toBeVisible()
+		await publicContext.close()
+
+		await page.goto('/index.php/apps/tables')
+		await loadTable(page, tableTitle)
+		await expect(page.locator('[data-cy="ncTable"]').getByText('Form submission')).toBeVisible()
 	})
 })

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -18,6 +18,7 @@
 		:can-edit-columns="canEditColumns"
 		:can-delete-columns="canDeleteColumns"
 		:can-delete-table="canDeleteTable"
+		:is-form-mode="isFormMode"
 		@import="openImportModal"
 		@create-column="createColumn"
 		@edit-column="editColumn"
@@ -98,6 +99,10 @@ export default {
 		canDeleteTable: {
 			type: Boolean,
 			default: true,
+		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/modules/main/sections/ElementTitle.vue
+++ b/src/modules/main/sections/ElementTitle.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="row first-row">
+	<div class="row first-row" :class="{ 'form-mode': isFormMode }">
 		<h1>
 			{{ activeElement.emoji }}&nbsp;{{ activeElement.title }}
 		</h1>
@@ -60,6 +60,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		isFiltered() {
@@ -96,6 +100,11 @@ export default {
 	z-index: 15;
 	background-color: var(--color-main-background);
 	align-items: center;
+
+	&.form-mode {
+		flex-direction: column;
+		text-align: center;
+	}
 }
 
 .user-bubble {

--- a/src/modules/main/sections/ElementTitle.vue
+++ b/src/modules/main/sections/ElementTitle.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="row first-row">
+	<div class="row first-row" :class="{ 'form-mode': isFormMode }">
 		<h1>
 			{{ activeElement.emoji }}&nbsp;{{ activeElement.title }}
 		</h1>
@@ -60,6 +60,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		isFiltered() {
@@ -97,6 +101,11 @@ export default {
 	background-color: var(--color-main-background);
 	align-items: center;
 	width: var(--app-content-width, 100%);
+
+	&.form-mode {
+		flex-direction: column;
+		text-align: center;
+	}
 }
 
 .user-bubble {

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -4,13 +4,20 @@
 -->
 <template>
 	<div>
-		<ElementTitle :active-element="element" :is-table="false" :view-setting.sync="localViewSetting" />
+		<ElementTitle :active-element="element" :is-table="false" :view-setting.sync="localViewSetting" :is-form-mode="isFormMode" />
 		<TableDescription :description="element.description" :read-only="true" />
 		<div class="table-wrapper">
 			<EmptyView v-if="columns.length === 0" :view="element" />
-			<TableView v-else :rows="rows" :columns="columns" :element="element" :can-read-rows="true"
-				:can-create-rows="false" :can-edit-rows="false" :can-delete-rows="false" :can-create-columns="false"
-				:can-edit-columns="false" :can-delete-columns="false" :can-delete-table="false">
+			<TableView v-else :rows="rows" :columns="columns" :element="element"
+				:can-read-rows="element.onSharePermissions.read"
+				:can-create-rows="element.onSharePermissions.create"
+				:can-edit-rows="element.onSharePermissions.update"
+				:can-delete-rows="element.onSharePermissions.delete"
+				:can-create-columns="false"
+				:can-edit-columns="false"
+				:can-delete-columns="false"
+				:can-delete-table="false"
+				:is-form-mode="isFormMode">
 				<template #actions>
 					<NcActions :force-menu="true" type="tertiary">
 						<NcActionButton :close-after-click="true" icon="icon-download" data-cy="dataTableExportBtn"
@@ -21,6 +28,27 @@
 				</template>
 			</TableView>
 		</div>
+		<CreateRow
+			:columns="columns"
+			:is-view="false"
+			:element-id="element.id"
+			:is-form-mode="isFormMode"
+			:show-modal="showCreateRow"
+			@close="showCreateRow = false" />
+		<DeleteRows
+			v-if="rowsToDelete"
+			:rows-to-delete="rowsToDelete?.rows"
+			:element-id="element.id"
+			:is-view="false"
+			@cancel="rowsToDelete = null" />
+		<EditRow
+			:columns="editRow?.columns"
+			:row="editRow?.row"
+			:is-view="false"
+			:element="element"
+			:show-modal="editRow !== null"
+			:out-transition="true"
+			@close="editRow = null" />
 	</div>
 </template>
 
@@ -30,10 +58,17 @@ import EmptyView from './EmptyView.vue'
 import TableDescription from './TableDescription.vue'
 import ElementTitle from './ElementTitle.vue'
 import { NcActions, NcActionButton } from '@nextcloud/vue'
+import CreateRow from '../../modals/CreateRow.vue'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import EditRow from '../../modals/EditRow.vue'
+import DeleteRows from '../../modals/DeleteRows.vue'
 
 export default {
 	name: 'PublicElement',
 	components: {
+		CreateRow,
+		DeleteRows,
+		EditRow,
 		EmptyView,
 		TableView,
 		NcActions,
@@ -55,6 +90,38 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+	},
+
+	data() {
+		return {
+			showCreateRow: false,
+			editRow: null,
+			rowsToDelete: null,
+		}
+	},
+
+	computed: {
+		isFormMode() {
+			return this.element.onSharePermissions.create && !this.element.onSharePermissions.read
+		},
+	},
+
+	mounted() {
+		subscribe('tables:row:create', () => {
+			this.showCreateRow = true
+		})
+		subscribe('tables:row:edit', rowInfo => {
+			this.editRow = rowInfo
+		})
+		subscribe('tables:row:delete', tableInfo => {
+			this.rowsToDelete = tableInfo
+		})
+	},
+
+	unmounted() {
+		unsubscribe('tables:row:create')
+		unsubscribe('tables:row:edit')
+		unsubscribe('tables:row:delete')
 	},
 }
 </script>

--- a/src/modules/main/sections/PublicMainWrapper.vue
+++ b/src/modules/main/sections/PublicMainWrapper.vue
@@ -20,6 +20,9 @@ import { useDataStore } from '../../../store/data.js'
 import { computed } from 'vue'
 import { loadState } from '@nextcloud/initial-state'
 
+const nodeData = loadState('tables', 'nodeData', null)
+const sharePermissions = loadState('tables', 'sharePermissions', null)
+
 export default {
 	name: 'PublicMainWrapper',
 
@@ -43,9 +46,8 @@ export default {
 		const stateKey = 'public-' + props.token
 		const rows = computed(() => getRows.value(false, stateKey))
 		const columns = computed(() => getColumns.value(false, stateKey))
-		const nodeData = loadState('tables', 'nodeData')
 
-		return { rows, columns, nodeData }
+		return { rows, columns }
 	},
 
 	data() {
@@ -53,33 +55,28 @@ export default {
 			loading: false,
 			publicElement: {
 				id: 'public',
-				emoji: this.nodeData.emoji,
-				title: this.nodeData.title,
-				description: this.nodeData.description,
+				emoji: nodeData.emoji,
+				title: nodeData.title,
+				description: nodeData.description,
 				isShared: false, // Setting as false to hide the user bubble
 				onSharePermissions: {
-					read: true,
+					read: sharePermissions.read,
+					create: sharePermissions.create,
+					update: sharePermissions.update,
+					delete: sharePermissions.delete,
 					manage: false,
-					share: false,
-					update: false,
-					create: false,
-					delete: false,
 				},
-				permissionDelete: false,
-				permissionManage: false,
-				permissionShare: false,
-				permissionUpdate: false,
-				permissionCreate: false,
 			},
 		}
 	},
 
 	beforeMount() {
+		this.setPublicToken(this.token)
 		this.loadData()
 	},
 
 	methods: {
-		...mapActions(useDataStore, ['loadPublicColumnsFromBE', 'loadPublicRowsFromBE']),
+		...mapActions(useDataStore, ['loadPublicColumnsFromBE', 'loadPublicRowsFromBE', 'setPublicToken']),
 
 		async loadData() {
 			this.loading = true

--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<NcDialog v-if="showModal"
-		:name="t('tables', 'Create row')"
+		:name="dialogTitle"
 		size="large"
 		data-cy="createRowModal"
 		@closing="actionCancel">
@@ -26,11 +26,11 @@
 				<div class="fix-col-4 space-T end">
 					<div class="padding-right">
 						<NcCheckboxRadioSwitch :checked.sync="addNewAfterSave" type="switch" data-cy="createRowAddMoreSwitch">
-							{{ t('tables', 'Add more') }}
+							{{ addMoreLabel }}
 						</NcCheckboxRadioSwitch>
 					</div>
 					<NcButton v-if="!localLoading" class="primary" :aria-label="t('tables', 'Save row')" :disabled="hasEmptyMandatoryRows || hasInvalidUrlProtocol" data-cy="createRowSaveButton" @click="actionConfirm()">
-						{{ t('tables', 'Save') }}
+						{{ saveButtonLabel }}
 					</NcButton>
 				</div>
 			</div>
@@ -76,6 +76,10 @@ export default {
 			type: Number,
 			default: null,
 		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -95,6 +99,15 @@ export default {
 		hasInvalidUrlProtocol() {
 			return this.nonMetaColumns.some(col => col.type === 'text-link' && !this.isValidUrlProtocol(this.row[col.id]))
 		},
+		dialogTitle() {
+			return this.isFormMode ? t('tables', 'Fill form') : t('tables', 'Create row')
+		},
+		addMoreLabel() {
+			return this.isFormMode ? t('tables', 'Fill form again') : t('tables', 'Add more')
+		},
+		saveButtonLabel() {
+			return this.isFormMode ? t('tables', 'Submit') : t('tables', 'Save')
+		},
 	},
 	watch: {
 		showModal() {
@@ -106,7 +119,7 @@ export default {
 		},
 	},
 	methods: {
-		...mapActions(useDataStore, ['insertNewRow']),
+		...mapActions(useDataStore, ['insertNewRow', 'insertPublicRow']),
 		t,
 		actionCancel() {
 			this.reset()
@@ -121,10 +134,15 @@ export default {
 			if (!success) {
 				return
 			}
+
+			const successMessage = this.isFormMode
+				? t('tables', 'Form successfully submitted.')
+				: t('tables', 'Row successfully created.')
+			showSuccess(successMessage)
+
 			if (!this.addNewAfterSave) {
 				this.actionCancel()
 			} else {
-				showSuccess(t('tables', 'Row successfully created.'))
 				this.reset()
 			}
 		},
@@ -139,6 +157,12 @@ export default {
 				for (const [key, value] of Object.entries(this.row)) {
 					data[key] = value
 				}
+
+				const token = useDataStore().publicToken
+				if (token) {
+					return await this.insertPublicRow({ token, data })
+				}
+
 				return await this.insertNewRow({
 					viewId: this.isView ? this.elementId : null,
 					tableId: !this.isView ? this.elementId : null,

--- a/src/modules/modals/DeleteRows.vue
+++ b/src/modules/modals/DeleteRows.vue
@@ -40,17 +40,20 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		token: {
+			type: String,
+			default: null,
+		},
 	},
 	methods: {
-		...mapActions(useDataStore, ['removeRow']),
+		...mapActions(useDataStore, ['removeRow', 'removePublicRow']),
 		deleteRows() {
+			const token = useDataStore().publicToken
 			let error = false
 			this.rowsToDelete.forEach(rowId => {
-				const res = this.removeRow({
-					rowId,
-					isView: this.isView,
-					elementId: this.elementId,
-				})
+				const res = token
+					? this.removePublicRow({ token, rowId })
+					: this.removeRow({ rowId, isView: this.isView, elementId: this.elementId })
 				if (!res) {
 					error = true
 				}

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -175,7 +175,7 @@ export default {
 		this.loadValues()
 	},
 	methods: {
-		...mapActions(useDataStore, ['updateRow', 'removeRow']),
+		...mapActions(useDataStore, ['updateRow', 'removeRow', 'updatePublicRow', 'removePublicRow']),
 		...mapActions(useTablesStore, ['setActiveRowId']),
 		t,
 		loadValues() {
@@ -229,6 +229,11 @@ export default {
 				})
 			}
 
+			const token = useDataStore().publicToken
+			if (token) {
+				return await this.updatePublicRow({ token, rowId: this.row.id, data })
+			}
+
 			return await this.updateRow({
 				id: this.row.id,
 				isView: this.isView,
@@ -248,11 +253,10 @@ export default {
 			await this.loadStore()
 
 			this.localLoading = true
-			const res = await this.removeRow({
-				rowId,
-				isView: this.isView,
-				elementId: this.element.id,
-			})
+			const token = useDataStore().publicToken
+			const res = token
+				? await this.removePublicRow({ token, rowId })
+				: await this.removeRow({ rowId, isView: this.isView, elementId: this.element.id })
 			if (!res) {
 				showError(t('tables', 'Could not delete row.'))
 			}

--- a/src/modules/sidebar/mixins/shareAPI.js
+++ b/src/modules/sidebar/mixins/shareAPI.js
@@ -128,6 +128,14 @@ export default {
 			}
 		},
 
+		async updateSharePermissionsToBE(shareId, data) {
+			try {
+				await axios.put(generateUrl('/apps/tables/share/' + shareId + '/permissions'), data)
+			} catch (e) {
+				displayError(e, t('tables', 'Could not update share.'))
+			}
+		},
+
 		isValidShareType(shareType) {
 			return [
 				this.SHARE_TYPES.SHARE_TYPE_USER,

--- a/src/modules/sidebar/partials/SharePermissionSelect.vue
+++ b/src/modules/sidebar/partials/SharePermissionSelect.vue
@@ -1,0 +1,219 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="share-permission-select">
+		<NcActions
+			ref="quickShareActions"
+			:menu-name="selectedOption"
+			:aria-label="t('tables', 'Quick share options, current: {option}', { option: selectedOption })"
+			variant="tertiary-no-background"
+			force-name>
+			<template #icon>
+				<TriangleSmallDown :size="15" />
+			</template>
+			<NcActionButton
+				v-for="option in options"
+				:key="option.label"
+				type="radio"
+				:model-value="option.label === selectedOption"
+				close-after-click
+				@click="selectOption(option.label)">
+				<template #icon>
+					<component :is="option.icon" :size="20" />
+				</template>
+				{{ option.label }}
+			</NcActionButton>
+		</NcActions>
+
+		<div v-if="showCustom" class="share-permission-select__custom">
+			<NcCheckboxRadioSwitch
+				:checked="share.permissionRead"
+				data-cy="sharePermissionRead"
+				@update:checked="updateCustom('permissionRead', $event)">
+				{{ t('tables', 'Read') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
+				:checked="share.permissionCreate"
+				data-cy="sharePermissionCreate"
+				@update:checked="updateCustom('permissionCreate', $event)">
+				{{ t('tables', 'Create') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
+				:checked="share.permissionUpdate"
+				:disabled="!share.permissionRead"
+				data-cy="sharePermissionUpdate"
+				@update:checked="updateCustom('permissionUpdate', $event)">
+				{{ t('tables', 'Update') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
+				:checked="share.permissionDelete"
+				:disabled="!share.permissionRead"
+				data-cy="sharePermissionDelete"
+				@update:checked="updateCustom('permissionDelete', $event)">
+				{{ t('tables', 'Delete') }}
+			</NcCheckboxRadioSwitch>
+		</div>
+	</div>
+</template>
+
+<script>
+import { t } from '@nextcloud/l10n'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import EyeOutline from 'vue-material-design-icons/EyeOutline.vue'
+import PencilOutline from 'vue-material-design-icons/PencilOutline.vue'
+import Tune from 'vue-material-design-icons/Tune.vue'
+import TriangleSmallDown from 'vue-material-design-icons/TriangleSmallDown.vue'
+
+export default {
+	name: 'SharePermissionSelect',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcCheckboxRadioSwitch,
+		TriangleSmallDown,
+	},
+
+	props: {
+		share: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	emits: ['update:share'],
+
+	data() {
+		return {
+			selectedOption: '',
+			showCustom: false,
+		}
+	},
+
+	computed: {
+		viewOnlyText() {
+			return t('tables', 'View only')
+		},
+		canEditText() {
+			return t('tables', 'Can edit')
+		},
+		customText() {
+			return t('tables', 'Custom permissions')
+		},
+
+		options() {
+			return [
+				{ label: this.viewOnlyText, icon: EyeOutline },
+				{ label: this.canEditText, icon: PencilOutline },
+				{ label: this.customText, icon: Tune },
+			]
+		},
+
+		preSelectedOption() {
+			const { permissionRead, permissionCreate, permissionUpdate, permissionDelete } = this.share
+
+			const isViewOnly = permissionRead && !permissionCreate && !permissionUpdate && !permissionDelete
+			const isCanEdit = permissionRead && permissionCreate && permissionUpdate && permissionDelete
+
+			if (isViewOnly) {
+				return this.viewOnlyText
+			}
+			if (isCanEdit) {
+				return this.canEditText
+			}
+			return this.customText
+		},
+	},
+
+	created() {
+		this.selectedOption = this.preSelectedOption
+		this.showCustom = this.selectedOption === this.customText
+	},
+
+	methods: {
+		t,
+
+		selectOption(label) {
+			this.selectedOption = label
+			this.showCustom = label === this.customText
+
+			if (label !== this.customText) {
+				this.$emit('update:share', this.permissionsForOption(label))
+			}
+		},
+
+		permissionsForOption(label) {
+			if (label === this.canEditText) {
+				return {
+					permissionRead: true,
+					permissionCreate: true,
+					permissionUpdate: true,
+					permissionDelete: true,
+				}
+			}
+			return {
+				permissionRead: true,
+				permissionCreate: false,
+				permissionUpdate: false,
+				permissionDelete: false,
+			}
+		},
+
+		updateCustom(key, value) {
+			const updated = {
+				permissionRead: this.share.permissionRead,
+				permissionCreate: this.share.permissionCreate,
+				permissionUpdate: this.share.permissionUpdate,
+				permissionDelete: this.share.permissionDelete,
+				...{ [key]: value },
+			}
+			if (!updated.permissionRead) {
+				updated.permissionUpdate = false
+				updated.permissionDelete = false
+			}
+			this.$emit('update:share', updated)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.share-permission-select {
+  display: flex;
+  flex-direction: column;
+
+  :deep(.action-item__menutoggle) {
+    color: var(--color-primary-element) !important;
+    font-size: 12.5px !important;
+    height: auto !important;
+    min-height: auto !important;
+
+    .button-vue__text {
+      font-weight: normal !important;
+    }
+
+    .button-vue__icon {
+      height: 24px !important;
+      min-height: 24px !important;
+      width: 24px !important;
+      min-width: 24px !important;
+    }
+
+    .button-vue__wrapper {
+      flex-direction: row-reverse !important;
+    }
+  }
+
+  &__custom {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding-top: 8px;
+  }
+}
+</style>

--- a/src/modules/sidebar/partials/SharingEntryLink.vue
+++ b/src/modules/sidebar/partials/SharingEntryLink.vue
@@ -63,7 +63,7 @@
 							{{ t('tables', 'Share link') }}
 						</span>
 						<div class="sharing-entry-link__subtitle">
-							{{ t('tables', 'View only') }}
+							<SharePermissionSelect :share="share" @update:share="onUpdatePermissions" />
 							<LockIcon v-if="hasPassword" :size="12" />
 						</div>
 					</div>
@@ -117,11 +117,13 @@ import TrashCan from 'vue-material-design-icons/TrashCan.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import LockIcon from 'vue-material-design-icons/Lock.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import SharePermissionSelect from './SharePermissionSelect.vue'
 
 export default {
 	name: 'SharingEntryLink',
 
 	components: {
+		SharePermissionSelect,
 		NcActions,
 		NcActionButton,
 		NcActionInput,
@@ -213,6 +215,9 @@ export default {
 				this.loading = false
 			}
 		},
+		onUpdatePermissions(data) {
+			this.$emit('update-share', { id: this.share.id, ...data })
+		},
 		copyLink() {
 			this.copyToClipboard(this.linkShareUrl)
 				.then(() => {
@@ -279,10 +284,12 @@ export default {
 	&__row {
 		display: flex;
 		align-items: center;
-		height: 44px;
+		min-height: 44px;
+    height: auto;
 	}
 
 	&__avatar {
+    align-self: flex-start;
 		margin-inline-end: 10px;
 		flex-shrink: 0;
 	}
@@ -311,6 +318,7 @@ export default {
 	}
 
 	&__actions {
+    align-self: flex-start;
 		display: flex;
 		align-items: center;
 		flex-shrink: 0;

--- a/src/modules/sidebar/partials/SharingLinkList.vue
+++ b/src/modules/sidebar/partials/SharingLinkList.vue
@@ -61,7 +61,7 @@ export default {
 			this.$emit('delete-share', share)
 		},
 		onUpdateShare(data) {
-			this.$emit('update-share', data)
+			this.$emit('update-share-permissions', data)
 		},
 	},
 }

--- a/src/modules/sidebar/sections/SidebarSharing.vue
+++ b/src/modules/sidebar/sections/SidebarSharing.vue
@@ -12,7 +12,7 @@
 				:shares="linkShares"
 				@create-link-share="onCreateLinkShare"
 				@delete-share="removeShare"
-				@update-share="updateShare" />
+				@update-share-permissions="updateSharePermissions" />
 		</div>
 	</div>
 </template>
@@ -121,6 +121,12 @@ export default {
 			const shareId = data.id
 			delete data.id
 			await this.updateShareToBE(shareId, data)
+			await this.loadSharesFromBE()
+		},
+		async updateSharePermissions(data) {
+			const shareId = data.id
+			delete data.id
+			await this.updateSharePermissionsToBE(shareId, data)
 			await this.loadSharesFromBE()
 		},
 		async onCreateLinkShare(password) {

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -65,18 +65,19 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				</template>
 			</CustomTable>
 			<NcEmptyContent v-else-if="config.canCreateRows && rows.length === 0"
-				:name="t('tables', 'Create rows')"
-				:description="t('tables', 'You are not allowed to read this table, but you can still create rows.')">
+				:name="emptyStateTitle"
+				:description="emptyStateDescription">
 				<template #icon>
-					<Plus :size="25" />
+					<FileDocumentEditOutline v-if="isFormMode" :size="25" />
+					<Plus v-else :size="25" />
 				</template>
 				<template #action>
-					<NcButton :aria-label="t('tables', 'Create row')" type="primary"
+					<NcButton :aria-label="emptyStateButtonLabel" type="primary"
 						@click="$emit('create-row')">
 						<template #icon>
 							<Plus :size="25" />
 						</template>
-						{{ t('tables', 'Create row') }}
+						{{ emptyStateButtonLabel }}
 					</NcButton>
 				</template>
 			</NcEmptyContent>
@@ -99,6 +100,7 @@ import exportTableMixin from './mixins/exportTableMixin.js'
 import { NcEmptyContent, NcButton } from '@nextcloud/vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Cancel from 'vue-material-design-icons/Cancel.vue'
+import FileDocumentEditOutline from 'vue-material-design-icons/FileDocumentEditOutline.vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { parseCol } from './mixins/columnParser.js'
 import { AbstractColumn } from './mixins/columnClass.js'
@@ -117,7 +119,7 @@ import { getFiltersForColumn } from './mixins/filter.js'
 export default {
 	name: 'NcTable',
 
-	components: { CustomTable, Options, NcButton, NcEmptyContent, Plus, Cancel },
+	components: { CustomTable, Options, NcButton, NcEmptyContent, Plus, Cancel, FileDocumentEditOutline },
 
 	mixins: [exportTableMixin],
 
@@ -198,6 +200,10 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -229,6 +235,15 @@ export default {
 				return this.columns.map(col => parseCol(col))
 			}
 			return this.columns
+		},
+		emptyStateTitle() {
+			return this.isFormMode ? t('tables', 'This is a public form.') : t('tables', 'Create rows')
+		},
+		emptyStateDescription() {
+			return this.isFormMode ? t('tables', 'You can add one or more replies.') : t('tables', 'You are not allowed to read this table, but you can still create rows.')
+		},
+		emptyStateButtonLabel() {
+			return this.isFormMode ? t('tables', 'Fill form') : t('tables', 'Create row')
 		},
 
 		sorting() {

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -65,18 +65,19 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				</template>
 			</CustomTable>
 			<NcEmptyContent v-else-if="config.canCreateRows && rows.length === 0"
-				:name="t('tables', 'Create rows')"
-				:description="t('tables', 'You are not allowed to read this table, but you can still create rows.')">
+				:name="emptyStateTitle"
+				:description="emptyStateDescription">
 				<template #icon>
-					<Plus :size="25" />
+					<FormatListGroupPlus v-if="isFormMode" :size="25" />
+					<Plus v-else :size="25" />
 				</template>
 				<template #action>
-					<NcButton :aria-label="t('tables', 'Create row')" type="primary"
+					<NcButton :aria-label="emptyStateButtonLabel" type="primary"
 						@click="$emit('create-row')">
 						<template #icon>
 							<Plus :size="25" />
 						</template>
-						{{ t('tables', 'Create row') }}
+						{{ emptyStateButtonLabel }}
 					</NcButton>
 				</template>
 			</NcEmptyContent>
@@ -99,6 +100,7 @@ import exportTableMixin from './mixins/exportTableMixin.js'
 import { NcEmptyContent, NcButton } from '@nextcloud/vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Cancel from 'vue-material-design-icons/Cancel.vue'
+import FormatListGroupPlus from 'vue-material-design-icons/FormatListGroupPlus.vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { parseCol } from './mixins/columnParser.js'
 import { AbstractColumn } from './mixins/columnClass.js'
@@ -107,7 +109,7 @@ import { translate as t } from '@nextcloud/l10n'
 export default {
 	name: 'NcTable',
 
-	components: { CustomTable, Options, NcButton, NcEmptyContent, Plus, Cancel },
+	components: { CustomTable, Options, NcButton, NcEmptyContent, Plus, Cancel, FormatListGroupPlus },
 
 	mixins: [exportTableMixin],
 
@@ -188,6 +190,10 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		isFormMode: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -219,6 +225,15 @@ export default {
 				return this.columns.map(col => parseCol(col))
 			}
 			return this.columns
+		},
+		emptyStateTitle() {
+			return this.isFormMode ? t('tables', 'This is a public form.') : t('tables', 'Create rows')
+		},
+		emptyStateDescription() {
+			return this.isFormMode ? t('tables', 'You can add one or more replies.') : t('tables', 'You are not allowed to read this table, but you can still create rows.')
+		},
+		emptyStateButtonLabel() {
+			return this.isFormMode ? t('tables', 'Fill form') : t('tables', 'Create row')
 		},
 	},
 	watch: {

--- a/src/shared/components/ncTable/mixins/cellEditMixin.js
+++ b/src/shared/components/ncTable/mixins/cellEditMixin.js
@@ -43,7 +43,7 @@ export default {
 	},
 
 	methods: {
-		...mapActions(useDataStore, ['updateRow']),
+		...mapActions(useDataStore, ['updateRow', 'updatePublicRow']),
 
 		canEditCell() {
 			// Prevent editing if row editing is globally disabled
@@ -88,12 +88,10 @@ export default {
 				value: newValue,
 			}]
 
-			const res = await this.updateRow({
-				id: this.rowId,
-				isView: this.isView,
-				elementId: this.elementId,
-				data,
-			})
+			const token = useDataStore().publicToken
+			const res = token
+				? await this.updatePublicRow({ token, rowId: this.rowId, data })
+				: await this.updateRow({ id: this.rowId, isView: this.isView, elementId: this.elementId, data })
 
 			if (!res) {
 				showError(t('tables', 'Could not update cell'))

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -22,6 +22,7 @@ export const useDataStore = defineStore('data', {
 		loading: {},
 		rows: {},
 		columns: {},
+		publicToken: null,
 	}),
 
 	getters: {
@@ -40,6 +41,11 @@ export const useDataStore = defineStore('data', {
 			this.loading = {}
 			this.columns = {}
 			this.rows = {}
+			this.publicToken = null
+		},
+
+		setPublicToken(token) {
+			this.publicToken = token
 		},
 
 		// COLUMNS
@@ -211,7 +217,6 @@ export const useDataStore = defineStore('data', {
 			try {
 				res = await axios.get(generateOcsUrl('/apps/tables/api/2/public/' + token + '/rows'))
 			} catch (e) {
-				displayError(e, t('tables', 'Could not load rows.'))
 				return false
 			}
 
@@ -253,6 +258,23 @@ export const useDataStore = defineStore('data', {
 			return true
 		},
 
+		async updatePublicRow({ token, rowId, data }) {
+			let res = null
+			try {
+				res = await axios.put(generateOcsUrl('/apps/tables/api/2/public/' + token + '/rows/' + rowId), { data })
+			} catch (e) {
+				displayError(e, t('tables', 'Could not update row.'))
+				return false
+			}
+			const stateId = 'public-' + token
+			if (this.rows[stateId]) {
+				const row = res?.data?.ocs?.data
+				const index = this.rows[stateId].findIndex(r => r.id === rowId)
+				set(this.rows[stateId], index, row)
+			}
+			return true
+		},
+
 		async insertNewRow({ viewId, tableId, data }) {
 			let res = null
 
@@ -271,6 +293,26 @@ export const useDataStore = defineStore('data', {
 				const newIndex = this.rows[stateId].length
 				set(this.rows[stateId], newIndex, row)
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
+			}
+
+			return true
+		},
+
+		async insertPublicRow({ token, data }) {
+			let res = null
+
+			try {
+				res = await axios.post(generateOcsUrl('/apps/tables/api/2/public/' + token + '/rows'), { data })
+			} catch (e) {
+				displayError(e, t('tables', 'Could not insert row.'))
+				return false
+			}
+
+			const stateId = 'public-' + token
+			if (this.rows[stateId]) {
+				const row = res?.data?.ocs?.data
+				const newIndex = this.rows[stateId].length
+				set(this.rows[stateId], newIndex, row)
 			}
 
 			return true
@@ -296,6 +338,21 @@ export const useDataStore = defineStore('data', {
 
 			const stateId = genStateKey(isView, elementId)
 			if (stateId && this.rows[stateId]) {
+				const filteredRows = this.rows[stateId].filter(r => r.id !== rowId)
+				set(this.rows, stateId, filteredRows)
+			}
+			return true
+		},
+
+		async removePublicRow({ token, rowId }) {
+			try {
+				await axios.delete(generateOcsUrl('/apps/tables/api/2/public/' + token + '/rows/' + rowId))
+			} catch (e) {
+				displayError(e, t('tables', 'Could not remove row.'))
+				return false
+			}
+			const stateId = 'public-' + token
+			if (this.rows[stateId]) {
 				const filteredRows = this.rows[stateId].filter(r => r.id !== rowId)
 				set(this.rows, stateId, filteredRows)
 			}

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -872,8 +872,27 @@ export type paths = {
         /** [api v2] Fetch all rows from a link share */
         readonly get: operations["public_rowocs-get-rows"];
         readonly put?: never;
-        readonly post?: never;
+        /** [api v2] Create a row in a link share */
+        readonly post: operations["public_rowocs-create-row"];
         readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/ocs/v2.php/apps/tables/api/2/public/{token}/rows/{rowId}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        /** [api v2] Update a row in a link share */
+        readonly put: operations["public_rowocs-update-row"];
+        readonly post?: never;
+        /** [api v2] Delete a row in a link share */
+        readonly delete: operations["public_rowocs-delete-row"];
         readonly options?: never;
         readonly head?: never;
         readonly patch?: never;
@@ -7133,6 +7152,297 @@ export interface operations {
                             readonly data: {
                                 readonly message: string;
                             };
+                        };
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Internal error */
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    readonly "public_rowocs-create-row": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header: {
+                /** @description Required to be true for the API request to pass */
+                readonly "OCS-APIRequest": boolean;
+            };
+            readonly path: {
+                /** @description The share token */
+                readonly token: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": {
+                    /** @description An array containing the column identifiers and their values */
+                    readonly data: string | {
+                        readonly [key: string]: Record<string, never>;
+                    };
+                };
+            };
+        };
+        readonly responses: {
+            /** @description Row created */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: components["schemas"]["PublicRow"];
+                        };
+                    };
+                };
+            };
+            /** @description Invalid request parameters */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Internal error */
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    readonly "public_rowocs-update-row": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header: {
+                /** @description Required to be true for the API request to pass */
+                readonly "OCS-APIRequest": boolean;
+            };
+            readonly path: {
+                /** @description The share token */
+                readonly token: string;
+                /** @description The row identifier */
+                readonly rowId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": {
+                    /** @description An array containing the column identifiers and their values */
+                    readonly data: string | {
+                        readonly [key: string]: Record<string, never>;
+                    };
+                };
+            };
+        };
+        readonly responses: {
+            /** @description Row updated */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: components["schemas"]["PublicRow"];
+                        };
+                    };
+                };
+            };
+            /** @description Invalid request parameters */
+            readonly 400: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description No permissions */
+            readonly 403: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            readonly 404: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Internal error */
+            readonly 500: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: {
+                                readonly message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+    readonly "public_rowocs-delete-row": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header: {
+                /** @description Required to be true for the API request to pass */
+                readonly "OCS-APIRequest": boolean;
+            };
+            readonly path: {
+                /** @description The share token */
+                readonly token: string;
+                /** @description The row identifier */
+                readonly rowId: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Row deleted */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly ocs: {
+                            readonly meta: components["schemas"]["OCSMeta"];
+                            readonly data: components["schemas"]["PublicRow"];
                         };
                     };
                 };


### PR DESCRIPTION
Adds view, create, update and delete permissions for public table shares.

- UI changes are kept minimal for now, as the sharing sidebar should be updated to the unified sharing component in the future
- Rows created/edited via public link shares use `public-<token>` for the `created_by` and `last_edit_by`value.
- If a public link share has only create permission, the UI handles it as a public form with adjusted icon and text

Closes #2389