### PR TITLE
fix: smartpicker fix row actions and action button z-index

### DIFF
--- a/src/shared/components/ncTable/sections/CustomTable.vue
+++ b/src/shared/components/ncTable/sections/CustomTable.vue
@@ -375,6 +375,7 @@ export default {
 		width: 55px;
 		background-color: inherit;
 		padding-inline-end: 16px;
+		z-index: 5;
 	}
 
 	tr>td.sticky:last-child {

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -250,8 +250,8 @@ export const useDataStore = defineStore('data', {
 			const stateId = genStateKey(isView, elementId)
 			if (stateId && this.rows[stateId]) {
 				const row = res.data
-				const index = this.rows[stateId].findIndex(r => r.id === row.id)
-				set(this.rows[stateId], index, row)
+				const updatedRows = this.rows[stateId].map(r => r.id === row.id ? row : r)
+				set(this.rows, stateId, updatedRows)
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
 			}
 
@@ -378,6 +378,13 @@ export const useDataStore = defineStore('data', {
 			if (rowInView === false) {
 				emit('tables:row:animate')
 				this.rows[stateId] = this.rows[stateId].filter(r => r.id !== rowId)
+			}
+		},
+
+		seedRows({ isView, elementId, rows }) {
+			const stateId = genStateKey(isView, elementId)
+			if (stateId) {
+				set(this.rows, stateId, rows)
 			}
 		},
 	},

--- a/src/views/ContentReferenceWidget.vue
+++ b/src/views/ContentReferenceWidget.vue
@@ -20,6 +20,8 @@
 			<NcTable
 				:rows="filteredRows"
 				:columns="richObject.columns"
+				:element-id="richObject.id"
+				:is-view="Boolean(richObject.type)"
 				v-bind="tablePermissions"
 				@edit-row="editRow"
 				@copy-row="copyRow"
@@ -222,6 +224,11 @@ export default {
 
 			if (this.richObject.rows) {
 				this.localRows = this.richObject.rows
+				this.dataStore.seedRows({
+					isView: Boolean(this.richObject.type),
+					elementId: this.richObject.id,
+					rows: this.richObject.rows,
+				})
 				return
 			}
 


### PR DESCRIPTION
Fixes pre-existing issues with Smart Picker embedded tables I found while testing PR #2456.
- Row inline edit changes now show in the UI without reload
- Delete now shows in the UI without reload
- Sticky action button is now always clickable, added `z-index: 5` for consistency with `.sticky:first-child`