### PR TITLE
test(context): Update nav bar test for 34+ update

### DIFF
--- a/cypress/e2e/context-navigation-hidden.cy.js
+++ b/cypress/e2e/context-navigation-hidden.cy.js
@@ -22,12 +22,12 @@ describe('Test context navigation hidden context', () => {
 	it('Create context that is hidden in nav by default', () => {
 		cy.createContext(contextTitle, false)
 		cy.visit('apps/tables')
-		cy.get(`#header .app-menu-entry [title="${contextTitle}"]`).should('not.exist')
+		cy.getAppMenuEntry(contextTitle).should('not.exist')
 
 		cy.get(`[data-cy="navigationContextItem"]:contains("${contextTitle}")`).find('button').click({ force: true })
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').should('not.be.checked')
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').click({ force: true })
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').should('be.checked')
-		cy.get(`#header .app-menu-entry [title="${contextTitle}"]`).should('exist')
+		cy.getAppMenuEntry(contextTitle).should('exist')
 	})
 })

--- a/cypress/e2e/context-navigation-shared.cy.js
+++ b/cypress/e2e/context-navigation-shared.cy.js
@@ -28,7 +28,7 @@ describe('Test context navigation shared context', () => {
 		cy.createContext(contextTitle, true)
 		cy.visit('apps/tables')
 
-		cy.get(`#header .app-menu-entry [title="${contextTitle}"]`).should('exist')
+		cy.getAppMenuEntry(contextTitle).should('exist')
 
 		cy.loadContext(contextTitle)
 		cy.get('[data-cy="context-title"]').should('be.visible')
@@ -42,10 +42,10 @@ describe('Test context navigation shared context', () => {
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').should('be.checked')
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').click({ force: true })
 		cy.get('[data-cy="navigationContextShowInNavSwitch"] input').should('not.be.checked')
-		cy.get(`#header .app-menu-entry [title="${contextTitle}"]`).should('not.exist')
+		cy.getAppMenuEntry(contextTitle).should('not.exist')
 
 		cy.login(nonLocalUser)
 		cy.visit('apps/tables')
-		cy.get(`#header .app-menu-entry [title="${contextTitle}"]`).should('exist')
+		cy.getAppMenuEntry(contextTitle).should('exist')
 	})
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -479,6 +479,21 @@ Cypress.Commands.add('uploadFile', (fileName, mimeType, target) => {
 		})
 })
 
+Cypress.Commands.add('getAppMenuEntry', (title) => {
+	return cy.get('body').then($body => {
+		if ($body.find('.app-menu__waffle').length > 0) {
+			// NC34+: open the waffle popover if not already open, then check the grid
+			return cy.get('.app-menu__waffle').then($btn => {
+				if ($btn.attr('aria-expanded') !== 'true') {
+					return cy.wrap($btn).click()
+				}
+			}).then(() => cy.get(`.app-menu__grid .app-item[title="${title}"]`))
+		}
+		// NC33: entries are always visible inline in the header
+		return cy.get(`#header .app-menu-entry [title="${title}"]`)
+	})
+})
+
 Cypress.Commands.add('ocsRequest', (user, options) => {
 	const auth = { user: user.userId, password: user.password }
 	return cy.request({


### PR DESCRIPTION
Root cause: Nextcloud server PR [#60180](https://github.com/nextcloud/server/pull/60180) replaced the app menu DOM structure. The old `#header .app-menu-entry  [title="..."]` was a flat list approach; the new structure uses a waffle-style popover grid where entries are `.app-item` elements inside `.app-menu__grid`.

  Fix:
  - Added `cy.getAppMenuEntry(title)` command to `cypress/support/commands.js:483` that branches on 
  `Cypress.env('ncVersion')`:
    - stable33 → `#header .app-menu-entry [title="${title}"]` (old structure)
    - anything else (master, future stable34+) → `.app-menu__grid .app-item[title="${title}"]` (new structure)
  - Replaced all 5 raw `cy.get('#header .app-menu-entry ...')` calls across both test files with
  `cy.getAppMenuEntry(contextTitle)`.

  The `CYPRESS_ncVersion` env var is already passed from the CI matrix (`matrix.server-versions`), so no workflow
  changes are needed.