### PR TITLE
build: disable renovate for EOL 0.9

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,13 +8,13 @@
   "minimumReleaseAge": "7 days",
   "rebaseWhen": "conflicted",
   "ignoreUnstable": false,
-  "baseBranches": ["main", "stable1.0", "stable0.9"],
+  "baseBranches": ["main", "stable1.0"],
   "enabledManagers": ["npm", "composer", "github-actions"],
   "ignoreDeps": ["node", "npm"],
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor"],
-      "matchBaseBranches": ["/^stable0\\.[3-8]$/"],
+      "matchBaseBranches": ["/^stable0\\.[3-9]$/"],
       "enabled": false
     },
     {


### PR DESCRIPTION
0.9 only covers NC 29 exclusively, we don't need dep updates there.