### PR TITLE
fix(import): restore view description when importing from scheme

### DIFF
--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -181,6 +181,7 @@ class ApiTablesController extends AOCSController {
 					$view['emoji'],
 					$table,
 					$this->userId,
+					$view['description'] ?? null,
 				);
 
 				$inputColumnsArray = [];

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -189,11 +189,12 @@ class ViewService extends SuperService {
 	 * @param string|null $emoji
 	 * @param Table $table
 	 * @param string|null $userId
+	 * @param string|null $description
 	 * @return View
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	public function create(string $title, ?string $emoji, Table $table, ?string $userId = null): View {
+	public function create(string $title, ?string $emoji, Table $table, ?string $userId = null, ?string $description = null): View {
 		/** @var string $userId */
 		$userId = $this->permissionsService->preCheckUserId($userId, false); // $userId is set
 
@@ -208,7 +209,7 @@ class ViewService extends SuperService {
 		if ($emoji) {
 			$item->setEmoji($emoji);
 		}
-		$item->setDescription('');
+		$item->setDescription($description ?? '');
 		$item->setTableId($table->getId());
 		$item->setCreatedBy($userId);
 		$item->setLastEditBy($userId);


### PR DESCRIPTION
When importing a table from a JSON scheme, the `description` of views was silently dropped. Column descriptions were imported correctly, but the same wiring was missing for views.

**Root cause:** `ViewService::create()` had no `description` parameter and always hardcoded `setDescription('')`. The controller never forwarded `$view['description']` from the scheme.

**Fix:** Added an optional `?string $description = null` parameter to `ViewService::create()` and pass it through in `ApiTablesController::createFromScheme()`. The signature change is backwards-compatible — all three existing callers continue to work unchanged via the default.

Fixes #1799