### PR TITLE
Fix: update wording for relation column label selection prompts

### DIFF
--- a/src/modules/modals/CreateColumn.vue
+++ b/src/modules/modals/CreateColumn.vue
@@ -310,7 +310,7 @@ export default {
 			} else if (this.column.type === ColumnTypes.Relation && !this.column.customSettings?.targetId) {
 				showInfo(t('tables', 'Please select a target.'))
 			} else if (this.column.type === ColumnTypes.Relation && !this.column.customSettings?.labelColumn) {
-				showInfo(t('tables', 'Please select a value selection label.'))
+				showInfo(t('tables', 'Please select a label for relation selection.'))
 			} else {
 				this.column.title = title
 				this.$emit('save', this.prepareSubmitData())

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
@@ -38,14 +38,14 @@
 
 		<div class="row space-T">
 			<div class="fix-col-4 title">
-				{{ t('tables', 'Value selection label') }}
+				{{ t('tables', 'Label for relation selection') }}
 			</div>
 			<div class="fix-col-4">
 				<NcSelect v-model="customSettings.labelColumn"
 					:options="availableLabelColumns"
 					:reduce="(option) => option.id"
 					:loading="loadingColumns"
-					:aria-label-combobox="t('tables', 'Select value selection label')"
+					:aria-label-combobox="t('tables', 'Select label for relation selection')"
 					required
 					:clearable="false"
 					@input="onLabelColumnChange" />


### PR DESCRIPTION
### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
