### PR TITLE
📍Option to pin a column

### DIFF
--- a/src/shared/components/ncTable/mixins/columnHandler.js
+++ b/src/shared/components/ncTable/mixins/columnHandler.js
@@ -24,3 +24,27 @@ export function getColumnWidthStyle(column) {
 
 	return width ? { width, maxWidth: width, minWidth: width } : null
 }
+
+const CHECKBOX_COLUMN_WIDTH = 60
+const DEFAULT_COLUMN_WIDTH = 150
+
+/**
+ * Returns a sticky-positioning style for a column within the frozen range, or null if it should scroll normally.
+ */
+export function getFrozenColumnStyle(col, colIndex, pinnedColumnIndex, hasCheckboxColumn, visibleColumns) {
+	if (pinnedColumnIndex < 0 || colIndex > pinnedColumnIndex) {
+		return null
+	}
+
+	const baseOffset = hasCheckboxColumn ? CHECKBOX_COLUMN_WIDTH : 0
+	const leftOffset = visibleColumns
+		.slice(0, colIndex)
+		.reduce((sum, c) => sum + (c.customSettings?.width ?? DEFAULT_COLUMN_WIDTH), baseOffset)
+
+	return {
+		position: 'sticky',
+		insetInlineStart: `${leftOffset}px`,
+		zIndex: 4,
+		backgroundColor: 'inherit',
+	}
+}

--- a/src/shared/components/ncTable/mixins/columnHandler.js
+++ b/src/shared/components/ncTable/mixins/columnHandler.js
@@ -30,16 +30,29 @@ const DEFAULT_COLUMN_WIDTH = 150
 
 /**
  * Returns a sticky-positioning style for a column within the frozen range, or null if it should scroll normally.
+ *
+ * columnWidths is an optional map of col.id → measured offsetWidth (px). When supplied it is used for the
+ * left-offset calculation so the offsets match the browser's actual auto-layout widths. Without it the
+ * calculation falls back to customSettings.width or DEFAULT_COLUMN_WIDTH.
+ *
+ * No explicit width is set on the frozen cell itself — the table's auto-layout already maintains the
+ * correct column width across all rows. Forcing a width here caused auto-sized columns to be narrowed
+ * to the DEFAULT_COLUMN_WIDTH fallback.
+ *
+ * Hidden columns are excluded from visibleColumns before this function is called, so pinnedColumnIndex
+ * naturally resolves to -1 when the pinned column is hidden, causing the freeze to silently disappear.
+ * This is intentional: when the pinned column is re-shown the freeze resumes automatically.
  */
-export function getFrozenColumnStyle(col, colIndex, pinnedColumnIndex, hasCheckboxColumn, visibleColumns) {
+export function getFrozenColumnStyle(col, colIndex, pinnedColumnIndex, hasCheckboxColumn, visibleColumns, columnWidths = null) {
 	if (pinnedColumnIndex < 0 || colIndex > pinnedColumnIndex) {
 		return null
 	}
 
+	const getWidth = (c) => columnWidths?.[c.id] ?? c.customSettings?.width ?? DEFAULT_COLUMN_WIDTH
 	const baseOffset = hasCheckboxColumn ? CHECKBOX_COLUMN_WIDTH : 0
 	const leftOffset = visibleColumns
 		.slice(0, colIndex)
-		.reduce((sum, c) => sum + (c.customSettings?.width ?? DEFAULT_COLUMN_WIDTH), baseOffset)
+		.reduce((sum, c) => sum + getWidth(c), baseOffset)
 
 	return {
 		position: 'sticky',

--- a/src/shared/components/ncTable/mixins/columnHandler.js
+++ b/src/shared/components/ncTable/mixins/columnHandler.js
@@ -28,21 +28,6 @@ export function getColumnWidthStyle(column) {
 const CHECKBOX_COLUMN_WIDTH = 60
 const DEFAULT_COLUMN_WIDTH = 150
 
-/**
- * Returns a sticky-positioning style for a column within the frozen range, or null if it should scroll normally.
- *
- * columnWidths is an optional map of col.id → measured offsetWidth (px). When supplied it is used for the
- * left-offset calculation so the offsets match the browser's actual auto-layout widths. Without it the
- * calculation falls back to customSettings.width or DEFAULT_COLUMN_WIDTH.
- *
- * No explicit width is set on the frozen cell itself — the table's auto-layout already maintains the
- * correct column width across all rows. Forcing a width here caused auto-sized columns to be narrowed
- * to the DEFAULT_COLUMN_WIDTH fallback.
- *
- * Hidden columns are excluded from visibleColumns before this function is called, so pinnedColumnIndex
- * naturally resolves to -1 when the pinned column is hidden, causing the freeze to silently disappear.
- * This is intentional: when the pinned column is re-shown the freeze resumes automatically.
- */
 export function getFrozenColumnStyle(col, colIndex, pinnedColumnIndex, hasCheckboxColumn, visibleColumns, columnWidths = null) {
 	if (pinnedColumnIndex < 0 || colIndex > pinnedColumnIndex) {
 		return null

--- a/src/shared/components/ncTable/partials/TableHeader.vue
+++ b/src/shared/components/ncTable/partials/TableHeader.vue
@@ -12,9 +12,10 @@
 		</th>
 		<th v-for="(col, index) in visibleColumns"
 			:key="col.id"
+			:data-col-id="col.id"
 			:style="{
 				...getColumnWidthStyle(col),
-				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns),
+				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns, columnWidths),
 			}"
 			:class="{
 				'frozen-column': index <= pinnedColumnIndex,
@@ -92,6 +93,10 @@ export default {
 		},
 		pinnedColumnId: {
 			type: Number,
+			default: null,
+		},
+		columnWidths: {
+			type: Object,
 			default: null,
 		},
 	},

--- a/src/shared/components/ncTable/partials/TableHeader.vue
+++ b/src/shared/components/ncTable/partials/TableHeader.vue
@@ -22,8 +22,10 @@
 							:open-state.sync="openedColumnHeaderMenus[col.id]"
 							:config="config"
 							:view-setting.sync="localViewSetting"
+							:pinned-column-id="pinnedColumnId"
 							@edit-column="col => $emit('edit-column', col)"
-							@delete-column="col => $emit('delete-column', col)" />
+							@delete-column="col => $emit('delete-column', col)"
+							@pin-column="id => $emit('pin-column', id)" />
 					</div>
 					<div v-if="getFilterForColumn(col).length > 0" class="filter-wrapper">
 						<FilterLabel v-for="filter in getFilterForColumn(col)"
@@ -77,6 +79,10 @@ export default {
 		},
 		config: {
 			type: Object,
+			default: null,
+		},
+		pinnedColumnId: {
+			type: Number,
 			default: null,
 		},
 	},

--- a/src/shared/components/ncTable/partials/TableHeader.vue
+++ b/src/shared/components/ncTable/partials/TableHeader.vue
@@ -10,7 +10,16 @@
 				<div v-if="hasRightHiddenNeighbor(-1)" class="hidden-indicator-first" @click="unhide(-1)" />
 			</div>
 		</th>
-		<th v-for="col in visibleColumns" :key="col.id" :style="getColumnWidthStyle(col)">
+		<th v-for="(col, index) in visibleColumns"
+			:key="col.id"
+			:style="{
+				...getColumnWidthStyle(col),
+				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns),
+			}"
+			:class="{
+				'frozen-column': index <= pinnedColumnIndex,
+				'frozen-column--last': index === pinnedColumnIndex,
+			}">
 			<div class="cell-wrapper">
 				<div class="cell-options-wrapper">
 					<div class="cell">
@@ -50,7 +59,7 @@ import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import TableHeaderColumnOptions from './TableHeaderColumnOptions.vue'
 import FilterLabel from './FilterLabel.vue'
 import { getFilterWithId, getFiltersForColumn } from '../mixins/filter.js'
-import { getColumnWidthStyle } from '../mixins/columnHandler.js'
+import { getColumnWidthStyle, getFrozenColumnStyle } from '../mixins/columnHandler.js'
 
 export default {
 
@@ -105,6 +114,10 @@ export default {
 		visibleColumns() {
 			return this.columns.filter(col => !this.localViewSetting?.hiddenColumns?.includes(col.id))
 		},
+		pinnedColumnIndex() {
+			if (this.pinnedColumnId === null) return -1
+			return this.visibleColumns.findIndex(col => col.id === this.pinnedColumnId)
+		},
 	},
 	watch: {
 		localViewSetting() {
@@ -118,6 +131,7 @@ export default {
 	methods: {
 		getFilterWithId,
 		getColumnWidthStyle,
+		getFrozenColumnStyle,
 		updateOpenState(columnId) {
 			this.openedColumnHeaderMenus[columnId] = !this.openedColumnHeaderMenus[columnId]
 			this.openedColumnHeaderMenus = Object.assign({}, this.openedColumnHeaderMenus)

--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -61,6 +61,13 @@
 				</NcActionButton>
 			</template>
 			<template v-else>
+				<NcActionButton v-if="column.id >= 0" @click="pinColumn()">
+					<template #icon>
+						<PinOffIcon v-if="pinnedColumnId === column.id" :size="20" />
+						<PinIcon v-else :size="20" />
+					</template>
+					{{ pinnedColumnId === column.id ? t('tables', 'Unpin column') : t('tables', 'Pin column') }}
+				</NcActionButton>
 				<NcActionCaption v-if="!hasPresetSorting && canSort" :name="t('tables', 'Sorting')" />
 				<NcActionButtonGroup v-if="!hasPresetSorting && canSort">
 					<NcActionButton :class="{ selected: getSortMode === 'ASC' }" :aria-label="t('tables', 'Sort asc')" @click="sort('ASC')">
@@ -118,13 +125,6 @@
 						</template>
 					</NcActionButton>
 				</NcActionButtonGroup>
-				<NcActionButton v-if="column.id >= 0" @click="$emit('pin-column', column.id)">
-					<template #icon>
-						<PinOffIcon v-if="pinnedColumnId === column.id" :size="20" />
-						<PinIcon v-else :size="20" />
-					</template>
-					{{ pinnedColumnId === column.id ? t('tables', 'Unpin column') : t('tables', 'Pin column') }}
-				</NcActionButton>
 			</template>
 		</NcActions>
 	</div>
@@ -325,6 +325,10 @@ export default {
 		},
 		close() {
 			this.localOpenState = false
+		},
+		pinColumn() {
+			this.$emit('pin-column', this.column.id)
+			this.close()
 		},
 		changeFilterOperator(op) {
 			this.selectedOperator = op

--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -63,8 +63,8 @@
 			<template v-else>
 				<NcActionButton v-if="column.id >= 0" @click="pinColumn()">
 					<template #icon>
-						<PinOffIcon v-if="pinnedColumnId === column.id" :size="20" />
-						<PinIcon v-else :size="20" />
+						<PinOffOutline v-if="pinnedColumnId === column.id" :size="20" />
+						<PinOutline v-else :size="20" />
 					</template>
 					{{ pinnedColumnId === column.id ? t('tables', 'Unpin column') : t('tables', 'Pin column') }}
 				</NcActionButton>
@@ -140,8 +140,8 @@ import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import FilterCogOutline from 'vue-material-design-icons/FilterCogOutline.vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
-import PinIcon from 'vue-material-design-icons/Pin.vue'
-import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
+import PinOutline from 'vue-material-design-icons/PinOutline.vue'
+import PinOffOutline from 'vue-material-design-icons/PinOffOutline.vue'
 import {
 	NcActionButton,
 	NcActionButtonGroup,
@@ -162,8 +162,8 @@ export default {
 		ChevronLeft,
 		FilterCogOutline,
 		Magnify,
-		PinIcon,
-		PinOffIcon,
+		PinOutline,
+		PinOffOutline,
 		NcActionInput,
 		NcActionRadio,
 		NcActionCaption,

--- a/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
+++ b/src/shared/components/ncTable/partials/TableHeaderColumnOptions.vue
@@ -118,6 +118,13 @@
 						</template>
 					</NcActionButton>
 				</NcActionButtonGroup>
+				<NcActionButton v-if="column.id >= 0" @click="$emit('pin-column', column.id)">
+					<template #icon>
+						<PinOffIcon v-if="pinnedColumnId === column.id" :size="20" />
+						<PinIcon v-else :size="20" />
+					</template>
+					{{ pinnedColumnId === column.id ? t('tables', 'Unpin column') : t('tables', 'Pin column') }}
+				</NcActionButton>
 			</template>
 		</NcActions>
 	</div>
@@ -133,6 +140,8 @@ import EyeOffOutline from 'vue-material-design-icons/EyeOffOutline.vue'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import FilterCogOutline from 'vue-material-design-icons/FilterCogOutline.vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
+import PinIcon from 'vue-material-design-icons/Pin.vue'
+import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
 import {
 	NcActionButton,
 	NcActionButtonGroup,
@@ -153,6 +162,8 @@ export default {
 		ChevronLeft,
 		FilterCogOutline,
 		Magnify,
+		PinIcon,
+		PinOffIcon,
 		NcActionInput,
 		NcActionRadio,
 		NcActionCaption,
@@ -178,6 +189,10 @@ export default {
 		},
 		viewSetting: {
 			type: Object,
+			default: null,
+		},
+		pinnedColumnId: {
+			type: Number,
 			default: null,
 		},
 	},

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -10,7 +10,7 @@
 		<td v-for="(col, index) in visibleColumns" :key="col.id"
 			:style="{
 				...getColumnWidthStyle(col),
-				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns),
+				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns, columnWidths),
 			}"
 			:class="{
 				'search-result': getCell(col.id)?.searchStringFound,
@@ -112,6 +112,10 @@ export default {
 		},
 		pinnedColumnId: {
 			type: Number,
+			default: null,
+		},
+		columnWidths: {
+			type: Object,
 			default: null,
 		},
 	},

--- a/src/shared/components/ncTable/partials/TableRow.vue
+++ b/src/shared/components/ncTable/partials/TableRow.vue
@@ -7,12 +7,17 @@
 		<td v-if="config.canSelectRows" :class="{sticky: config.canSelectRows}">
 			<NcCheckboxRadioSwitch :checked="selected" @update:checked="v => $emit('update-row-selection', { rowId: row.id, value: v })" />
 		</td>
-		<td v-for="col in visibleColumns" :key="col.id"
-			:style="getColumnWidthStyle(col)"
+		<td v-for="(col, index) in visibleColumns" :key="col.id"
+			:style="{
+				...getColumnWidthStyle(col),
+				...getFrozenColumnStyle(col, index, pinnedColumnIndex, config.canSelectRows, visibleColumns),
+			}"
 			:class="{
 				'search-result': getCell(col.id)?.searchStringFound,
 				'filter-result': getCell(col.id)?.filterFound,
-				'fixed-width': col.customSettings?.width > 0
+				'fixed-width': col.customSettings?.width > 0,
+				'frozen-column': index <= pinnedColumnIndex,
+				'frozen-column--last': index === pinnedColumnIndex,
 			}"
 			@click="handleCellClick(col)">
 			<component :is="getTableCell(col)"
@@ -48,7 +53,7 @@ import TableCellSelection from './TableCellSelection.vue'
 import TableCellMultiSelection from './TableCellMultiSelection.vue'
 import TableCellTextRich from './TableCellEditor.vue'
 import TableCellUsergroup from './TableCellUsergroup.vue'
-import { ColumnTypes, getColumnWidthStyle } from './../mixins/columnHandler.js'
+import { ColumnTypes, getColumnWidthStyle, getFrozenColumnStyle } from './../mixins/columnHandler.js'
 import { translate as t } from '@nextcloud/l10n'
 import {
 	TYPE_META_ID, TYPE_META_CREATED_BY, TYPE_META_CREATED_AT, TYPE_META_UPDATED_BY, TYPE_META_UPDATED_AT,
@@ -105,6 +110,10 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		pinnedColumnId: {
+			type: Number,
+			default: null,
+		},
 	},
 	computed: {
 		getSelection: {
@@ -113,6 +122,10 @@ export default {
 		},
 		visibleColumns() {
 			return this.columns.filter(col => !this.viewSetting?.hiddenColumns?.includes(col.id))
+		},
+		pinnedColumnIndex() {
+			if (this.pinnedColumnId === null) return -1
+			return this.visibleColumns.findIndex(col => col.id === this.pinnedColumnId)
 		},
 		// column types that don't support inline editing yet
 		// to be used to trigger the edit modal instead of inline editing
@@ -124,6 +137,7 @@ export default {
 	methods: {
 		t,
 		getColumnWidthStyle,
+		getFrozenColumnStyle,
 		handleCellClick(column) {
 			// If the column type doesn't support inline editing, trigger the edit modal
 			if (this.nonInlineEditableColumnTypes.includes(column.type) && this.config.canEditRows) {

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -11,12 +11,14 @@
 					:rows="getSearchedAndFilteredAndSortedRows"
 					:view-setting.sync="localViewSetting"
 					:config="config"
+					:pinned-column-id="pinnedColumnId"
 					@create-row="$emit('create-row')"
 					@create-column="$emit('create-column')"
 					@edit-column="col => $emit('edit-column', col)"
 					@delete-column="col => $emit('delete-column', col)"
 					@download-csv="data => $emit('download-csv', data)"
-					@select-all-rows="selectAllRows">
+					@select-all-rows="selectAllRows"
+					@pin-column="setPinnedColumn">
 					<template #actions>
 						<slot name="actions" />
 					</template>
@@ -37,6 +39,7 @@
 					:config="config"
 					:element-id="elementId"
 					:is-view="isView"
+					:pinned-column-id="pinnedColumnId"
 					@update-row-selection="updateRowSelection"
 					@edit-row="rowId => $emit('edit-row', rowId)" />
 			</transition-group>
@@ -155,6 +158,7 @@ export default {
 			pageNumber: 1,
 			rowsPerPage: 100,
 			rowAnimation: false,
+			pinnedColumnId: null,
 		}
 	},
 
@@ -346,6 +350,9 @@ export default {
 
 	methods: {
 		t,
+		setPinnedColumn(columnId) {
+			this.pinnedColumnId = this.pinnedColumnId === columnId ? null : columnId
+		},
 		addMagicFieldsValues(filter) {
 			Object.values(MagicFields).forEach(field => {
 				const newFilterValue = filter.value.replace('@' + field.id, field.replace)

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -612,18 +612,13 @@ export default {
 	thead tr > th.frozen-column {
 		z-index: 6;
 		border-right: 1px solid transparent; // aligns inset shadow with td (which has a 1px border)
-		// Combine the existing thead bottom-border shadow with a per-column right-border shadow.
-		// This rule has higher specificity than `thead tr th`, so it must re-declare both shadows.
 		box-shadow: inset 0 -1px 0 var(--color-border), inset -1px 0 0 var(--color-border-dark);
 	}
 
-	// Right border via box-shadow: with border-collapse the shared border is "owned" by the
-	// non-frozen neighbouring cell and scrolls away with it. box-shadow stays on the sticky cell.
 	tr > td.frozen-column {
 		box-shadow: inset -1px 0 0 var(--color-border-dark);
 	}
 
-	// Visual separator on the last frozen column � 2px overrides the 1px per-column border above.
 	thead tr > th.frozen-column--last {
 		box-shadow: inset 0 -1px 0 var(--color-border), inset -3px 0 0 var(--color-border-dark);
 	}

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -12,6 +12,7 @@
 					:view-setting.sync="localViewSetting"
 					:config="config"
 					:pinned-column-id="pinnedColumnId"
+					:column-widths="columnWidths"
 					@create-row="$emit('create-row')"
 					@create-column="$emit('create-column')"
 					@edit-column="col => $emit('edit-column', col)"
@@ -40,6 +41,7 @@
 					:element-id="elementId"
 					:is-view="isView"
 					:pinned-column-id="pinnedColumnId"
+					:column-widths="columnWidths"
 					@update-row-selection="updateRowSelection"
 					@edit-row="rowId => $emit('edit-row', rowId)" />
 			</transition-group>
@@ -159,6 +161,7 @@ export default {
 			rowsPerPage: 100,
 			rowAnimation: false,
 			pinnedColumnId: null,
+			columnWidths: null,
 		}
 	},
 
@@ -331,6 +334,13 @@ export default {
 		viewSetting() {
 			this.localViewSetting = this.viewSetting
 		},
+		pinnedColumnId(newVal) {
+			if (newVal !== null) {
+				this.$nextTick(() => this.measureColumnWidths())
+			} else {
+				this.columnWidths = null
+			}
+		},
 	},
 
 	updated() {
@@ -352,6 +362,17 @@ export default {
 		t,
 		setPinnedColumn(columnId) {
 			this.pinnedColumnId = this.pinnedColumnId === columnId ? null : columnId
+		},
+		measureColumnWidths() {
+			const headerRow = this.$el.querySelector('thead tr')
+			if (!headerRow) return
+			const widths = {}
+			headerRow.querySelectorAll('th[data-col-id]').forEach(th => {
+				widths[parseInt(th.dataset.colId, 10)] = th.offsetWidth
+			})
+			if (JSON.stringify(widths) !== JSON.stringify(this.columnWidths)) {
+				this.columnWidths = widths
+			}
 		},
 		addMagicFieldsValues(filter) {
 			Object.values(MagicFields).forEach(field => {
@@ -590,9 +611,22 @@ export default {
 
 	thead tr > th.frozen-column {
 		z-index: 6;
+		// Combine the existing thead bottom-border shadow with a per-column right-border shadow.
+		// This rule has higher specificity than `thead tr th`, so it must re-declare both shadows.
+		box-shadow: inset 0 -1px 0 var(--color-border), inset -1px 0 0 var(--color-border-dark);
 	}
 
-	tr > th.frozen-column--last,
+	// Right border via box-shadow: with border-collapse the shared border is "owned" by the
+	// non-frozen neighbouring cell and scrolls away with it. box-shadow stays on the sticky cell.
+	tr > td.frozen-column {
+		box-shadow: inset -1px 0 0 var(--color-border-dark);
+	}
+
+	// Visual separator on the last frozen column — 2px overrides the 1px per-column border above.
+	thead tr > th.frozen-column--last {
+		box-shadow: inset 0 -1px 0 var(--color-border), inset -2px 0 0 var(--color-border-dark);
+	}
+
 	tr > td.frozen-column--last {
 		box-shadow: inset -2px 0 0 var(--color-border-dark);
 	}

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -611,6 +611,7 @@ export default {
 
 	thead tr > th.frozen-column {
 		z-index: 6;
+		border-right: 1px solid transparent; // aligns inset shadow with td (which has a 1px border)
 		// Combine the existing thead bottom-border shadow with a per-column right-border shadow.
 		// This rule has higher specificity than `thead tr th`, so it must re-declare both shadows.
 		box-shadow: inset 0 -1px 0 var(--color-border), inset -1px 0 0 var(--color-border-dark);
@@ -622,13 +623,13 @@ export default {
 		box-shadow: inset -1px 0 0 var(--color-border-dark);
 	}
 
-	// Visual separator on the last frozen column — 2px overrides the 1px per-column border above.
+	// Visual separator on the last frozen column ï¿½ 2px overrides the 1px per-column border above.
 	thead tr > th.frozen-column--last {
-		box-shadow: inset 0 -1px 0 var(--color-border), inset -2px 0 0 var(--color-border-dark);
+		box-shadow: inset 0 -1px 0 var(--color-border), inset -3px 0 0 var(--color-border-dark);
 	}
 
 	tr > td.frozen-column--last {
-		box-shadow: inset -2px 0 0 var(--color-border-dark);
+		box-shadow: inset -3px 0 0 var(--color-border-dark);
 	}
 
 	tr>th.sticky:first-child,tr>td.sticky:first-child {

--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -582,6 +582,21 @@ export default {
 		}
 	}
 
+	tr > th.frozen-column,
+	tr > td.frozen-column {
+		background-color: inherit;
+		z-index: 4;
+	}
+
+	thead tr > th.frozen-column {
+		z-index: 6;
+	}
+
+	tr > th.frozen-column--last,
+	tr > td.frozen-column--last {
+		box-shadow: inset -2px 0 0 var(--color-border-dark);
+	}
+
 	tr>th.sticky:first-child,tr>td.sticky:first-child {
 		position: sticky;
 		inset-inline-start: 0;


### PR DESCRIPTION
implements the column aspect of #613 - frontend-only (not persisted in the backend in any way - also currently not planned to, see below). 

So this is not persisted in any way to keep the PR simple. Storing the info could be a follow-up, question would be the scope, general or per user while I think pinning is in most cases something temporary or general so I am unsure about a user option.
For general pinning it should then just happen via the dialog not in the tabular view itself I think.

* The pinning works for table, view and application items/columns.
* Pinning a column pins all columns to the left of it.

Pin | Unpin
---|---
<img width="176" height="309" alt="2026-04-19 17_47_37-Welcome to Nextcloud Tables! - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/62240a9a-38d4-4b34-b2f2-fe0b446bcf4c" />|<img width="170" height="315" alt="2026-04-19 18_04_39-Welcome to Nextcloud Tables! - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/16d886b8-93a7-4276-85e4-8fecc1c6e6b7" />

## ❓ Open Question
Should the pinned column be more visually marked as such, see below. Currently the column line is thicker, but that is the only way to spot the pinned column and of course it becomes apparent upon horizontal scrolling. Can't tell given that spreadsheets also don't visualize it, but the thought crossed my mind, so I wanted to bring it up. Below "Ease of use" is the pinned column (see the slightly thickened column line)

<img width="1665" height="618" alt="2026-04-19 18_01_47-Welcome to Nextcloud Tables! - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/5193d7b3-c75b-4e62-bab5-fd0f63ba3631" />
