### PR TITLE
🎨 Icons should be outline-variant where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@material-symbols/svg-400": "^0.44.8",
         "@mdi/svg": "^7.4.47",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.2",
@@ -2746,6 +2747,12 @@
       "dependencies": {
         "unist-util-is": "^3.0.0"
       }
+    },
+    "node_modules/@material-symbols/svg-400": {
+      "version": "0.44.8",
+      "resolved": "https://registry.npmjs.org/@material-symbols/svg-400/-/svg-400-0.44.8.tgz",
+      "integrity": "sha512-p4Lebev1M3UfRQug5rRV4Yci/j72+Pf4e3lZtyA0eLNAxUtYBiTlwMJHYHe8Pzw8QTU8KvZwULvRFxmO2rmWXA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@mdi/js": {
       "version": "7.4.47",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start:nextcloud": "node playwright/start-nextcloud-server.mjs"
   },
   "dependencies": {
+    "@material-symbols/svg-400": "^0.44.8",
     "@mdi/svg": "^7.4.47",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.2",

--- a/src/modules/main/sections/Dashboard.vue
+++ b/src/modules/main/sections/Dashboard.vue
@@ -80,7 +80,7 @@
 										@click="actionShowIntegration(view)">
 										{{ t('tables', 'Integration') }}
 										<template #icon>
-											<Connection :size="20" />
+											<ListBoxOutline :size="20" />
 										</template>
 									</NcActionButton>
 									<NcActionButton v-if="canManageElement(table)"
@@ -121,7 +121,7 @@ import permissionsMixin from '../../../shared/components/ncTable/mixins/permissi
 import PlaylistPlus from 'vue-material-design-icons/PlaylistPlus.vue'
 import DeleteOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import Moment from '@nextcloud/moment'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import displayError from '../../../shared/utils/displayError.js'
@@ -135,7 +135,7 @@ export default {
 	components: {
 		NcLoadingIcon,
 		NcActionButton,
-		Connection,
+		ListBoxOutline,
 		NcActions,
 		NcButton,
 		NcAvatar,

--- a/src/modules/main/sections/DataTable.vue
+++ b/src/modules/main/sections/DataTable.vue
@@ -64,7 +64,7 @@
 							@click="$emit('show-integration')">
 							{{ t('tables', 'Integration') }}
 							<template #icon>
-								<Connection :size="20" />
+								<ListBoxOutline :size="20" />
 							</template>
 						</NcActionButton>
 					</NcActions>
@@ -155,7 +155,7 @@
 							@click="$emit('show-integration')">
 							{{ t('tables', 'Integration') }}
 							<template #icon>
-								<Connection :size="20" />
+								<ListBoxOutline :size="20" />
 							</template>
 						</NcActionButton>
 					</NcActions>
@@ -173,7 +173,7 @@ import IconRename from 'vue-material-design-icons/RenameOutline.vue'
 import IconTool from 'vue-material-design-icons/TableCog.vue'
 import TableView from '../partials/TableView.vue'
 import EmptyTable from './EmptyTable.vue'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
 import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import Import from 'vue-material-design-icons/Import.vue'
 import { NcActionButton, NcActions, NcActionCaption } from '@nextcloud/vue'
@@ -186,7 +186,7 @@ export default {
 		IconTool,
 		TableView,
 		NcActionButton,
-		Connection,
+		ListBoxOutline,
 		TrayArrowDown,
 		NcActionCaption,
 		NcActions,

--- a/src/modules/main/sections/View.vue
+++ b/src/modules/main/sections/View.vue
@@ -77,7 +77,7 @@
 							@click="$emit('show-integration')">
 							{{ t('tables', 'Integration') }}
 							<template #icon>
-								<Connection :size="20" />
+								<ListBoxOutline :size="20" />
 							</template>
 						</NcActionButton>
 					</NcActions>
@@ -98,7 +98,7 @@ import TableColumnPlusAfter from 'vue-material-design-icons/TableColumnPlusAfter
 import PlaylistEdit from 'vue-material-design-icons/PlaylistEdit.vue'
 import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import IconImport from 'vue-material-design-icons/Import.vue'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
 import ElementTitle from './ElementTitle.vue'
 import TableDescription from './TableDescription.vue'
 
@@ -114,7 +114,7 @@ export default {
 		NcActionButton,
 		TableColumnPlusAfter,
 		NcActionCaption,
-		Connection,
+		ListBoxOutline,
 		ElementTitle,
 	},
 

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -27,7 +27,8 @@
 					wide
 					@click="activeTabId = 'activity'">
 					<template #icon>
-						<ActivityIcon />
+						<ActivityIcon v-if="activeTabId === 'activity'" />
+						<ActivityOutlineIcon v-else />
 					</template>
 					{{ t('tables', 'Activity') }}
 				</NcButton>
@@ -96,6 +97,7 @@ import { useTablesStore } from '../../store/store.js'
 import { useDataStore } from '../../store/data.js'
 import { ALLOWED_PROTOCOLS } from '../../shared/constants.ts'
 import ActivityIcon from 'vue-material-design-icons/LightningBolt.vue'
+import ActivityOutlineIcon from 'vue-material-design-icons/LightningBoltOutline.vue'
 import HomeIcon from 'vue-material-design-icons/Home.vue'
 import HomeOutlineIcon from 'vue-material-design-icons/HomeOutline.vue'
 import ActivityList from '../../shared/components/ActivityList.vue'
@@ -110,6 +112,7 @@ export default {
 		ColumnFormComponent,
 		NcNoteCard,
 		ActivityIcon,
+		ActivityOutlineIcon,
 		HomeIcon,
 		HomeOutlineIcon,
 	},

--- a/src/modules/modals/ImportPreview.vue
+++ b/src/modules/modals/ImportPreview.vue
@@ -65,7 +65,7 @@
 import { translate as t } from '@nextcloud/l10n'
 import { NcButton, NcCheckboxRadioSwitch, NcSelect } from '@nextcloud/vue'
 import { mapState, mapActions } from 'pinia'
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
 import { ColumnTypes } from '../../shared/components/ncTable/mixins/columnHandler.js'
 import { emit } from '@nextcloud/event-bus'
 import { useTablesStore } from '../../store/store.js'

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -71,7 +71,7 @@
 			<NcActionButton :close-after-click="true" @click="actionShowIntegration">
 				{{ t('tables', 'Integration') }}
 				<template #icon>
-					<Connection :size="20" />
+					<ListBoxOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -89,7 +89,7 @@
 				@click="toggleFavoriteTable(true)">
 				{{ t('tables', 'Add to favorites') }}
 				<template #icon>
-					<Star :size="20" />
+					<StarOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -97,7 +97,7 @@
 			<NcActionButton v-if="table.favorite" :close-after-click="true" @click="toggleFavoriteTable(false)">
 				{{ t('tables', 'Remove from favorites') }}
 				<template #icon>
-					<StarOutline :size="20" />
+					<Star :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -106,7 +106,7 @@
 				:close-after-click="true" @click="toggleArchiveTable(true)">
 				{{ t('tables', 'Archive table') }}
 				<template #icon>
-					<ArchiveArrowDown :size="20" />
+					<ArchiveArrowDownOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -143,19 +143,19 @@ import { useTablesStore } from '../../../store/store.js'
 import Table from 'vue-material-design-icons/Table.vue'
 import Star from 'vue-material-design-icons/Star.vue'
 import StarOutline from 'vue-material-design-icons/StarOutline.vue'
-import ArchiveArrowDown from 'vue-material-design-icons/ArchiveArrowDown.vue'
+import ArchiveArrowDownOutline from 'vue-material-design-icons/ArchiveArrowDownOutline.vue'
 import ArchiveArrowUpOutline from 'vue-material-design-icons/ArchiveArrowUpOutline.vue'
 import DeleteOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import activityMixin from '../../../shared/mixins/activityMixin.js'
 import { getCurrentUser, getRequestToken } from '@nextcloud/auth'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
 import Import from 'vue-material-design-icons/Import.vue'
 import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
 import NavigationViewItem from './NavigationViewItem.vue'
 import PlaylistPlus from 'vue-material-design-icons/PlaylistPlus.vue'
 import IconRename from 'vue-material-design-icons/RenameOutline.vue'
-import ActivityIcon from 'vue-material-design-icons/LightningBolt.vue'
+import ActivityIcon from 'vue-material-design-icons/LightningBoltOutline.vue'
 import { generateUrl } from '@nextcloud/router'
 
 export default {
@@ -166,7 +166,7 @@ export default {
 		Table,
 		Star,
 		StarOutline,
-		ArchiveArrowDown,
+		ArchiveArrowDownOutline,
 		ArchiveArrowUpOutline,
 		Import,
 		TrayArrowDown,
@@ -175,7 +175,7 @@ export default {
 		NcAppNavigationItem,
 		NcCounterBubble,
 		NcAvatar,
-		Connection,
+		ListBoxOutline,
 		PlaylistPlus,
 		DeleteOutline,
 		ActivityIcon,

--- a/src/modules/navigation/partials/NavigationViewItem.vue
+++ b/src/modules/navigation/partials/NavigationViewItem.vue
@@ -71,7 +71,7 @@
 				@click="actionShowIntegration">
 				{{ t('tables', 'Integration') }}
 				<template #icon>
-					<Connection :size="20" />
+					<ListBoxOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -81,7 +81,7 @@
 				@click="toggleFavoriteView(true)">
 				{{ t('tables', 'Add to favorites') }}
 				<template #icon>
-					<Star :size="20" />
+					<StarOutline :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -91,7 +91,7 @@
 				@click="toggleFavoriteView(false)">
 				{{ t('tables', 'Remove from favorites') }}
 				<template #icon>
-					<StarOutline :size="20" />
+					<Star :size="20" />
 				</template>
 			</NcActionButton>
 
@@ -119,7 +119,7 @@ import Star from 'vue-material-design-icons/Star.vue'
 import StarOutline from 'vue-material-design-icons/StarOutline.vue'
 import DeleteOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
 import PlaylistPlay from 'vue-material-design-icons/PlaylistPlay.vue'
 import { emit } from '@nextcloud/event-bus'
 import PlaylistEdit from 'vue-material-design-icons/PlaylistEdit.vue'
@@ -137,7 +137,7 @@ export default {
 		NcAppNavigationItem,
 		NcCounterBubble,
 		NcActionButton,
-		Connection,
+		ListBoxOutline,
 		NcAvatar,
 		PlaylistPlay,
 		Import,

--- a/src/modules/sidebar/partials/SharingEntryLink.vue
+++ b/src/modules/sidebar/partials/SharingEntryLink.vue
@@ -115,7 +115,7 @@ import {
 
 import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import LockIcon from 'vue-material-design-icons/Lock.vue'
+import LockIcon from 'vue-material-design-icons/LockOutline.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import SharePermissionSelect from './SharePermissionSelect.vue'
 

--- a/src/modules/sidebar/sections/Sidebar.vue
+++ b/src/modules/sidebar/sections/Sidebar.vue
@@ -36,7 +36,8 @@
 				:name="t('tables', 'Integration')">
 				<SidebarIntegration />
 				<template #icon>
-					<Connection :size="20" />
+					<ListBox v-if="activeSidebarTab === 'integration'" :size="20" />
+					<ListBoxOutline v-else :size="20" />
 				</template>
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="isActivityEnabled"
@@ -44,15 +45,19 @@
 				:order="1"
 				:name="t('tables', 'Activity')">
 				<template #icon>
-					<ActivityIcon :size="20" />
+					<ActivityIcon v-if="activeSidebarTab === 'activity'" :size="20" />
+					<LightningBoltOutline v-else :size="20" />
 				</template>
 				<SidebarActivity />
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="activeElement && canShareElement(activeElement)"
 				id="sharing"
-				icon="icon-share"
 				:order="0"
 				:name="t('tables', 'Sharing')">
+				<template #icon>
+					<NcIconSvgWrapper v-if="activeSidebarTab === 'sharing'" :svg="IconPersonAdd" />
+					<NcIconSvgWrapper v-else :svg="IconPersonAddOutline" />
+				</template>
 				<SidebarSharing />
 			</NcAppSidebarTab>
 		</NcAppSidebar>
@@ -64,10 +69,14 @@ import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import SidebarActivity from './SidebarActivity.vue'
 import SidebarSharing from './SidebarSharing.vue'
 import SidebarIntegration from './SidebarIntegration.vue'
-import { NcAppSidebar, NcAppSidebarTab, NcUserBubble } from '@nextcloud/vue'
+import { NcAppSidebar, NcAppSidebarTab, NcUserBubble, NcIconSvgWrapper } from '@nextcloud/vue'
 import { mapState } from 'pinia'
 import ActivityIcon from 'vue-material-design-icons/LightningBolt.vue'
-import Connection from 'vue-material-design-icons/Connection.vue'
+import LightningBoltOutline from 'vue-material-design-icons/LightningBoltOutline.vue'
+import ListBox from 'vue-material-design-icons/ListBox.vue'
+import ListBoxOutline from 'vue-material-design-icons/ListBoxOutline.vue'
+import IconPersonAdd from '@material-symbols/svg-400/outlined/person_add-fill.svg?raw'
+import IconPersonAddOutline from '@material-symbols/svg-400/outlined/person_add.svg?raw'
 import permissionsMixin from '../../../shared/components/ncTable/mixins/permissionsMixin.js'
 import activityMixin from '../../../shared/mixins/activityMixin.js'
 import Moment from '@nextcloud/moment'
@@ -75,6 +84,9 @@ import { useTablesStore } from '../../../store/store.js'
 
 export default {
 	name: 'Sidebar',
+	setup() {
+		return { IconPersonAdd, IconPersonAddOutline }
+	},
 	components: {
 		NcUserBubble,
 		SidebarActivity,
@@ -83,7 +95,10 @@ export default {
 		NcAppSidebar,
 		NcAppSidebarTab,
 		ActivityIcon,
-		Connection,
+		LightningBoltOutline,
+		ListBox,
+		ListBoxOutline,
+		NcIconSvgWrapper,
 	},
 
 	filters: {

--- a/src/shared/components/ncEditor/NcEditor.vue
+++ b/src/shared/components/ncEditor/NcEditor.vue
@@ -21,7 +21,7 @@
 
 <script>
 import { NcEmptyContent } from '@nextcloud/vue'
-import Alert from 'vue-material-design-icons/Alert.vue'
+import Alert from 'vue-material-design-icons/AlertOutline.vue'
 import { translate as t } from '@nextcloud/l10n'
 
 export default {


### PR DESCRIPTION
and tab icons should reflect a state (filled/outlined)

### 🖼️ Screenshots

🏚️ Before (current prod) | 🏡 After
---|---
<img width="311" height="704" alt="2026-05-19 14_10_44-Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/e6dd3b38-66da-406a-81bb-98f7b9c0b7c7" />|<img width="318" height="705" alt="2026-05-19 14_10_05-Welcome to Nextcloud Tables! - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/18c7a68c-7727-4f61-bfbd-6b72b565df56" />
<img width="575" height="124" alt="2026-05-19 14_11_01-Maintained applications - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/53272eca-7b29-4ef9-9f55-25c76953fc89" />|<img width="971" height="160" alt="2026-05-19 14_30_36-Welcome to Nextcloud Tables! - Tables - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/dc8e519f-d0b2-4b85-8bb7-46f77d93eb58" />
