### PR TITLE
Fix Add 'does-not-contain' condition to Row2Mapper

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -628,6 +628,8 @@ class Row2Mapper {
 				return $qb->expr()->like($columnName, $qb->createNamedParameter($this->db->escapeLikeParameter($value) . '%', $paramType));
 			case 'contains':
 				return $qb->expr()->like($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
+			case 'does-not-contain':
+				return $qb->expr()->notLike($columnName, $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 			case 'is-equal':
 				return $qb->expr()->eq($columnName, $qb->createNamedParameter($value, $paramType));
 			case 'is-not-equal':


### PR DESCRIPTION
Certainly an omission tested here and it works. If you try with current master an error occur if you try to use the filter on creator while with this changes the filter does work.. 

