### PR TITLE
fix: Adjust date formatting

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellDateTime.vue
+++ b/src/shared/components/ncTable/partials/TableCellDateTime.vue
@@ -171,7 +171,10 @@ export default {
 				newValue = 'none'
 			} else {
 				const format = this.getDateFormat()
-				newValue = Moment(this.editDateTimeValue).utc().format(format)
+				const editDateTimeMoment = Moment(this.editDateTimeValue)
+				newValue = this.column.type === 'datetime-date'
+					? editDateTimeMoment.format(format)
+					: editDateTimeMoment.utc().format(format)
 			}
 
 			if (newValue === this.value) {


### PR DESCRIPTION
When you select a date in the date column, it subtracts one day. This only happens with the inline editing for date columns. This fixes it. 