### PR TITLE
feat: enhance relation permissions and accessibility checks

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,10 @@ class Application extends App implements IBootstrap {
 	public const NODE_TYPE_TABLE = 0;
 	public const NODE_TYPE_VIEW = 1;
 
+	public const NODE_TYPE_NAME_TABLE = 'table';
+	public const NODE_TYPE_NAME_VIEW = 'view';
+	public const NODE_TYPE_NAME_CONTEXT = 'context';
+
 	public const OWNER_TYPE_USER = 0;
 
 	public const NAV_ENTRY_MODE_HIDDEN = 0;

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -65,6 +65,10 @@ class Application extends App implements IBootstrap {
 	public const NODE_TYPE_TABLE = 0;
 	public const NODE_TYPE_VIEW = 1;
 
+	public const NODE_TYPE_NAME_TABLE = 'table';
+	public const NODE_TYPE_NAME_VIEW = 'view';
+	public const NODE_TYPE_NAME_CONTEXT = 'context';
+
 	public const OWNER_TYPE_USER = 0;
 
 	public const NAV_ENTRY_MODE_HIDDEN = 0;

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -9,6 +9,7 @@ namespace OCA\Tables\Service;
 
 use DateTime;
 use Exception;
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Constants\ColumnType;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
@@ -304,6 +305,9 @@ class ColumnService extends SuperService {
 		}
 
 		$this->validateCustomSettings($columnDto->getCustomSettings());
+		if ($columnDto->getType() === Column::TYPE_RELATION) {
+			$this->validateRelationTargetAccess($columnDto->getCustomSettings(), $userId);
+		}
 
 		$item = Column::fromDto($columnDto);
 		$item->setTitle($newTitle);
@@ -408,6 +412,9 @@ class ColumnService extends SuperService {
 			$item->setUsergroupSelectTeams($columnDto->getUsergroupSelectTeams());
 			$item->setShowUserStatus($columnDto->getShowUserStatus());
 			$this->validateCustomSettings($columnDto->getCustomSettings());
+			if ($columnDto->getType() === Column::TYPE_RELATION || $item->getType() === Column::TYPE_RELATION) {
+				$this->validateRelationTargetAccess($columnDto->getCustomSettings(), $userId);
+			}
 			$item->setCustomSettings($columnDto->getCustomSettings());
 
 			$this->updateMetadata($item, $userId);
@@ -447,6 +454,41 @@ class ColumnService extends SuperService {
 					$translatedMessage
 				);
 			}
+		}
+	}
+
+	/**
+	 * Ensure the user configuring a relation column can actually read the target
+	 *
+	 * @param string|null $customSettings
+	 * @throws BadRequestError
+	 */
+	private function validateRelationTargetAccess(?string $customSettings, ?string $userId): void {
+		if ($customSettings === null) {
+			return;
+		}
+		$settings = json_decode($customSettings, true);
+		if (!is_array($settings)) {
+			return;
+		}
+
+		$relationType = $settings[Column::RELATION_TYPE] ?? null;
+		$targetId = isset($settings[Column::RELATION_TARGET_ID]) ? (int)$settings[Column::RELATION_TARGET_ID] : null;
+		if (empty($relationType) || empty($targetId)) {
+			return;
+		}
+
+		if ($relationType === Application::NODE_TYPE_NAME_VIEW) {
+			$canRead = $this->permissionsService->canReadColumnsByViewId($targetId, $userId);
+		} elseif ($relationType === Application::NODE_TYPE_NAME_TABLE) {
+			$canRead = $this->permissionsService->canReadColumnsByTableId($targetId, $userId);
+		} else {
+			$canRead = false;
+		}
+
+		if (!$canRead) {
+			$translatedMessage = $this->l->t('You can only link to a table or view that you have access to.');
+			throw new BadRequestError($translatedMessage, 0, null, $translatedMessage);
 		}
 	}
 

--- a/lib/Service/ColumnService.php
+++ b/lib/Service/ColumnService.php
@@ -10,6 +10,7 @@ namespace OCA\Tables\Service;
 use DateTime;
 use Exception;
 use OCA\Tables\Activity\ActivityManager;
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Constants\ColumnType;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
@@ -290,6 +291,9 @@ class ColumnService extends SuperService {
 		}
 
 		$this->validateCustomSettings($columnDto->getCustomSettings());
+		if ($columnDto->getType() === Column::TYPE_RELATION) {
+			$this->validateRelationTargetAccess($columnDto->getCustomSettings(), $userId);
+		}
 
 		$item = Column::fromDto($columnDto);
 		$item->setTitle($newTitle);
@@ -423,6 +427,9 @@ class ColumnService extends SuperService {
 			$item->setUsergroupSelectTeams($columnDto->getUsergroupSelectTeams());
 			$item->setShowUserStatus($columnDto->getShowUserStatus());
 			$this->validateCustomSettings($columnDto->getCustomSettings());
+			if ($columnDto->getType() === Column::TYPE_RELATION || $item->getType() === Column::TYPE_RELATION) {
+				$this->validateRelationTargetAccess($columnDto->getCustomSettings(), $userId);
+			}
 			$item->setCustomSettings($columnDto->getCustomSettings());
 
 			$this->updateMetadata($item, $userId);
@@ -481,6 +488,41 @@ class ColumnService extends SuperService {
 					$translatedMessage
 				);
 			}
+		}
+	}
+
+	/**
+	 * Ensure the user configuring a relation column can actually read the target
+	 *
+	 * @param string|null $customSettings
+	 * @throws BadRequestError
+	 */
+	private function validateRelationTargetAccess(?string $customSettings, ?string $userId): void {
+		if ($customSettings === null) {
+			return;
+		}
+		$settings = json_decode($customSettings, true);
+		if (!is_array($settings)) {
+			return;
+		}
+
+		$relationType = $settings[Column::RELATION_TYPE] ?? null;
+		$targetId = isset($settings[Column::RELATION_TARGET_ID]) ? (int)$settings[Column::RELATION_TARGET_ID] : null;
+		if (empty($relationType) || empty($targetId)) {
+			return;
+		}
+
+		if ($relationType === Application::NODE_TYPE_NAME_VIEW) {
+			$canRead = $this->permissionsService->canReadColumnsByViewId($targetId, $userId);
+		} elseif ($relationType === Application::NODE_TYPE_NAME_TABLE) {
+			$canRead = $this->permissionsService->canReadColumnsByTableId($targetId, $userId);
+		} else {
+			$canRead = false;
+		}
+
+		if (!$canRead) {
+			$translatedMessage = $this->l->t('You can only link to a table or view that you have access to.');
+			throw new BadRequestError($translatedMessage, 0, null, $translatedMessage);
 		}
 	}
 

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -7,9 +7,11 @@
 
 namespace OCA\Tables\Service;
 
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
 use OCA\Tables\Db\Row2Mapper;
+use OCA\Tables\Db\TableMapper;
 use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
@@ -20,11 +22,17 @@ class RelationService {
 	/** @var array<string, array> Cache for relation data */
 	private array $cacheRelationData = [];
 
+	/** @var array<string, bool> Cache for manager accessibility decisions, keyed by host table + target */
+	private array $cacheManagerAccess = [];
+
 	public function __construct(
 		private ColumnMapper $columnMapper,
 		private ViewMapper $viewMapper,
+		private TableMapper $tableMapper,
 		private Row2Mapper $row2Mapper,
 		private ColumnService $columnService,
+		private PermissionsService $permissionsService,
+		private ShareService $shareService,
 		private ?string $userId,
 	) {
 	}
@@ -83,9 +91,10 @@ class RelationService {
 		foreach ($groupedColumns as $target => $columns) {
 			$relationData = $this->getRelationDataForTarget($target, $columns[0]);
 
-			// Assign the same data to all columns with this target
+			// Assign the same data to all columns with this target, but only when
+			// the relation is still backed by a manager of the hosting table.
 			foreach ($columns as $column) {
-				$result[$column->getId()] = $relationData;
+				$result[$column->getId()] = $this->isTargetAccessibleByManager($column) ? $relationData : [];
 			}
 		}
 
@@ -133,9 +142,70 @@ class RelationService {
 			return [];
 		}
 
+		if (!$this->isTargetAccessibleByManager($column)) {
+			return [];
+		}
+
 		$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
 
 		return $this->getRelationDataForTarget($target, $column);
+	}
+
+	public function isTargetAccessibleByManager(Column $relationColumn): bool {
+		$settings = $relationColumn->getCustomSettingsArray();
+		$relationType = $settings[Column::RELATION_TYPE] ?? null;
+		$targetId = isset($settings[Column::RELATION_TARGET_ID]) ? (int)$settings[Column::RELATION_TARGET_ID] : null;
+		if (empty($relationType) || empty($targetId)) {
+			return false;
+		}
+
+		$hostTableId = $relationColumn->getTableId();
+		$cacheKey = sprintf('%s_%s_%s', $hostTableId, $relationType, $targetId);
+		if (isset($this->cacheManagerAccess[$cacheKey])) {
+			return $this->cacheManagerAccess[$cacheKey];
+		}
+
+		$candidateUserIds = [];
+		try {
+			$hostTable = $this->tableMapper->find($hostTableId);
+			if ($hostTable->getOwnership() !== null && $hostTable->getOwnership() !== '') {
+				$candidateUserIds[] = $hostTable->getOwnership();
+			}
+		} catch (DoesNotExistException|\OCP\AppFramework\Db\MultipleObjectsReturnedException|\OCP\DB\Exception $e) {
+			// host table gone, so nothing to expose
+			$this->cacheManagerAccess[$cacheKey] = false;
+			return false;
+		}
+
+		try {
+			$candidateUserIds = array_unique(array_merge(
+				$candidateUserIds,
+				$this->shareService->findManagerUserIds($hostTableId, Application::NODE_TYPE_NAME_TABLE),
+			));
+		} catch (InternalError $e) {
+			// fall back to the owner only
+		}
+
+		$accessible = false;
+		foreach ($candidateUserIds as $candidateUserId) {
+			if ($candidateUserId === null || $candidateUserId === '') {
+				continue;
+			}
+			if ($relationType === Application::NODE_TYPE_NAME_VIEW) {
+				$canRead = $this->permissionsService->canReadColumnsByViewId($targetId, $candidateUserId);
+			} elseif ($relationType === Application::NODE_TYPE_NAME_TABLE) {
+				$canRead = $this->permissionsService->canReadColumnsByTableId($targetId, $candidateUserId);
+			} else {
+				$canRead = false;
+			}
+			if ($canRead) {
+				$accessible = true;
+				break;
+			}
+		}
+
+		$this->cacheManagerAccess[$cacheKey] = $accessible;
+		return $accessible;
 	}
 
 	/**
@@ -159,7 +229,7 @@ class RelationService {
 			return [];
 		}
 
-		$isView = $settings[Column::RELATION_TYPE] === 'view';
+		$isView = $settings[Column::RELATION_TYPE] === Application::NODE_TYPE_NAME_VIEW;
 		$targetId = $settings[Column::RELATION_TARGET_ID] ?? null;
 
 		try {

--- a/lib/Service/RelationService.php
+++ b/lib/Service/RelationService.php
@@ -7,9 +7,11 @@
 
 namespace OCA\Tables\Service;
 
+use OCA\Tables\AppInfo\Application;
 use OCA\Tables\Db\Column;
 use OCA\Tables\Db\ColumnMapper;
 use OCA\Tables\Db\Row2Mapper;
+use OCA\Tables\Db\TableMapper;
 use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Errors\InternalError;
 use OCA\Tables\Errors\NotFoundError;
@@ -20,11 +22,17 @@ class RelationService {
 	/** @var array<string, array> Cache for relation data */
 	private array $cacheRelationData = [];
 
+	/** @var array<string, bool> Cache for manager accessibility decisions, keyed by host table + target */
+	private array $cacheManagerAccess = [];
+
 	public function __construct(
 		private readonly ColumnMapper $columnMapper,
 		private readonly ViewMapper $viewMapper,
+		private readonly TableMapper $tableMapper,
 		private readonly Row2Mapper $row2Mapper,
 		private readonly ColumnService $columnService,
+		private readonly PermissionsService $permissionsService,
+		private readonly ShareService $shareService,
 		private readonly ?string $userId,
 	) {
 	}
@@ -79,9 +87,10 @@ class RelationService {
 		foreach ($groupedColumns as $target => $columns) {
 			$relationData = $this->getRelationDataForTarget($target, $columns[0]);
 
-			// Assign the same data to all columns with this target
+			// Assign the same data to all columns with this target, but only when
+			// the relation is still backed by a manager of the hosting table.
 			foreach ($columns as $column) {
-				$result[$column->getId()] = $relationData;
+				$result[$column->getId()] = $this->isTargetAccessibleByManager($column) ? $relationData : [];
 			}
 		}
 
@@ -129,9 +138,70 @@ class RelationService {
 			return [];
 		}
 
+		if (!$this->isTargetAccessibleByManager($column)) {
+			return [];
+		}
+
 		$target = sprintf('%s_%s_%s', $settings['relationType'], $settings['targetId'], $settings['labelColumn']);
 
 		return $this->getRelationDataForTarget($target, $column);
+	}
+
+	public function isTargetAccessibleByManager(Column $relationColumn): bool {
+		$settings = $relationColumn->getCustomSettingsArray();
+		$relationType = $settings[Column::RELATION_TYPE] ?? null;
+		$targetId = isset($settings[Column::RELATION_TARGET_ID]) ? (int)$settings[Column::RELATION_TARGET_ID] : null;
+		if (empty($relationType) || empty($targetId)) {
+			return false;
+		}
+
+		$hostTableId = $relationColumn->getTableId();
+		$cacheKey = sprintf('%s_%s_%s', $hostTableId, $relationType, $targetId);
+		if (isset($this->cacheManagerAccess[$cacheKey])) {
+			return $this->cacheManagerAccess[$cacheKey];
+		}
+
+		$candidateUserIds = [];
+		try {
+			$hostTable = $this->tableMapper->find($hostTableId);
+			if ($hostTable->getOwnership() !== null && $hostTable->getOwnership() !== '') {
+				$candidateUserIds[] = $hostTable->getOwnership();
+			}
+		} catch (DoesNotExistException|\OCP\AppFramework\Db\MultipleObjectsReturnedException|\OCP\DB\Exception $e) {
+			// host table gone, so nothing to expose
+			$this->cacheManagerAccess[$cacheKey] = false;
+			return false;
+		}
+
+		try {
+			$candidateUserIds = array_unique(array_merge(
+				$candidateUserIds,
+				$this->shareService->findManagerUserIds($hostTableId, Application::NODE_TYPE_NAME_TABLE),
+			));
+		} catch (InternalError $e) {
+			// fall back to the owner only
+		}
+
+		$accessible = false;
+		foreach ($candidateUserIds as $candidateUserId) {
+			if ($candidateUserId === null || $candidateUserId === '') {
+				continue;
+			}
+			if ($relationType === Application::NODE_TYPE_NAME_VIEW) {
+				$canRead = $this->permissionsService->canReadColumnsByViewId($targetId, $candidateUserId);
+			} elseif ($relationType === Application::NODE_TYPE_NAME_TABLE) {
+				$canRead = $this->permissionsService->canReadColumnsByTableId($targetId, $candidateUserId);
+			} else {
+				$canRead = false;
+			}
+			if ($canRead) {
+				$accessible = true;
+				break;
+			}
+		}
+
+		$this->cacheManagerAccess[$cacheKey] = $accessible;
+		return $accessible;
 	}
 
 	/**
@@ -155,7 +225,7 @@ class RelationService {
 			return [];
 		}
 
-		$isView = $settings[Column::RELATION_TYPE] === 'view';
+		$isView = $settings[Column::RELATION_TYPE] === Application::NODE_TYPE_NAME_VIEW;
 		$targetId = $settings[Column::RELATION_TARGET_ID] ?? null;
 
 		try {

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -794,27 +794,55 @@ class ShareService extends SuperService {
 	public function findSharedWithUserIds(int $elementId, string $elementType): array {
 		try {
 			$shares = $this->mapper->findAllSharesForNode($elementType, $elementId, '');
-			$sharedWithUserIds = [];
-
-			foreach ($shares as $share) {
-				if ($share->getReceiverType() === ShareReceiverType::USER) {
-					$sharedWithUserIds[$share->getReceiver()] = 1;
-				}
-				if ($share->getReceiverType() === ShareReceiverType::CIRCLE && $this->circleHelper->isCirclesEnabled()) {
-					$userIds = $this->circleHelper->getUserIdsInCircle($share->getReceiver());
-					$sharedWithUserIds += array_fill_keys($userIds, 1);
-				}
-				if ($share->getReceiverType() === ShareReceiverType::GROUP) {
-					$userIds = $this->groupHelper->getUserIdsInGroup($share->getReceiver());
-					$sharedWithUserIds += array_fill_keys($userIds, 1);
-				}
-			}
-
-			return array_keys($sharedWithUserIds);
+			return $this->resolveShareReceiversToUserIds($shares);
 		} catch (Exception $e) {
 			$this->logger->error('Could not find shared with users: ' . $e->getMessage(), ['exception' => $e]);
 			throw new InternalError('Could not find shared with users');
 		}
+	}
+
+	/**
+	 * Returns the IDs of all users that hold the manage permission on the given node
+	 *
+	 * @param int $elementId
+	 * @param string $elementType
+	 * @return string[]
+	 * @throws InternalError
+	 */
+	public function findManagerUserIds(int $elementId, string $elementType): array {
+		try {
+			$shares = $this->mapper->findAllSharesForNode($elementType, $elementId, '');
+			return $this->resolveShareReceiversToUserIds($shares, true);
+		} catch (Exception $e) {
+			$this->logger->error('Could not find managing users: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Could not find managing users');
+		}
+	}
+
+	/**
+	 * Resolves a list of shares into the set of user IDs they grant access to
+	 *
+	 * @param Share[] $shares
+	 * @param bool $requireManage when true, only shares carrying the manage permission are considered
+	 * @return string[]
+	 */
+	private function resolveShareReceiversToUserIds(array $shares, bool $requireManage = false): array {
+		$userIds = [];
+
+		foreach ($shares as $share) {
+			if ($requireManage && !$share->getPermissionManage()) {
+				continue;
+			}
+			if ($share->getReceiverType() === ShareReceiverType::USER) {
+				$userIds[$share->getReceiver()] = 1;
+			} elseif ($share->getReceiverType() === ShareReceiverType::CIRCLE && $this->circleHelper->isCirclesEnabled()) {
+				$userIds += array_fill_keys($this->circleHelper->getUserIdsInCircle($share->getReceiver()), 1);
+			} elseif ($share->getReceiverType() === ShareReceiverType::GROUP) {
+				$userIds += array_fill_keys($this->groupHelper->getUserIdsInGroup($share->getReceiver()), 1);
+			}
+		}
+
+		return array_keys($userIds);
 	}
 
 	/**

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -917,23 +917,7 @@ class ShareService extends SuperService {
 	public function findSharedWithUserIds(int $elementId, string $elementType): array {
 		try {
 			$shares = $this->mapper->findAllSharesForNode($elementType, $elementId, '');
-			$sharedWithUserIds = [];
-
-			foreach ($shares as $share) {
-				if ($share->getReceiverType() === ShareReceiverType::USER) {
-					$sharedWithUserIds[$share->getReceiver()] = 1;
-				}
-				if ($share->getReceiverType() === ShareReceiverType::CIRCLE && $this->circleHelper->isCirclesEnabled()) {
-					$userIds = $this->circleHelper->getUserIdsInCircle($share->getReceiver());
-					$sharedWithUserIds += array_fill_keys($userIds, 1);
-				}
-				if ($share->getReceiverType() === ShareReceiverType::GROUP) {
-					$userIds = $this->groupHelper->getUserIdsInGroup($share->getReceiver());
-					$sharedWithUserIds += array_fill_keys($userIds, 1);
-				}
-			}
-
-			return array_keys($sharedWithUserIds);
+			return $this->resolveShareReceiversToUserIds($shares);
 		} catch (Exception $e) {
 			$this->logger->error('Could not find shared with users: ' . $e->getMessage(), ['exception' => $e]);
 			throw new InternalError('Could not find shared with users');
@@ -971,6 +955,50 @@ class ShareService extends SuperService {
 		}
 
 		return [];
+	}
+
+	/**
+	 * Returns the IDs of all users that hold the manage permission on the given node
+	 *
+	 * @param int $elementId
+	 * @param string $elementType
+	 * @return string[]
+	 * @throws InternalError
+	 */
+	public function findManagerUserIds(int $elementId, string $elementType): array {
+		try {
+			$shares = $this->mapper->findAllSharesForNode($elementType, $elementId, '');
+			return $this->resolveShareReceiversToUserIds($shares, true);
+		} catch (Exception $e) {
+			$this->logger->error('Could not find managing users: ' . $e->getMessage(), ['exception' => $e]);
+			throw new InternalError('Could not find managing users');
+		}
+	}
+
+	/**
+	 * Resolves a list of shares into the set of user IDs they grant access to
+	 *
+	 * @param Share[] $shares
+	 * @param bool $requireManage when true, only shares carrying the manage permission are considered
+	 * @return string[]
+	 */
+	private function resolveShareReceiversToUserIds(array $shares, bool $requireManage = false): array {
+		$userIds = [];
+
+		foreach ($shares as $share) {
+			if ($requireManage && !$share->getPermissionManage()) {
+				continue;
+			}
+			if ($share->getReceiverType() === ShareReceiverType::USER) {
+				$userIds[$share->getReceiver()] = 1;
+			} elseif ($share->getReceiverType() === ShareReceiverType::CIRCLE && $this->circleHelper->isCirclesEnabled()) {
+				$userIds += array_fill_keys($this->circleHelper->getUserIdsInCircle($share->getReceiver()), 1);
+			} elseif ($share->getReceiverType() === ShareReceiverType::GROUP) {
+				$userIds += array_fill_keys($this->groupHelper->getUserIdsInGroup($share->getReceiver()), 1);
+			}
+		}
+
+		return array_keys($userIds);
 	}
 
 	/**

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
@@ -55,17 +55,22 @@
 			<IconInformation :size="16" class="info-icon" />
 			<span>{{ t('tables', 'Only text and number columns can be used as label') }}</span>
 		</div>
+
+		<NcNoteCard v-if="targetInaccessible"
+			type="warning"
+			:text="t('tables', 'The linked table or view is no longer accessible to you, so this relation is disabled. Ask its owner to share it with you, or pick a different target.')" />
 	</div>
 </template>
 
 <script>
-import { NcSelect } from '@nextcloud/vue'
+import { NcSelect, NcNoteCard } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
 import { mapState } from 'pinia'
 import { useTablesStore } from '../../../../../../store/store.js'
 import { useDataStore } from '../../../../../../store/data.js'
 import NumberColumn from '../../../mixins/columnsTypes/number.js'
 import TextLineColumn from '../../../mixins/columnsTypes/textLine.js'
+import permissionsMixin from '../../../mixins/permissionsMixin.js'
 import IconInformation from 'vue-material-design-icons/InformationOutline.vue'
 
 export default {
@@ -73,7 +78,9 @@ export default {
 	components: {
 		IconInformation,
 		NcSelect,
+		NcNoteCard,
 	},
+	mixins: [permissionsMixin],
 	props: {
 		column: {
 			type: Object,
@@ -88,6 +95,7 @@ export default {
 				relationType: this.column.customSettings.relationType ?? 'table',
 			},
 			loadingColumns: false,
+			targetInaccessible: false,
 			relationTypeOptions: [
 				{ id: 'table', label: t('tables', 'Table') },
 				{ id: 'view', label: t('tables', 'View') },
@@ -96,20 +104,29 @@ export default {
 		}
 	},
 	computed: {
-		...mapState(useTablesStore, ['tables', 'views']),
+		...mapState(useTablesStore, ['tables', 'views', 'activeTable', 'activeView']),
+		hostTableId() {
+			return this.activeView ? this.activeView.tableId : (this.activeTable?.id ?? null)
+		},
 		availableTargets() {
 			if (this.customSettings.relationType === 'table') {
-				return this.tables.map(table => ({
-					id: table.id,
-					label: `${table.emoji} ${table.title}`,
-				}))
+				return this.tables
+					// exclude the host table (no self-reference) and anything the
+					// user cannot read
+					.filter(table => table.id !== this.hostTableId && this.canReadData(table))
+					.map(table => ({
+						id: table.id,
+						label: `${table.emoji} ${table.title}`,
+					}))
 			}
 
 			if (this.customSettings.relationType === 'view') {
-				return this.views.map(view => ({
-					id: view.id,
-					label: `${view.emoji} ${view.title}`,
-				}))
+				return this.views
+					.filter(view => view.tableId !== this.hostTableId && this.canReadData(view))
+					.map(view => ({
+						id: view.id,
+						label: `${view.emoji} ${view.title}`,
+					}))
 			}
 
 			return []
@@ -129,17 +146,23 @@ export default {
 			}
 
 			this.loadingColumns = true
+			this.targetInaccessible = false
 			try {
 				const dataStore = useDataStore()
 				const columns = await dataStore.getColumnsFromBE({
 					tableId: this.customSettings.relationType === 'table' ? this.customSettings.targetId : null,
 					viewId: this.customSettings.relationType === 'view' ? this.customSettings.targetId : null,
+					showError: false,
 				})
 				this.availableLabelColumns = columns
 					.filter(column =>
 						column instanceof NumberColumn || column instanceof TextLineColumn,
 					)
 					.map(column => ({ id: column.id, label: column.title }))
+			} catch (e) {
+				// The target is no longer readable (e.g. it was unshared)
+				this.availableLabelColumns = []
+				this.targetInaccessible = true
 			} finally {
 				this.loadingColumns = false
 			}

--- a/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
+++ b/src/shared/components/ncTable/partials/columnTypePartials/forms/RelationForm.vue
@@ -55,17 +55,22 @@
 			<IconInformation :size="16" class="info-icon" />
 			<span>{{ t('tables', 'Only text and number columns can be used as label') }}</span>
 		</div>
+
+		<NcNoteCard v-if="targetInaccessible"
+			type="warning"
+			:text="t('tables', 'The linked table or view is no longer accessible to you, so this relation is disabled. Ask its owner to share it with you, or pick a different target.')" />
 	</div>
 </template>
 
 <script>
-import { NcSelect } from '@nextcloud/vue'
+import { NcSelect, NcNoteCard } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
 import { mapState } from 'pinia'
 import { useTablesStore } from '../../../../../../store/store.js'
 import { useDataStore } from '../../../../../../store/data.js'
 import NumberColumn from '../../../mixins/columnsTypes/number.js'
 import TextLineColumn from '../../../mixins/columnsTypes/textLine.js'
+import permissionsMixin from '../../../mixins/permissionsMixin.js'
 import IconInformation from 'vue-material-design-icons/InformationOutline.vue'
 
 export default {
@@ -73,7 +78,9 @@ export default {
 	components: {
 		IconInformation,
 		NcSelect,
+		NcNoteCard,
 	},
+	mixins: [permissionsMixin],
 	props: {
 		column: {
 			type: Object,
@@ -91,6 +98,7 @@ export default {
 				relationType: this.column.customSettings.relationType ?? 'table',
 			},
 			loadingColumns: false,
+			targetInaccessible: false,
 			relationTypeOptions: [
 				{ id: 'table', label: t('tables', 'Table') },
 				{ id: 'view', label: t('tables', 'View') },
@@ -99,20 +107,29 @@ export default {
 		}
 	},
 	computed: {
-		...mapState(useTablesStore, ['tables', 'views']),
+		...mapState(useTablesStore, ['tables', 'views', 'activeTable', 'activeView']),
+		hostTableId() {
+			return this.activeView ? this.activeView.tableId : (this.activeTable?.id ?? null)
+		},
 		availableTargets() {
 			if (this.customSettings.relationType === 'table') {
-				return this.tables.map(table => ({
-					id: table.id,
-					label: `${table.emoji} ${table.title}`,
-				}))
+				return this.tables
+					// exclude the host table (no self-reference) and anything the
+					// user cannot read
+					.filter(table => table.id !== this.hostTableId && this.canReadData(table))
+					.map(table => ({
+						id: table.id,
+						label: `${table.emoji} ${table.title}`,
+					}))
 			}
 
 			if (this.customSettings.relationType === 'view') {
-				return this.views.map(view => ({
-					id: view.id,
-					label: `${view.emoji} ${view.title}`,
-				}))
+				return this.views
+					.filter(view => view.tableId !== this.hostTableId && this.canReadData(view))
+					.map(view => ({
+						id: view.id,
+						label: `${view.emoji} ${view.title}`,
+					}))
 			}
 
 			return []
@@ -132,17 +149,23 @@ export default {
 			}
 
 			this.loadingColumns = true
+			this.targetInaccessible = false
 			try {
 				const dataStore = useDataStore()
 				const columns = await dataStore.getColumnsFromBE({
 					tableId: this.customSettings.relationType === 'table' ? this.customSettings.targetId : null,
 					viewId: this.customSettings.relationType === 'view' ? this.customSettings.targetId : null,
+					showError: false,
 				})
 				this.availableLabelColumns = columns
 					.filter(column =>
 						column instanceof NumberColumn || column instanceof TextLineColumn,
 					)
 					.map(column => ({ id: column.id, label: column.title }))
+			} catch (e) {
+				// The target is no longer readable (e.g. it was unshared)
+				this.availableLabelColumns = []
+				this.targetInaccessible = true
 			} finally {
 				this.loadingColumns = false
 			}

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -63,7 +63,7 @@ export const useDataStore = defineStore('data', {
 		},
 
 		// COLUMNS
-		async getColumnsFromBE({ tableId, viewId }) {
+		async getColumnsFromBE({ tableId, viewId, showError = true }) {
 			const stateId = genStateKey(!!(viewId), viewId ?? tableId)
 			this.loading[stateId] = true
 			let res = null
@@ -80,10 +80,17 @@ export const useDataStore = defineStore('data', {
 				}
 				if (!Array.isArray(res.data)) {
 					const e = new Error('Expected array, but is not')
+					if (!showError) {
+						throw e
+					}
 					displayError(e, 'Format for loaded columns not valid.')
 					return []
 				}
 			} catch (e) {
+				if (!showError) {
+					this.loading[stateId] = false
+					throw e
+				}
 				displayError(e, t('tables', 'Could not load columns.'))
 				return []
 			}
@@ -159,6 +166,17 @@ export const useDataStore = defineStore('data', {
 				this.columns[stateId].push(parseCol(res.data))
 				this.loading[stateId] = false
 			}
+
+			// A freshly added relation column has no entry in the already-loaded
+			// relations cache, so force a reload to populate its dropdown options
+			// without requiring a page refresh.
+			if (res.data?.type === 'relation') {
+				await this.loadRelationsFromBE({
+					tableId: isView ? undefined : elementId,
+					viewId: isView ? elementId : undefined,
+					force: true,
+				})
+			}
 			return true
 		},
 
@@ -179,6 +197,16 @@ export const useDataStore = defineStore('data', {
 				const col = res.data
 				const index = this.columns[stateId].findIndex(c => c.id === col.id)
 				set(this.columns[stateId], index, parseCol(col))
+			}
+
+			// The relation's target or label column may have changed, which makes
+			// the cached relation data stale, so we reload it.
+			if (res.data?.type === 'relation') {
+				await this.loadRelationsFromBE({
+					tableId: isView ? undefined : elementId,
+					viewId: isView ? elementId : undefined,
+					force: true,
+				})
 			}
 
 			return true

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -74,7 +74,7 @@ export const useDataStore = defineStore('data', {
 		},
 
 		// COLUMNS
-		async getColumnsFromBE({ tableId, viewId }) {
+		async getColumnsFromBE({ tableId, viewId, showError = true }) {
 			const stateId = genStateKey(!!(viewId), viewId ?? tableId)
 			this.loading[stateId] = true
 			let res = null
@@ -91,10 +91,17 @@ export const useDataStore = defineStore('data', {
 				}
 				if (!Array.isArray(res.data)) {
 					const e = new Error('Expected array, but is not')
+					if (!showError) {
+						throw e
+					}
 					displayError(e, 'Format for loaded columns not valid.')
 					return []
 				}
 			} catch (e) {
+				if (!showError) {
+					this.loading[stateId] = false
+					throw e
+				}
 				displayError(e, t('tables', 'Could not load columns.'))
 				return []
 			}
@@ -171,6 +178,17 @@ export const useDataStore = defineStore('data', {
 				this.columns[stateId].push(parseCol(res.data))
 				this.loading[stateId] = false
 			}
+
+			// A freshly added relation column has no entry in the already-loaded
+			// relations cache, so force a reload to populate its dropdown options
+			// without requiring a page refresh.
+			if (res.data?.type === 'relation') {
+				await this.loadRelationsFromBE({
+					tableId: isView ? undefined : elementId,
+					viewId: isView ? elementId : undefined,
+					force: true,
+				})
+			}
 			return true
 		},
 
@@ -191,6 +209,16 @@ export const useDataStore = defineStore('data', {
 				const col = res.data
 				const index = this.columns[stateId].findIndex(c => c.id === col.id)
 				this.columns[stateId][index] = parseCol(col)
+			}
+
+			// The relation's target or label column may have changed, which makes
+			// the cached relation data stale, so we reload it.
+			if (res.data?.type === 'relation') {
+				await this.loadRelationsFromBE({
+					tableId: isView ? undefined : elementId,
+					viewId: isView ? elementId : undefined,
+					force: true,
+				})
 			}
 
 			return true


### PR DESCRIPTION
This PR has the following improvements:
- Relation columns can now only link to tables or views you actually have access to, so you can't link to (and expose data from) something you can't see.
- The target picker now hides tables/views you can't read and the table the column lives in, so you only choose valid targets.
- If a linked table or view stops being accessible (e.g. it gets unshared), the relation is automatically disabled and its data hidden, instead of leaking stale information.
- A clear warning now appears on a relation whose target is no longer accessible, telling you to ask for access or pick a different target (right now, the column ID is shown with the warning, but we could just make it empty instead)
<img width="1354" height="468" alt="Screenshot 2026-06-26 at 06 07 59" src="https://github.com/user-attachments/assets/4b3f160a-686f-4f87-92ce-8bbc9379e0a2" />

- Newly added or edited relation columns show their linked data immediately, without needing a page refresh.

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
