### PR TITLE
fix: handle first option select

### DIFF
--- a/lib/Service/ColumnTypes/SelectionBusiness.php
+++ b/lib/Service/ColumnTypes/SelectionBusiness.php
@@ -24,7 +24,7 @@ class SelectionBusiness extends SuperBusiness {
 
 		foreach ($column->getSelectionOptionsArray() as $option) {
 			if ($option['id'] === $intValue) {
-				return json_encode($option['id']);
+				return json_encode((string)$option['id']);
 			}
 		}
 

--- a/tests/unit/Service/ColumnTypes/SelectionBusinessTest.php
+++ b/tests/unit/Service/ColumnTypes/SelectionBusinessTest.php
@@ -33,9 +33,9 @@ class SelectionBusinessTest extends TestCase {
 
 	public function parseValueProvider(): array {
 		return [
-			'valid integer value' => [2, '2'],
-			'valid string value' => ['2', '2'],
-			'valid string value for numeric option' => ['4', '4'],
+			'valid integer value' => [2, '"2"'],
+			'valid string value' => ['2', '"2"'],
+			'valid string value for numeric option' => ['4', '"4"'],
 			'invalid value' => [5, ''],
 			'null value' => [null, ''],
 			'empty string' => ['', ''],


### PR DESCRIPTION
* Resolves: #2545

## Summary
Cell value parsing improvements: adjust the value parsing logic in the `RowService`. Add handle cases where the parsed value is the integer `0`, ensuring it is returned as the string `'0'` instead of being treated as a null value.