### PR TITLE
Fix Embed table full scroll 

### DIFF
--- a/src/views/ContentReferenceWidget.vue
+++ b/src/views/ContentReferenceWidget.vue
@@ -246,70 +246,70 @@ export default {
 </script>
 <style lang="scss" scoped>
 
-	.tables-content-widget {
-		min-height: max(50vh, 200px);
-		height: 50vh;
-		overflow: scroll;
+.tables-content-widget {
+    min-height: max(50vh, 200px);
+    height: 50vh;
+    overflow: auto;
 
-		& .header {
-			position: sticky;
-			top: 0;
-			inset-inline-start: 0;
-			z-index: 1;
+    & .header {
+        position: static;
+        top: auto;
+        inset-inline-start: auto;
+        z-index: auto;
 
-			:where(.options) {
-				position: sticky;
-				top: 57px;
-				z-index: 1;
-				padding-bottom: 10px;
-				background-color: var(--color-main-background);
-			}
+        :where(.options) {
+            position: static;
+            top: auto;
+            z-index: auto;
+            padding-bottom: 10px;
+            background-color: var(--color-main-background);
+        }
 
-			h2 {
-				position: sticky;
-				top: 0;
-				min-width: var(--widget-content-width);
-				z-index: 1;
-				background-color: var(--color-main-background);
-				margin: 0 !important;
-				padding: calc(var(--default-grid-baseline) * 4);
+        h2 {
+            position: static;
+            top: auto;
+            min-width: var(--widget-content-width);
+            z-index: auto;
+            background-color: var(--color-main-background);
+            margin: 0 !important;
+            padding: calc(var(--default-grid-baseline) * 4);
 
-				& .loading-icon {
-					display: inline-block;
-					vertical-align: middle;
-				}
-			}
-		}
+            & .loading-icon {
+                display: inline-block;
+                vertical-align: middle;
+            }
+        }
+    }
 
-		.nc-table {
-			min-width: var(--widget-content-width);
+    .nc-table {
+        min-width: var(--widget-content-width);
 
-			:where(.options.row) {
-				display: none;
-			}
+        :where(.options.row) {
+            display: none;
+        }
 
-			:where(thead) {
-				position: sticky;
-				top: 117px;
+        :where(thead) {
+            position: static;
+            top: auto;
 
-				:where(.cell-wrapper) {
-					min-width: 150px;
-					max-width: 200px;
-				}
+            :where(.cell-wrapper) {
+                min-width: 150px;
+                max-width: 200px;
+            }
 
-				:where(.sticky) {
-					background: transparent !important;
-				}
-			}
-		}
+            :where(.sticky) {
+                background: transparent !important;
+            }
+        }
+    }
 
-		& :deep(.options.row) {
-			width: calc(var(--widget-content-width, 100%) - 12px);
-		}
+    & :deep(.options.row) {
+        width: calc(var(--widget-content-width, 100%) - 12px);
+    }
 
-		& :deep(td) {
-			vertical-align: middle !important;
-		}
-	}
+    & :deep(td) {
+        vertical-align: middle !important;
+    }
+}
 
 </style>


### PR DESCRIPTION
* Fix remove sticky and scroll everything 

Widget is too small to let headers stick so let headers scroll, this as well solves issue with overlay on the headers by simplifying the logic. The only issue is the three dots on the right but they are accessible if the user goes back to the top of the table


* Fix issue https://github.com/nextcloud/tables/issues/2596



---------



### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="663" height="197" alt="image" src="https://github.com/user-attachments/assets/119117d4-0283-4310-9e55-b8fb678bb6d4" /> | <img width="866" height="529" alt="image" src="https://github.com/user-attachments/assets/6f41042f-92e8-4e28-acc6-33ecc6cdb687" />



### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [X] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [X] The content of this PR was partly or fully generated using AI
