### PR TITLE
chore: add useBaseBranchConfig option to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "rebaseWhen": "conflicted",
   "ignoreUnstable": false,
   "baseBranches": ["main", "stable1.0"],
+  "useBaseBranchConfig": "merge",
   "enabledManagers": ["npm", "composer", "github-actions"],
   "ignoreDeps": ["node", "npm"],
   "packageRules": [


### PR DESCRIPTION
So that the stable branches renovate config are respected when making automatic PRs