### PR TITLE
📦 Add all/filtered/selected CSV export actions

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -151,7 +151,7 @@ Cypress.Commands.add('openContextEditModal', (title) => {
 
 Cypress.Commands.add('clickOnTableThreeDotMenu', (optionName) => {
 	cy.get('[data-cy="customTableAction"] button').click()
-	cy.get('[data-cy="dataTableExportBtn"]').contains(optionName).click({ force: true })
+	cy.get('.v-popper__popper button, [role="menuitem"]').contains(optionName).click({ force: true })
 })
 
 Cypress.Commands.add('sortTableColumn', (columnTitle, mode = 'ASC') => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -172,7 +172,7 @@ Cypress.Commands.add('openContextEditModal', (title) => {
 
 Cypress.Commands.add('clickOnTableThreeDotMenu', (optionName) => {
 	cy.get('[data-cy="customTableAction"] button').click()
-	cy.get('[data-cy="dataTableExportBtn"]').contains(optionName).click({ force: true })
+	cy.get('.v-popper__popper button, [role="menuitem"]').contains(optionName).click({ force: true })
 })
 
 Cypress.Commands.add('sortTableColumn', (columnTitle, mode = 'ASC') => {

--- a/playwright/e2e/tables-export-csv.spec.ts
+++ b/playwright/e2e/tables-export-csv.spec.ts
@@ -5,20 +5,46 @@
 
 import { test, expect } from '../support/fixtures'
 import * as fs from 'fs'
+import { type Page } from '@playwright/test'
 import { clickOnTableThreeDotMenu, getTutorialTableName, loadTable } from '../support/commands'
 
-test.describe('Import csv', () => {
+async function fillSearchInput(page: Page, value: string) {
+	// Scope to the NcTable container to avoid matching Nextcloud header search elements
+	const searchInput = page.locator('[data-cy="ncTable"]').getByRole('textbox', { name: 'Search' })
+	await expect(searchInput).toBeVisible({ timeout: 10000 })
+	await searchInput.fill(value)
+	await page.waitForTimeout(600) // debounce in SearchForm is 500 ms
+}
 
-	test('Export csv', async ({ userPage: { page } }) => {
+async function clickSelectionBarAction(page: Page, label: string) {
+	await expect(page.locator('.icon-loading').first()).toBeHidden({ timeout: 10000 })
+	await expect(page.locator('.selected-rows-option')).toBeVisible({ timeout: 10000 })
+	// NcActionButton does not forward data-cy to the DOM; match by button text content instead.
+	// With inline=2 the items render as plain <button> elements directly in the selection bar.
+	const item = page.locator('.selected-rows-option button').filter({ hasText: label })
+	await expect(item.first()).toBeVisible({ timeout: 5000 })
+	await item.first().click()
+}
+
+async function selectFirstRow(page: Page) {
+	const checkbox = page.locator('[data-cy="customTableRow"]:first-of-type input[type="checkbox"]').first()
+	await expect(checkbox).toBeVisible({ timeout: 10000 })
+	await checkbox.click({ force: true })
+	await expect(checkbox).toBeChecked()
+}
+
+test.describe('CSV export', () => {
+
+	test('Export all rows is always available in the three-dot menu', async ({ userPage: { page } }) => {
 		await page.goto('/index.php/apps/tables')
 		await loadTable(page, 'Welcome to Nextcloud Tables!')
 
 		const tutorialName = await getTutorialTableName(page)
-		const fileNamePattern = new RegExp(`^\\d{2}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_${tutorialName.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\.csv$`)
+		const fileNamePattern = new RegExp(`^\\d{2}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_${tutorialName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.csv$`)
 
 		const [download] = await Promise.all([
 			page.waitForEvent('download'),
-			clickOnTableThreeDotMenu(page, 'Export as CSV'),
+			clickOnTableThreeDotMenu(page, 'Export all rows'),
 		])
 
 		expect(download.suggestedFilename()).toMatch(fileNamePattern)
@@ -29,4 +55,79 @@ test.describe('Import csv', () => {
 		expect(content).toContain('What,How to do,Ease of use,Done')
 		expect(content).toContain('Open the tables app,Reachable via the Tables icon in the apps list.,5,true')
 	})
+
+	test('Export filtered rows only appears in three-dot menu when a filter is active', async ({ userPage: { page } }) => {
+		await page.goto('/index.php/apps/tables')
+		await loadTable(page, 'Welcome to Nextcloud Tables!')
+
+		await fillSearchInput(page, 'Open the tables app')
+
+		// Export filtered and verify only the matching row is in the CSV
+		const [download] = await Promise.all([
+			page.waitForEvent('download'),
+			clickOnTableThreeDotMenu(page, 'Export filtered rows'),
+		])
+
+		const path = await download.path()
+		const content = fs.readFileSync(path, 'utf8')
+
+		expect(content).toContain('Open the tables app')
+		expect(content).not.toContain('Add a new column')
+	})
+
+	test('Export selected rows appears in selection bar when rows are checked', async ({ userPage: { page } }) => {
+		await page.goto('/index.php/apps/tables')
+		await loadTable(page, 'Welcome to Nextcloud Tables!')
+
+		await selectFirstRow(page)
+
+		// Export selected — should only contain 1 data row
+		const [download] = await Promise.all([
+			page.waitForEvent('download'),
+			clickSelectionBarAction(page, 'Export selected rows'),
+		])
+
+		const path = await download.path()
+		const content = fs.readFileSync(path, 'utf8')
+		const lines = content.trim().split('\n')
+
+		// Header + exactly 1 data row
+		expect(lines).toHaveLength(2)
+	})
+
+	test('Export filtered rows appears in selection bar when rows are selected and filter is active', async ({ userPage: { page } }) => {
+		await page.goto('/index.php/apps/tables')
+		await loadTable(page, 'Welcome to Nextcloud Tables!')
+
+		await fillSearchInput(page, 'Open')
+		await selectFirstRow(page)
+
+		// Both export buttons must be visible in the selection bar
+		await expect(page.locator('.selected-rows-option')).toBeVisible({ timeout: 10000 })
+		for (const label of ['Export selected rows', 'Export filtered rows']) {
+			await expect(
+				page.locator('.selected-rows-option button').filter({ hasText: label }).first(),
+			).toBeVisible({ timeout: 5000 })
+		}
+	})
+
+	test('Export all rows includes unfiltered data even when filter is active', async ({ userPage: { page } }) => {
+		await page.goto('/index.php/apps/tables')
+		await loadTable(page, 'Welcome to Nextcloud Tables!')
+
+		await fillSearchInput(page, 'Open the tables app')
+
+		// Export ALL rows — must include rows not matching the filter
+		const [download] = await Promise.all([
+			page.waitForEvent('download'),
+			clickOnTableThreeDotMenu(page, 'Export all rows'),
+		])
+
+		const path = await download.path()
+		const content = fs.readFileSync(path, 'utf8')
+
+		expect(content).toContain('Open the tables app')
+		expect(content).toContain('Add a new column')
+	})
+
 })

--- a/playwright/support/commands.ts
+++ b/playwright/support/commands.ts
@@ -67,7 +67,7 @@ async function openTableActionsMenu(page: Page) {
 
 	const menuButton = page.locator('[data-cy="customTableAction"] button').first()
 	const anyMenuAction = page.locator(
-		'[data-cy="dataTableEditTableBtn"], [data-cy="dataTableCreateViewBtn"], [data-cy="dataTableCreateColumnBtn"], [data-cy="dataTableShareBtn"], [data-cy="dataTableExportBtn"]',
+		'[data-cy="dataTableEditTableBtn"], [data-cy="dataTableCreateViewBtn"], [data-cy="dataTableCreateColumnBtn"], [data-cy="dataTableShareBtn"], [data-cy="dataTableExportAllBtn"]',
 	)
 
 	for (let attempt = 1; attempt <= 3; attempt++) {
@@ -97,9 +97,11 @@ function getTableActionLocator(page: Page, optionName: string) {
 	case 'Share':
 		return page.locator('[data-cy="dataTableShareBtn"]')
 	case 'Import':
-		return page.locator('[data-cy="dataTableExportBtn"]').filter({ hasText: /^Import$/ })
-	case 'Export as CSV':
-		return page.locator('[data-cy="dataTableExportBtn"]').filter({ hasText: /^Export as CSV$/ })
+		return page.locator('[data-cy="dataTableImportBtn"]')
+	case 'Export all rows':
+		return page.locator('[data-cy="dataTableExportAllBtn"]')
+	case 'Export filtered rows':
+		return page.locator('[data-cy="dataTableExportFilteredBtn"]')
 	default:
 		return null
 	}

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -26,8 +26,8 @@
 		@create-row="createRow"
 		@edit-row="editRow"
 		@delete-selected-rows="deleteSelectedRows">
-		<template #actions>
-			<slot name="actions" />
+		<template #actions="slotProps">
+			<slot name="actions" v-bind="slotProps" />
 		</template>
 	</NcTable>
 </template>

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -25,8 +25,8 @@
 		@create-row="createRow"
 		@edit-row="editRow"
 		@delete-selected-rows="deleteSelectedRows">
-		<template #actions>
-			<slot name="actions" />
+		<template #actions="slotProps">
+			<slot name="actions" v-bind="slotProps" />
 		</template>
 	</NcTable>
 </template>

--- a/src/modules/main/partials/TableView.vue
+++ b/src/modules/main/partials/TableView.vue
@@ -25,7 +25,8 @@
 		@delete-column="deleteColumn"
 		@create-row="createRow"
 		@edit-row="editRow"
-		@delete-selected-rows="deleteSelectedRows">
+		@delete-selected-rows="deleteSelectedRows"
+		@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 		<template #actions="slotProps">
 			<slot name="actions" v-bind="slotProps" />
 		</template>

--- a/src/modules/main/sections/DataTable.vue
+++ b/src/modules/main/sections/DataTable.vue
@@ -45,10 +45,13 @@
 							</template>
 							{{ t('tables', 'Import') }}
 						</NcActionButton>
-						<NcActionButton v-if="canReadData(table)" :close-after-click="true"
-							icon="icon-download"
+						<NcActionButton v-if="canReadData(table)"
+							:close-after-click="true"
 							@click="$emit('download-csv')">
-							{{ t('tables', 'Export as CSV') }}
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export all rows') }}
 						</NcActionButton>
 						<NcActionButton v-if="canShareElement(table)"
 							:close-after-click="true"
@@ -85,7 +88,7 @@
 				:can-edit-columns="canManageTable(table)"
 				:can-delete-columns="canManageTable(table)"
 				:can-delete-table="canManageTable(table)">
-				<template #actions>
+				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" :type="isViewSettingSet ? 'secondary' : 'tertiary'">
 						<NcActionCaption v-if="canManageElement(table)" :name="t('tables', 'Manage table')" />
 						<NcActionButton v-if="canManageElement(table)"
@@ -115,16 +118,29 @@
 						<NcActionCaption :name="t('tables', 'Integration')" />
 						<NcActionButton v-if="canCreateRowInElement(table)"
 							:close-after-click="true"
-							data-cy="dataTableExportBtn" @click="$emit('import', table)">
+							data-cy="dataTableImportBtn" @click="$emit('import', table)">
 							<template #icon>
 								<Import :size="20" decorative title="Import" />
 							</template>
 							{{ t('tables', 'Import') }}
 						</NcActionButton>
-						<NcActionButton v-if="canReadData(table)" :close-after-click="true"
-							icon="icon-download"
-							data-cy="dataTableExportBtn" @click="$emit('download-csv')">
-							{{ t('tables', 'Export as CSV') }}
+						<NcActionButton v-if="canReadData(table)"
+							:close-after-click="true"
+							data-cy="dataTableExportAllBtn"
+							@click="$emit('download-csv')">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export all rows') }}
+						</NcActionButton>
+						<NcActionButton v-if="canReadData(table) && isFiltered"
+							:close-after-click="true"
+							data-cy="dataTableExportFilteredBtn"
+							@click="onExportFiltered">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export filtered rows') }}
 						</NcActionButton>
 						<NcActionButton v-if="canShareElement(table)"
 							data-cy="dataTableShareBtn"
@@ -157,6 +173,7 @@ import IconTool from 'vue-material-design-icons/TableCog.vue'
 import TableView from '../partials/TableView.vue'
 import EmptyTable from './EmptyTable.vue'
 import Connection from 'vue-material-design-icons/Connection.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import Import from 'vue-material-design-icons/Import.vue'
 import { NcActionButton, NcActions, NcActionCaption } from '@nextcloud/vue'
 import { mapState } from 'pinia'
@@ -169,6 +186,7 @@ export default {
 		TableView,
 		NcActionButton,
 		Connection,
+		TrayArrowDown,
 		NcActionCaption,
 		NcActions,
 		TableColumnPlusAfter,

--- a/src/modules/main/sections/DataTable.vue
+++ b/src/modules/main/sections/DataTable.vue
@@ -87,7 +87,8 @@
 				:can-create-columns="canManageTable(table)"
 				:can-edit-columns="canManageTable(table)"
 				:can-delete-columns="canManageTable(table)"
-				:can-delete-table="canManageTable(table)">
+				:can-delete-table="canManageTable(table)"
+				@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" :type="isViewSettingSet ? 'secondary' : 'tertiary'">
 						<NcActionCaption v-if="canManageElement(table)" :name="t('tables', 'Manage table')" />

--- a/src/modules/main/sections/MainWrapper.vue
+++ b/src/modules/main/sections/MainWrapper.vue
@@ -15,6 +15,7 @@
 				@create-column="createColumn"
 				@import="openImportModal"
 				@download-csv="downloadCSV"
+				@download-filtered-csv="downloadFilteredCSV"
 				@toggle-share="toggleShare"
 				@show-integration="showIntegration" />
 			<CustomTable v-else
@@ -25,6 +26,7 @@
 				@create-column="createColumn"
 				@import="openImportModal"
 				@download-csv="downloadCSV"
+				@download-filtered-csv="downloadFilteredCSV"
 				@toggle-share="toggleShare"
 				@show-integration="showIntegration" />
 		</div>
@@ -119,6 +121,21 @@ export default {
 			}
 
 			this.downloadCsv(this.rows, this.columns, this.element.title)
+		},
+		async downloadFilteredCSV(rows) {
+			const access = await this.validateExportAccess({
+				id: this.element.id,
+				isView: this.isView,
+			})
+
+			if (!access?.ok) {
+				if (access?.reason === 'NO_ACCESS') {
+					showError(t('tables', 'Your access was revoked. Reload the page to update your permissions.'))
+				}
+				return
+			}
+
+			this.downloadCsv(rows, this.columns, this.element.title)
 		},
 		toggleShare() {
 			emit('tables:sidebar:sharing', { open: true, tab: 'sharing' })

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -18,14 +18,22 @@
 				:can-delete-columns="false"
 				:can-delete-table="false"
 				:is-form-mode="isFormMode">
-				<template #actions>
+				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" type="tertiary">
 						<NcActionButton :close-after-click="true" data-cy="dataTableExportBtn"
 							@click="$emit('download-csv')">
 							<template #icon>
 								<TrayArrowDown :size="20" decorative />
 							</template>
-							{{ t('tables', 'Export as CSV') }}
+							{{ t('tables', 'Export all rows') }}
+						</NcActionButton>
+						<NcActionButton v-if="isFiltered" :close-after-click="true"
+							data-cy="dataTableExportFilteredBtn"
+							@click="onExportFiltered">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export filtered rows') }}
 						</NcActionButton>
 					</NcActions>
 				</template>
@@ -66,6 +74,7 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EditRow from '../../modals/EditRow.vue'
 import DeleteRows from '../../modals/DeleteRows.vue'
 import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
+import { translate as t } from '@nextcloud/l10n'
 
 export default {
 	name: 'PublicElement',
@@ -127,6 +136,10 @@ export default {
 		unsubscribe('tables:row:create')
 		unsubscribe('tables:row:edit')
 		unsubscribe('tables:row:delete')
+	},
+
+	methods: {
+		t,
 	},
 }
 </script>

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -20,8 +20,11 @@
 				:is-form-mode="isFormMode">
 				<template #actions>
 					<NcActions :force-menu="true" type="tertiary">
-						<NcActionButton :close-after-click="true" icon="icon-download" data-cy="dataTableExportBtn"
+						<NcActionButton :close-after-click="true" data-cy="dataTableExportBtn"
 							@click="$emit('download-csv')">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
 							{{ t('tables', 'Export as CSV') }}
 						</NcActionButton>
 					</NcActions>
@@ -62,6 +65,7 @@ import CreateRow from '../../modals/CreateRow.vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import EditRow from '../../modals/EditRow.vue'
 import DeleteRows from '../../modals/DeleteRows.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 
 export default {
 	name: 'PublicElement',
@@ -70,6 +74,7 @@ export default {
 		DeleteRows,
 		EditRow,
 		EmptyView,
+		TrayArrowDown,
 		TableView,
 		NcActions,
 		NcActionButton,

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -13,8 +13,11 @@
 				:can-edit-columns="false" :can-delete-columns="false" :can-delete-table="false">
 				<template #actions>
 					<NcActions :force-menu="true" type="tertiary">
-						<NcActionButton :close-after-click="true" icon="icon-download" data-cy="dataTableExportBtn"
+						<NcActionButton :close-after-click="true" data-cy="dataTableExportBtn"
 							@click="$emit('download-csv')">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
 							{{ t('tables', 'Export as CSV') }}
 						</NcActionButton>
 					</NcActions>
@@ -30,11 +33,13 @@ import EmptyView from './EmptyView.vue'
 import TableDescription from './TableDescription.vue'
 import ElementTitle from './ElementTitle.vue'
 import { NcActions, NcActionButton } from '@nextcloud/vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 
 export default {
 	name: 'PublicElement',
 	components: {
 		EmptyView,
+		TrayArrowDown,
 		TableView,
 		NcActions,
 		NcActionButton,

--- a/src/modules/main/sections/PublicElement.vue
+++ b/src/modules/main/sections/PublicElement.vue
@@ -17,7 +17,8 @@
 				:can-edit-columns="false"
 				:can-delete-columns="false"
 				:can-delete-table="false"
-				:is-form-mode="isFormMode">
+				:is-form-mode="isFormMode"
+				@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" type="tertiary">
 						<NcActionButton :close-after-click="true" data-cy="dataTableExportBtn"

--- a/src/modules/main/sections/PublicMainWrapper.vue
+++ b/src/modules/main/sections/PublicMainWrapper.vue
@@ -7,7 +7,7 @@
 		<div v-if="loading" class="icon-loading" />
 
 		<div v-else>
-			<PublicElement :element="publicElement" :columns="columns" :rows="rows" @download-csv="downloadCSV" />
+			<PublicElement :element="publicElement" :columns="columns" :rows="rows" @download-csv="downloadCSV" @download-filtered-csv="downloadFilteredCSV" />
 		</div>
 	</div>
 </template>
@@ -94,6 +94,9 @@ export default {
 
 		downloadCSV() {
 			this.downloadCsv(this.rows, this.columns, 'public-export')
+		},
+		downloadFilteredCSV(rows) {
+			this.downloadCsv(rows, this.columns, 'public-export')
 		},
 	},
 }

--- a/src/modules/main/sections/PublicMainWrapper.vue
+++ b/src/modules/main/sections/PublicMainWrapper.vue
@@ -17,8 +17,11 @@ import { mapActions, storeToRefs } from 'pinia'
 import PublicElement from './PublicElement.vue'
 import exportTableMixin from '../../../shared/components/ncTable/mixins/exportTableMixin.js'
 import { useDataStore } from '../../../store/data.js'
+import { useTablesStore } from '../../../store/store.js'
 import { computed } from 'vue'
 import { loadState } from '@nextcloud/initial-state'
+import { showError } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
 
 const nodeData = loadState('tables', 'nodeData', null)
 const sharePermissions = loadState('tables', 'sharePermissions', null)
@@ -77,6 +80,7 @@ export default {
 
 	methods: {
 		...mapActions(useDataStore, ['loadPublicColumnsFromBE', 'loadPublicRowsFromBE', 'setPublicToken']),
+		...mapActions(useTablesStore, ['validatePublicExportAccess']),
 
 		async loadData() {
 			this.loading = true
@@ -92,10 +96,24 @@ export default {
 			}
 		},
 
-		downloadCSV() {
+		async downloadCSV() {
+			const access = await this.validatePublicExportAccess(this.token)
+			if (!access?.ok) {
+				if (access?.reason === 'NO_ACCESS') {
+					showError(t('tables', 'Your access was revoked. Reload the page to update your permissions.'))
+				}
+				return
+			}
 			this.downloadCsv(this.rows, this.columns, 'public-export')
 		},
-		downloadFilteredCSV(rows) {
+		async downloadFilteredCSV(rows) {
+			const access = await this.validatePublicExportAccess(this.token)
+			if (!access?.ok) {
+				if (access?.reason === 'NO_ACCESS') {
+					showError(t('tables', 'Your access was revoked. Reload the page to update your permissions.'))
+				}
+				return
+			}
 			this.downloadCsv(rows, this.columns, 'public-export')
 		},
 	},

--- a/src/modules/main/sections/Table.vue
+++ b/src/modules/main/sections/Table.vue
@@ -17,6 +17,7 @@
 			@create-column="$emit('create-column')"
 			@import="$emit('import')"
 			@download-csv="$emit('download-csv')"
+			@download-filtered-csv="rows => $emit('download-filtered-csv', rows)"
 			@toggle-share="$emit('toggle-share')"
 			@show-integration="$emit('show-integration')"
 			@create-view="createView" />

--- a/src/modules/main/sections/TableWrapper.vue
+++ b/src/modules/main/sections/TableWrapper.vue
@@ -10,6 +10,7 @@
 			@create-column="$emit('create-column')"
 			@import="$emit('import')"
 			@download-csv="$emit('download-csv')"
+			@download-filtered-csv="rows => $emit('download-filtered-csv', rows)"
 			@toggle-share="$emit('toggle-share')"
 			@show-integration="$emit('show-integration')"
 			@create-view="createView" />

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -22,7 +22,7 @@
 				:can-edit-columns="canManageTable(view)"
 				:can-delete-columns="canManageTable(view)"
 				:can-delete-table="canManageTable(view)">
-				<template #actions>
+				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" :type="isViewSettingSet ? 'secondary' : 'tertiary'">
 						<NcActionCaption v-if="canManageElement(view)" :name="t('tables', 'Manage view')" />
 						<NcActionButton v-if="canManageElement(view) "
@@ -49,10 +49,21 @@
 							</template>
 							{{ t('tables', 'Import') }}
 						</NcActionButton>
-						<NcActionButton v-if="canReadData(view)" :close-after-click="true"
-							icon="icon-download"
+						<NcActionButton v-if="canReadData(view)"
+							:close-after-click="true"
 							@click="$emit('download-csv')">
-							{{ t('tables', 'Export as CSV') }}
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export all rows') }}
+						</NcActionButton>
+						<NcActionButton v-if="canReadData(view) && isFiltered"
+							:close-after-click="true"
+							@click="onExportFiltered">
+							<template #icon>
+								<TrayArrowDown :size="20" decorative />
+							</template>
+							{{ t('tables', 'Export filtered rows') }}
 						</NcActionButton>
 						<NcActionButton v-if="canShareElement(view)"
 							:close-after-click="true"
@@ -84,6 +95,7 @@ import { emit } from '@nextcloud/event-bus'
 import { NcActions, NcActionButton, NcActionCaption } from '@nextcloud/vue'
 import TableColumnPlusAfter from 'vue-material-design-icons/TableColumnPlusAfter.vue'
 import PlaylistEdit from 'vue-material-design-icons/PlaylistEdit.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import IconImport from 'vue-material-design-icons/Import.vue'
 import Connection from 'vue-material-design-icons/Connection.vue'
 import ElementTitle from './ElementTitle.vue'
@@ -93,6 +105,7 @@ export default {
 	components: {
 		TableDescription,
 		EmptyView,
+		TrayArrowDown,
 		TableView,
 		PlaylistEdit,
 		IconImport,

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -21,7 +21,8 @@
 				:can-create-columns="canManageTable(view)"
 				:can-edit-columns="canManageTable(view)"
 				:can-delete-columns="canManageTable(view)"
-				:can-delete-table="canManageTable(view)">
+				:can-delete-table="canManageTable(view)"
+				@download-filtered-csv="rows => $emit('download-filtered-csv', rows)">
 				<template #actions="{ isFiltered, onExportFiltered }">
 					<NcActions :force-menu="true" :type="isViewSettingSet ? 'secondary' : 'tertiary'">
 						<NcActionCaption v-if="canManageElement(view)" :name="t('tables', 'Manage view')" />

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -64,7 +64,7 @@
 			<NcActionButton @click="exportFile">
 				{{ t('tables', 'Export') }}
 				<template #icon>
-					<Export :size="20" />
+					<TrayArrowDown :size="20" />
 				</template>
 			</NcActionButton>
 			<!-- INTEGRATION -->
@@ -151,7 +151,7 @@ import activityMixin from '../../../shared/mixins/activityMixin.js'
 import { getCurrentUser, getRequestToken } from '@nextcloud/auth'
 import Connection from 'vue-material-design-icons/Connection.vue'
 import Import from 'vue-material-design-icons/Import.vue'
-import Export from 'vue-material-design-icons/Export.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import NavigationViewItem from './NavigationViewItem.vue'
 import PlaylistPlus from 'vue-material-design-icons/PlaylistPlus.vue'
 import IconRename from 'vue-material-design-icons/RenameOutline.vue'
@@ -169,7 +169,7 @@ export default {
 		ArchiveArrowDown,
 		ArchiveArrowUpOutline,
 		Import,
-		Export,
+		TrayArrowDown,
 		NavigationViewItem,
 		NcActionButton,
 		NcAppNavigationItem,

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -24,12 +24,14 @@
 					<div v-if="!resource.isView" class="resource">
 						<TableWrapper :table="resource" :columns="columns[resource.key]" :rows="rows[resource.key]"
 							:view-setting="viewSetting" @create-column="createColumn(false, resource)"
-							@import="openImportModal(resource, false)" @download-csv="downloadCSV(resource, false)" />
+							@import="openImportModal(resource, false)" @download-csv="downloadCSV(resource, false)"
+							@download-filtered-csv="rows => downloadFilteredCSV(rows, resource, false)" />
 					</div>
 					<div v-else-if="resource.isView" class="resource">
 						<CustomView :view="resource" :columns="columns[resource.key]" :rows="rows[resource.key]"
 							:view-setting="viewSetting" @create-column="createColumn(true, resource)"
-							@import="openImportModal(resource, true)" @download-csv="downloadCSV(resource, true)" />
+							@import="openImportModal(resource, true)" @download-csv="downloadCSV(resource, true)"
+							@download-filtered-csv="rows => downloadFilteredCSV(rows, resource, true)" />
 					</div>
 				</div>
 			</div>
@@ -253,6 +255,22 @@ export default {
 			const rowId = this.getKey(isView, element.key)
 			const colId = this.getKey(isView, element.key)
 			this.downloadCsv(this.rows[rowId], this.columns[colId], element.title)
+		},
+		async downloadFilteredCSV(rows, element, isView) {
+			const access = await this.validateExportAccess({
+				id: element.id,
+				isView,
+			})
+
+			if (!access?.ok) {
+				if (access?.reason === 'NO_ACCESS') {
+					showError(t('tables', 'Your access was revoked. Reload the page to update your permissions.'))
+				}
+				return
+			}
+
+			const colId = this.getKey(isView, element.key)
+			this.downloadCsv(rows, this.columns[colId], element.title)
 		},
 		getKey(isView, id) {
 			return isView ? 'view-' + id : id

--- a/src/pages/Context.vue
+++ b/src/pages/Context.vue
@@ -252,8 +252,8 @@ export default {
 				return
 			}
 
-			const rowId = this.getKey(isView, element.key)
-			const colId = this.getKey(isView, element.key)
+			const rowId = this.getKey(isView, element.id)
+			const colId = this.getKey(isView, element.id)
 			this.downloadCsv(this.rows[rowId], this.columns[colId], element.title)
 		},
 		async downloadFilteredCSV(rows, element, isView) {
@@ -269,7 +269,7 @@ export default {
 				return
 			}
 
-			const colId = this.getKey(isView, element.key)
+			const colId = this.getKey(isView, element.id)
 			this.downloadCsv(rows, this.columns[colId], element.title)
 		},
 		getKey(isView, id) {

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -43,8 +43,9 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 <template>
 	<div ref="table" class="NcTable" data-cy="ncTable">
 		<div class="options row" style="padding-right: calc(var(--default-grid-baseline) * 2);">
-			<Options :rows="getSearchedAndFilteredAndSortedRows" :all-rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
-				:selected-rows="localSelectedRows" :show-options="parsedColumns.length !== 0"
+			<Options :rows="rows" :all-rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
+				:selected-rows="localSelectedRows" :filtered-rows="getSearchedAndFilteredAndSortedRows"
+				:show-options="parsedColumns.length !== 0"
 				:view-setting.sync="localViewSetting" :config="config" @create-row="$emit('create-row')"
 				@download-csv="data => downloadCsv(data, parsedColumns, downloadTitle)"
 				@set-search-string="str => setSearchString(str)"
@@ -61,7 +62,9 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				@update-selected-rows="rowIds => localSelectedRows = rowIds"
 				@download-csv="data => downloadCsv(data, parsedColumns, table)">
 				<template #actions>
-					<slot name="actions" />
+					<slot name="actions"
+						:is-filtered="isFilteredComputed"
+						:on-export-filtered="() => downloadCsv(getSearchedAndFilteredAndSortedRows, parsedColumns, downloadTitle)" />
 				</template>
 			</CustomTable>
 			<NcEmptyContent v-else-if="config.canCreateRows && rows.length === 0"
@@ -244,6 +247,9 @@ export default {
 		},
 		emptyStateButtonLabel() {
 			return this.isFormMode ? t('tables', 'Fill form') : t('tables', 'Create row')
+		},
+		isFilteredComputed() {
+			return (this.localViewSetting?.filter?.length > 0) || !!this.localViewSetting?.searchString
 		},
 
 		sorting() {

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -44,7 +44,8 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 	<div ref="table" class="NcTable" data-cy="ncTable">
 		<div class="options row" style="padding-right: calc(var(--default-grid-baseline) * 2);">
 			<Options :rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
-				:selected-rows="localSelectedRows" :show-options="parsedColumns.length !== 0"
+				:selected-rows="localSelectedRows" :filtered-rows="localFilteredRows"
+				:show-options="parsedColumns.length !== 0"
 				:view-setting.sync="localViewSetting" :config="config" @create-row="$emit('create-row')"
 				@download-csv="data => downloadCsv(data, parsedColumns, downloadTitle)"
 				@set-search-string="str => setSearchString(str)"
@@ -59,9 +60,12 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				@edit-column="col => $emit('edit-column', col)"
 				@delete-column="col => $emit('delete-column', col)"
 				@update-selected-rows="rowIds => localSelectedRows = rowIds"
+				@update:filteredRows="rows => localFilteredRows = rows"
 				@download-csv="data => downloadCsv(data, parsedColumns, table)">
 				<template #actions>
-					<slot name="actions" />
+					<slot name="actions"
+						:is-filtered="isFilteredComputed"
+						:on-export-filtered="() => downloadCsv(localFilteredRows, parsedColumns, downloadTitle)" />
 				</template>
 			</CustomTable>
 			<NcEmptyContent v-else-if="config.canCreateRows && rows.length === 0"
@@ -193,6 +197,7 @@ export default {
 		return {
 			localSelectedRows: [],
 			localViewSetting: this.viewSetting ?? {},
+			localFilteredRows: this.rows,
 			viewerAppAvailable: !!window.OCA?.Viewer?.open,
 			table: null,
 		}
@@ -220,6 +225,9 @@ export default {
 			}
 			return this.columns
 		},
+		isFilteredComputed() {
+			return (this.localViewSetting?.filter?.length > 0) || !!this.localViewSetting?.searchString
+		},
 	},
 	watch: {
 		localSelectedRows() {
@@ -230,6 +238,9 @@ export default {
 		},
 		viewSetting() {
 			this.localViewSetting = this.viewSetting
+		},
+		rows(newRows) {
+			this.localFilteredRows = newRows
 		},
 	},
 	mounted() {

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -47,7 +47,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				:selected-rows="localSelectedRows" :filtered-rows="getSearchedAndFilteredAndSortedRows"
 				:show-options="parsedColumns.length !== 0"
 				:view-setting.sync="localViewSetting" :config="config" @create-row="$emit('create-row')"
-				@download-csv="data => downloadCsv(data, parsedColumns, downloadTitle)"
+				@download-filtered-csv="rows => $emit('download-filtered-csv', rows)"
 				@set-search-string="str => setSearchString(str)"
 				@delete-selected-rows="rowIds => $emit('delete-selected-rows', rowIds)" />
 		</div>
@@ -64,7 +64,7 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 				<template #actions>
 					<slot name="actions"
 						:is-filtered="isFilteredComputed"
-						:on-export-filtered="() => downloadCsv(getSearchedAndFilteredAndSortedRows, parsedColumns, downloadTitle)" />
+						:on-export-filtered="() => $emit('download-filtered-csv', getSearchedAndFilteredAndSortedRows)" />
 				</template>
 			</CustomTable>
 			<NcEmptyContent v-else-if="config.canCreateRows && rows.length === 0"

--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -43,8 +43,8 @@ deselect-all-rows        -> unselect all rows, e.g. after deleting selected rows
 <template>
 	<div ref="table" class="NcTable" data-cy="ncTable">
 		<div class="options row" style="padding-right: calc(var(--default-grid-baseline) * 2);">
-			<Options :rows="rows" :all-rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
-				:selected-rows="localSelectedRows" :filtered-rows="getSearchedAndFilteredAndSortedRows"
+			<Options :rows="getSearchedAndFilteredAndSortedRows" :all-rows="rows" :columns="parsedColumns" :element-id="elementId" :is-view="isView"
+				:selected-rows="localSelectedRows"
 				:show-options="parsedColumns.length !== 0"
 				:view-setting.sync="localViewSetting" :config="config" @create-row="$emit('create-row')"
 				@download-filtered-csv="rows => $emit('download-filtered-csv', rows)"

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -327,6 +327,9 @@ export default {
 		viewSetting() {
 			this.localViewSetting = this.viewSetting
 		},
+		getSearchedAndFilteredAndSortedRows(rows) {
+			this.$emit('update:filteredRows', rows)
+		},
 	},
 
 	updated() {
@@ -338,6 +341,7 @@ export default {
 	mounted() {
 		subscribe('tables:selected-rows:deselect', ({ elementId, isView }) => this.deselectAllRows(elementId, isView))
 		subscribe('tables:row:animate', this.enableRowAnimation)
+		this.$emit('update:filteredRows', this.getSearchedAndFilteredAndSortedRows)
 	},
 	beforeDestroy() {
 		unsubscribe('tables:selected-rows:deselect', ({ elementId, isView }) => this.deselectAllRows(elementId, isView))

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -32,11 +32,17 @@
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
 				<NcActions type="secondary" :force-name="true" :inline="showFullOptions ? 2 : 0">
-					<NcActionButton close-after-click @click="exportCsv">
+					<NcActionButton close-after-click data-cy="exportSelectedBtn" @click="exportSelected">
 						<template #icon>
-							<Export :size="20" />
+							<TrayArrowDown :size="20" />
 						</template>
-						{{ t('tables', 'Export CSV') }}
+						{{ t('tables', 'Export selected rows') }}
+					</NcActionButton>
+					<NcActionButton v-if="isFiltered" close-after-click data-cy="exportFilteredBtn" @click="exportFiltered">
+						<template #icon>
+							<TrayArrowDown :size="20" />
+						</template>
+						{{ t('tables', 'Export filtered rows') }}
 					</NcActionButton>
 					<NcActionButton v-if="config.canDeleteRows" close-after-click @click="deleteSelectedRows">
 						<template #icon>
@@ -62,10 +68,10 @@ import { emit } from '@nextcloud/event-bus'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Check from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
-import Export from 'vue-material-design-icons/Export.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import viewportHelper from '../../../mixins/viewportHelper.js'
 import SearchForm from '../partials/SearchForm.vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 
 export default {
 	name: 'Options',
@@ -78,7 +84,7 @@ export default {
 		Plus,
 		Check,
 		Delete,
-		Export,
+		TrayArrowDown,
 	},
 
 	mixins: [viewportHelper],
@@ -107,6 +113,10 @@ export default {
 		columns: {
 			type: Array,
 			default: null,
+		},
+		filteredRows: {
+			type: Array,
+			default: () => [],
 		},
 		viewSetting: {
 			type: Object,
@@ -138,19 +148,30 @@ export default {
 		showFullOptions() {
 			return this.optionsDivWidth > 800
 		},
+		isFiltered() {
+			return (this.viewSetting?.filter?.length > 0) || !!this.viewSetting?.searchString
+		},
 	},
 
-	created() {
+	mounted() {
 		this.updateOptionsDivWidth()
 		window.addEventListener('resize', this.updateOptionsDivWidth)
 	},
 
+	beforeDestroy() {
+		window.removeEventListener('resize', this.updateOptionsDivWidth)
+	},
+
 	methods: {
 		t,
+		n,
 		updateOptionsDivWidth() {
-			this.optionsDivWidth = document.getElementsByClassName('options row')[0]?.offsetWidth
+			this.optionsDivWidth = this.$el?.offsetWidth
 		},
-		exportCsv() {
+		exportFiltered() {
+			this.$emit('download-csv', this.filteredRows)
+		},
+		exportSelected() {
 			this.$emit('download-csv', this.getSelectedRows)
 		},
 		getRowById(rowId) {
@@ -207,4 +228,5 @@ export default {
 	width: auto;
 	min-width: 100px;
 }
+
 </style>

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -32,11 +32,17 @@
 					{{ n('tables', '%n selected row', '%n selected rows', selectedRows.length, {}) }}
 				</div>
 				<NcActions type="secondary" :force-name="true" :inline="showFullOptions ? 2 : 0">
-					<NcActionButton close-after-click @click="exportCsv">
+					<NcActionButton close-after-click data-cy="exportSelectedBtn" @click="exportSelected">
 						<template #icon>
-							<Export :size="20" />
+							<TrayArrowDown :size="20" />
 						</template>
-						{{ t('tables', 'Export CSV') }}
+						{{ t('tables', 'Export selected rows') }}
+					</NcActionButton>
+					<NcActionButton v-if="isFiltered" close-after-click data-cy="exportFilteredBtn" @click="exportFiltered">
+						<template #icon>
+							<TrayArrowDown :size="20" />
+						</template>
+						{{ t('tables', 'Export filtered rows') }}
 					</NcActionButton>
 					<NcActionButton v-if="config.canDeleteRows" close-after-click @click="deleteSelectedRows">
 						<template #icon>
@@ -63,11 +69,11 @@ import { emit } from '@nextcloud/event-bus'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Check from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
-import Export from 'vue-material-design-icons/Export.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import viewportHelper from '../../../mixins/viewportHelper.js'
 import SearchForm from '../partials/SearchForm.vue'
 import PaginationBlock from './PaginationBlock.vue'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 
 export default {
 	name: 'Options',
@@ -80,7 +86,7 @@ export default {
 		Plus,
 		Check,
 		Delete,
-		Export,
+		TrayArrowDown,
 		PaginationBlock,
 	},
 
@@ -115,6 +121,10 @@ export default {
 			type: Array,
 			default: null,
 		},
+		filteredRows: {
+			type: Array,
+			default: () => [],
+		},
 		viewSetting: {
 			type: Object,
 			default: null,
@@ -145,19 +155,30 @@ export default {
 		showFullOptions() {
 			return this.optionsDivWidth > 800
 		},
+		isFiltered() {
+			return (this.viewSetting?.filter?.length > 0) || !!this.viewSetting?.searchString
+		},
 	},
 
-	created() {
+	mounted() {
 		this.updateOptionsDivWidth()
 		window.addEventListener('resize', this.updateOptionsDivWidth)
 	},
 
+	beforeDestroy() {
+		window.removeEventListener('resize', this.updateOptionsDivWidth)
+	},
+
 	methods: {
 		t,
+		n,
 		updateOptionsDivWidth() {
-			this.optionsDivWidth = document.getElementsByClassName('options row')[0]?.offsetWidth
+			this.optionsDivWidth = this.$el?.offsetWidth
 		},
-		exportCsv() {
+		exportFiltered() {
+			this.$emit('download-csv', this.filteredRows)
+		},
+		exportSelected() {
 			this.$emit('download-csv', this.getSelectedRows)
 		},
 		getRowById(rowId) {
@@ -254,4 +275,5 @@ export default {
 		flex: 1 1 auto;
 	}
 }
+
 </style>

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -176,10 +176,10 @@ export default {
 			this.optionsDivWidth = this.$el?.offsetWidth
 		},
 		exportFiltered() {
-			this.$emit('download-csv', this.filteredRows)
+			this.$emit('download-filtered-csv', this.filteredRows)
 		},
 		exportSelected() {
-			this.$emit('download-csv', this.getSelectedRows)
+			this.$emit('download-filtered-csv', this.getSelectedRows)
 		},
 		getRowById(rowId) {
 			const index = this.allRows.findIndex(row => row.id === rowId)

--- a/src/shared/components/ncTable/sections/Options.vue
+++ b/src/shared/components/ncTable/sections/Options.vue
@@ -121,10 +121,6 @@ export default {
 			type: Array,
 			default: null,
 		},
-		filteredRows: {
-			type: Array,
-			default: () => [],
-		},
 		viewSetting: {
 			type: Object,
 			default: null,
@@ -176,7 +172,7 @@ export default {
 			this.optionsDivWidth = this.$el?.offsetWidth
 		},
 		exportFiltered() {
-			this.$emit('download-filtered-csv', this.filteredRows)
+			this.$emit('download-filtered-csv', this.rows)
 		},
 		exportSelected() {
 			this.$emit('download-filtered-csv', this.getSelectedRows)

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -576,6 +576,20 @@ export const useTablesStore = defineStore('store', {
 			return { ok: true }
 		},
 
+		async validatePublicExportAccess(token) {
+			try {
+				await axios.get(generateOcsUrl('/apps/tables/api/2/public/' + token + '/rows'), { params: { limit: 1 } })
+			} catch (e) {
+				if ([401, 403, 404].includes(e?.response?.status)) {
+					return { ok: false, reason: 'NO_ACCESS' }
+				}
+				displayError(e, t('tables', 'Could not verify export permissions.'))
+				return { ok: false, reason: 'ERROR' }
+			}
+
+			return { ok: true }
+		},
+
 		async transferContext({ id, data }) {
 			try {
 				await axios.put(generateOcsUrl('/apps/tables/api/2/contexts/' + id + '/transfer'), data)


### PR DESCRIPTION
Closes #1412 #1436

* Implements contextual CSV export with three options: 
  1. all
  2. filtered
  3. selected
* Now, in addition when a filter is active (via the header-filtering) is present another menu item is shown in both menus
* Since exports are always CSV I dropped that technical term (can be added again of course)

🏚️ Export (header)|🏡 Export (header new)|🏡 Export (header filter new)|🏚️ Export (selection)|🏡 Export (selection new)|🏡 Export (selection filter (new))
---|---|---|---|---|---
<img width="449" height="647" alt="export" src="https://github.com/user-attachments/assets/4f82c652-d3df-4356-a145-03a8fb6e1130" />|<img width="305" height="662" alt="export_new" src="https://github.com/user-attachments/assets/4171d7ac-eb92-4f3d-b60d-f85163b3e130" />|<img width="466" height="835" alt="export_filtered_new" src="https://github.com/user-attachments/assets/f675857e-1e74-430a-986c-29dde7f08bf9" />|<img width="307" height="300" alt="export_selection_menu" src="https://github.com/user-attachments/assets/5cfa5932-dfa1-4de5-aa06-3bd41b5bc421" />|<img width="375" height="299" alt="export_selection_menu_new" src="https://github.com/user-attachments/assets/f7e0af2b-cf66-40d5-b71e-6edb120440bf" />|<img width="377" height="366" alt="export_selection_filtered_new" src="https://github.com/user-attachments/assets/fc4951ad-4375-4c29-95ee-456378c59010" />
