### PR TITLE
fix: Prevent editing when clicking on links in TableCellLink

### DIFF
--- a/src/shared/components/ncTable/partials/TableCellLink.vue
+++ b/src/shared/components/ncTable/partials/TableCellLink.vue
@@ -212,6 +212,11 @@ export default {
 		t,
 
 		handleStartEditing(event) {
+			if (event?.target?.closest?.('a')) {
+				event.stopPropagation()
+				return
+			}
+
 			if (event && (event.ctrlKey || event.metaKey)) {
 				return
 			}


### PR DESCRIPTION
If I click a link in a field it goes into editing mode (link is still opened but if I go back to the Tables tab the field is to be edited). This PR fixes this. 