### PR TITLE
Fix respect view column order in public sharing

### DIFF
--- a/src/store/data.js
+++ b/src/store/data.js
@@ -133,12 +133,12 @@ export const useDataStore = defineStore('data', {
 				return []
 			}
 			const columns = [...res.data.ocs.data]
-				.sort((a, b) => {
-					const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-					const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-				return orderA - orderB
-			})
-			.map(col => parseCol(col))
+        		.sort((a, b) => {
+            		const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+            		const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+            	return orderA - orderB
+				})
+				.map(col => parseCol(col))
 			set(this.columns, stateId, columns)
 			this.loading[stateId] = false
 			return columns

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -133,10 +133,10 @@ export const useDataStore = defineStore('data', {
 				return []
 			}
 			const columns = [...res.data.ocs.data]
-        		.sort((a, b) => {
-            		const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-            		const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-            	return orderA - orderB
+				.sort((a, b) => {
+					const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+					const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+					return orderA - orderB
 				})
 				.map(col => parseCol(col))
 			set(this.columns, stateId, columns)

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -132,12 +132,15 @@ export const useDataStore = defineStore('data', {
 				displayError(e, t('tables', 'Could not load columns.'))
 				return []
 			}
-
-			const columns = res.data.ocs.data.map(col => parseCol(col))
-				.sort((a, b) => a.id - b.id)
-			// Fix up columns to match expected structure if needed
-			// Public API might return slightly different structure, but parseCol should handle it if it's standard TableColumn
-
+			
+			const columns = [...res.data.ocs.data]
+        		.sort((a, b) => {
+            		const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+            		const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+            	return orderA - orderB
+       		})
+        	.map(col => parseCol(col))
+			
 			set(this.columns, stateId, columns)
 			this.loading[stateId] = false
 			return columns

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -132,15 +132,13 @@ export const useDataStore = defineStore('data', {
 				displayError(e, t('tables', 'Could not load columns.'))
 				return []
 			}
-			
 			const columns = [...res.data.ocs.data]
-        		.sort((a, b) => {
-            		const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-            		const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
-            	return orderA - orderB
-       		})
-        	.map(col => parseCol(col))
-			
+				.sort((a, b) => {
+					const orderA = a.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+					const orderB = b.viewColumnInformation?.order ?? Number.MAX_SAFE_INTEGER
+				return orderA - orderB
+			})
+			.map(col => parseCol(col))
 			set(this.columns, stateId, columns)
 			this.loading[stateId] = false
 			return columns


### PR DESCRIPTION
At the moment filtered views are not sorted as per the view column order if you share them pubicly 
with this PR they are sorted and respect the table order. this will fix #2595 

Screenshot of private view
<img width="1289" height="642" alt="image" src="https://github.com/user-attachments/assets/0f999617-93e9-465c-85fe-6b661fd9c5a2" />


in public sorted
<img width="1298" height="647" alt="image" src="https://github.com/user-attachments/assets/c7ae20f2-23c5-41f7-aba0-e6e763057bed" />

with an other order.
<img width="1291" height="647" alt="image" src="https://github.com/user-attachments/assets/32385acf-4a9f-4743-bbec-2b5d4c977946" />

