### PR TITLE
fix(rows): keep row counters fresh and reduce count queries

### DIFF
--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -973,15 +973,29 @@ class Row2Mapper {
 	 */
 	public function countRowsForView(View $view, string $userId): int {
 		$filter = $view->getFilterArray();
-		try {
-			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter, $view->getSortArray());
 
-			$rowIds = $this->getWantedRowIds($userId, $view->getTableId(), $filter);
-		} catch (InternalError $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			$rowIds = [];
+		if (empty($filter)) {
+			return $this->countRowsForTable($view->getTableId());
 		}
-		return count($rowIds);
+
+		try {
+			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter);
+
+			$qb = $this->db->getQueryBuilder();
+			$qb->select($qb->func()->count('*', 'counter'))
+				->from('tables_row_sleeves', 'sleeves')
+				->where($qb->expr()->eq('table_id', $qb->createNamedParameter($view->getTableId(), IQueryBuilder::PARAM_INT)));
+
+			$this->addFilterToQuery($qb, $filter, $userId);
+
+			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
+			$count = (int)$result->fetchOne();
+			$result->closeCursor();
+			return $count;
+		} catch (InternalError|Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			return 0;
+		}
 	}
 
 	private function getFormattedDefaultValue(Column $column) {

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -967,6 +967,14 @@ class Row2Mapper {
 	}
 
 	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function countRowsForTables(array $tableIds): array {
+		return $this->rowSleeveMapper->countRowsByTableIds($tableIds);
+	}
+
+	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -957,15 +957,29 @@ class Row2Mapper {
 	 */
 	public function countRowsForView(View $view, string $userId): int {
 		$filter = $view->getFilterArray();
-		try {
-			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter, $view->getSortArray());
 
-			$rowIds = $this->getWantedRowIds($userId, $view->getTableId(), $filter);
-		} catch (InternalError $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			$rowIds = [];
+		if (empty($filter)) {
+			return $this->countRowsForTable($view->getTableId());
 		}
-		return count($rowIds);
+
+		try {
+			$this->columnMapper->preloadColumns($view->getColumnsArray(), $filter);
+
+			$qb = $this->db->getQueryBuilder();
+			$qb->select($qb->func()->count('*', 'counter'))
+				->from('tables_row_sleeves', 'sleeves')
+				->where($qb->expr()->eq('table_id', $qb->createNamedParameter($view->getTableId(), IQueryBuilder::PARAM_INT)));
+
+			$this->addFilterToQuery($qb, $filter, $userId);
+
+			$result = $this->db->executeQuery($qb->getSQL(), $qb->getParameters(), $qb->getParameterTypes());
+			$count = (int)$result->fetchOne();
+			$result->closeCursor();
+			return $count;
+		} catch (InternalError|Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			return 0;
+		}
 	}
 
 	private function getFormattedDefaultValue(Column $column) {

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -604,7 +604,7 @@ class Row2Mapper {
 	/**
 	 * Helper method to use notILike if available, otherwise fall back to not(iLike(...))
 	 */
-	private function notILike(IQueryBuilder $qb, string $column, $parameter): string {
+	private function notILike(IQueryBuilder $qb, string $column, \OCP\DB\QueryBuilder\IParameter $parameter): string {
 		$expr = $qb->expr();
 		// Nextcloud v35 introduced shortcut method
 		if (method_exists($expr, 'notILike')) {

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -951,6 +951,14 @@ class Row2Mapper {
 	}
 
 	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function countRowsForTables(array $tableIds): array {
+		return $this->rowSleeveMapper->countRowsByTableIds($tableIds);
+	}
+
+	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int

--- a/lib/Db/RowSleeveMapper.php
+++ b/lib/Db/RowSleeveMapper.php
@@ -17,6 +17,8 @@ use Psr\Log\LoggerInterface;
 
 /** @template-extends QBMapper<RowSleeve> */
 class RowSleeveMapper extends QBMapper {
+	private const DB_CHUNK_SIZE = 1_000;
+
 	protected string $table = 'tables_row_sleeves';
 	protected LoggerInterface $logger;
 
@@ -121,6 +123,38 @@ class RowSleeveMapper extends QBMapper {
 			$this->logger->warning('Exception occurred: ' . $e->getMessage() . ' Will return 0.');
 			return 0;
 		}
+	}
+
+	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function countRowsByTableIds(array $tableIds): array {
+		if (empty($tableIds)) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('table_id')
+			->selectAlias($qb->func()->count('*'), 'counter')
+			->from($this->table)
+			->where($qb->expr()->in('table_id', $qb->createParameter('tableIds')))
+			->groupBy('table_id');
+
+		$counts = [];
+		foreach (array_chunk($tableIds, self::DB_CHUNK_SIZE) as $chunk) {
+			$qb->setParameter('tableIds', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+			try {
+				$result = $qb->executeQuery();
+				while ($row = $result->fetch()) {
+					$counts[(int)$row['table_id']] = (int)$row['counter'];
+				}
+				$result->closeCursor();
+			} catch (Exception $e) {
+				$this->logger->warning('Exception occurred: ' . $e->getMessage() . ' Will skip chunk.');
+			}
+		}
+		return $counts;
 	}
 
 	/**

--- a/lib/Db/RowSleeveMapper.php
+++ b/lib/Db/RowSleeveMapper.php
@@ -17,6 +17,8 @@ use Psr\Log\LoggerInterface;
 
 /** @template-extends QBMapper<RowSleeve> */
 class RowSleeveMapper extends QBMapper {
+	private const DB_CHUNK_SIZE = 1_000;
+
 	protected string $table = 'tables_row_sleeves';
 
 	public function __construct(
@@ -122,6 +124,38 @@ class RowSleeveMapper extends QBMapper {
 			$this->logger->warning('Exception occurred: ' . $e->getMessage() . ' Will return 0.');
 			return 0;
 		}
+	}
+
+	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function countRowsByTableIds(array $tableIds): array {
+		if (empty($tableIds)) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('table_id')
+			->selectAlias($qb->func()->count('*'), 'counter')
+			->from($this->table)
+			->where($qb->expr()->in('table_id', $qb->createParameter('tableIds')))
+			->groupBy('table_id');
+
+		$counts = [];
+		foreach (array_chunk($tableIds, self::DB_CHUNK_SIZE) as $chunk) {
+			$qb->setParameter('tableIds', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+			try {
+				$result = $qb->executeQuery();
+				while ($row = $result->fetch()) {
+					$counts[(int)$row['table_id']] = (int)$row['counter'];
+				}
+				$result->closeCursor();
+			} catch (Exception $e) {
+				$this->logger->warning('Exception occurred: ' . $e->getMessage() . ' Will skip chunk.');
+			}
+		}
+		return $counts;
 	}
 
 	/**

--- a/lib/Db/RowSleeveMapper.php
+++ b/lib/Db/RowSleeveMapper.php
@@ -147,7 +147,7 @@ class RowSleeveMapper extends QBMapper {
 			$qb->setParameter('tableIds', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
 			try {
 				$result = $qb->executeQuery();
-				while ($row = $result->fetch()) {
+				while ($row = $result->fetchAssociative()) {
 					$counts[(int)$row['table_id']] = (int)$row['counter'];
 				}
 				$result->closeCursor();

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -839,6 +839,25 @@ class RowService extends SuperService {
 	}
 
 	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function getRowsCountForTables(array $tableIds): array {
+		$readableTableIds = array_values(array_filter(
+			$tableIds,
+			fn (int $tableId): bool => $this->permissionsService->canReadRowsByElementId($tableId, 'table'),
+		));
+
+		$counts = $this->row2Mapper->countRowsForTables($readableTableIds);
+
+		$result = [];
+		foreach ($tableIds as $tableId) {
+			$result[$tableId] = $counts[$tableId] ?? 0;
+		}
+		return $result;
+	}
+
+	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int

--- a/lib/Service/RowService.php
+++ b/lib/Service/RowService.php
@@ -875,6 +875,25 @@ class RowService extends SuperService {
 	}
 
 	/**
+	 * @param int[] $tableIds
+	 * @return array<int, int>
+	 */
+	public function getRowsCountForTables(array $tableIds): array {
+		$readableTableIds = array_values(array_filter(
+			$tableIds,
+			fn (int $tableId): bool => $this->permissionsService->canReadRowsByElementId($tableId, 'table'),
+		));
+
+		$counts = $this->row2Mapper->countRowsForTables($readableTableIds);
+
+		$result = [];
+		foreach ($tableIds as $tableId) {
+			$result[$tableId] = $counts[$tableId] ?? 0;
+		}
+		return $result;
+	}
+
+	/**
 	 * @param View $view
 	 * @param string $userId
 	 * @return int

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -127,16 +127,17 @@ class TableService extends SuperService {
 				) {
 					continue;
 				}
-				$allTables[$node['node_id']] = $this->find($node['node_id'], $skipTableEnhancement, $userId);
+				$allTables[$node['node_id']] = $this->find($node['node_id'], true, $userId);
 			}
 		}
 
 		// enhance table objects with additional data
 		if (!$skipTableEnhancement) {
+			$rowCountsByTableId = $this->rowService->getRowsCountForTables(array_keys($allTables));
 			foreach ($allTables as $table) {
 				/** @var string $userId */
 				try {
-					$this->enhanceTable($table, $userId);
+					$this->enhanceTable($table, $userId, $rowCountsByTableId);
 				} catch (InternalError|PermissionError $e) {
 					$this->logger->error($e->getMessage(), ['exception' => $e]);
 				}
@@ -168,7 +169,7 @@ class TableService extends SuperService {
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	private function enhanceTable(Table $table, string $userId): void {
+	private function enhanceTable(Table $table, string $userId, ?array $rowCountsByTableId = null): void {
 		// add owner display name for UI
 		$this->addOwnerDisplayName($table);
 
@@ -183,10 +184,14 @@ class TableService extends SuperService {
 		}
 
 		// add the rows count
-		try {
-			$table->setRowsCount($this->rowService->getRowsCount($table->getId()));
-		} catch (PermissionError $e) {
-			$table->setRowsCount(0);
+		if ($rowCountsByTableId !== null) {
+			$table->setRowsCount($rowCountsByTableId[$table->getId()] ?? 0);
+		} else {
+			try {
+				$table->setRowsCount($this->rowService->getRowsCount($table->getId()));
+			} catch (PermissionError $e) {
+				$table->setRowsCount(0);
+			}
 		}
 
 		// add the column count

--- a/lib/Service/TableService.php
+++ b/lib/Service/TableService.php
@@ -135,16 +135,17 @@ class TableService extends SuperService {
 				) {
 					continue;
 				}
-				$allTables[$node['node_id']] = $this->find($node['node_id'], $skipTableEnhancement, $userId);
+				$allTables[$node['node_id']] = $this->find($node['node_id'], true, $userId);
 			}
 		}
 
 		// enhance table objects with additional data
 		if (!$skipTableEnhancement) {
+			$rowCountsByTableId = $this->rowService->getRowsCountForTables(array_keys($allTables));
 			foreach ($allTables as $table) {
 				/** @var string $userId */
 				try {
-					$this->enhanceTable($table, $userId);
+					$this->enhanceTable($table, $userId, $rowCountsByTableId);
 				} catch (InternalError|PermissionError $e) {
 					$this->logger->error($e->getMessage(), ['exception' => $e]);
 				}
@@ -176,7 +177,7 @@ class TableService extends SuperService {
 	 * @throws InternalError
 	 * @throws PermissionError
 	 */
-	private function enhanceTable(Table $table, string $userId): void {
+	private function enhanceTable(Table $table, string $userId, ?array $rowCountsByTableId = null): void {
 		// add owner display name for UI
 		$this->addOwnerDisplayName($table);
 
@@ -191,10 +192,14 @@ class TableService extends SuperService {
 		}
 
 		// add the rows count
-		try {
-			$table->setRowsCount($this->rowService->getRowsCount($table->getId()));
-		} catch (PermissionError) {
-			$table->setRowsCount(0);
+		if ($rowCountsByTableId !== null) {
+			$table->setRowsCount($rowCountsByTableId[$table->getId()] ?? 0);
+		} else {
+			try {
+				$table->setRowsCount($this->rowService->getRowsCount($table->getId()));
+			} catch (PermissionError) {
+				$table->setRowsCount(0);
+			}
 		}
 
 		// add the column count

--- a/playwright/e2e/rows-counter.spec.ts
+++ b/playwright/e2e/rows-counter.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { test, expect } from '../support/fixtures'
+import { createTable, createTextLineColumn, createView, ensureNavigationOpen, loadTable } from '../support/commands'
+
+test.describe('Row counter freshness', () => {
+
+	test('Navigation counters update for table and sibling view after adding a row', async ({ userPage: { page } }) => {
+		await page.goto('/index.php/apps/tables')
+		await createTable(page, 'Counter sync table')
+		await loadTable(page, 'Counter sync table')
+		await createTextLineColumn(page, 'label', '', '', true)
+
+		await createView(page, 'Counter sync view')
+		await loadTable(page, 'Counter sync table')
+		await ensureNavigationOpen(page)
+
+		const tableCounter = page
+			.locator('[data-cy="navigationTableItem"]')
+			.filter({ hasText: 'Counter sync table' })
+			.locator('.counter-bubble__counter')
+			.first()
+		const viewCounter = page
+			.locator('[data-cy="navigationViewItem"]')
+			.filter({ hasText: 'Counter sync view' })
+			.locator('.counter-bubble__counter')
+			.first()
+
+		await page.locator('button').filter({ hasText: 'Create row' }).click()
+		const input = page.locator('.modal__content input').first()
+		await input.fill('first row')
+		await page.locator('button').filter({ hasText: 'Save' }).click()
+		await expect(page.locator('.custom-table table tr td div').filter({ hasText: 'first row' }).first()).toBeVisible()
+
+		await expect(tableCounter).toHaveText('1')
+		await expect(viewCounter).toHaveText('1')
+	})
+})

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -11,10 +11,22 @@ import { MetaColumns } from '../shared/components/ncTable/mixins/metaColumns.js'
 import { showError } from '@nextcloud/dialogs'
 import { set } from 'vue'
 import { emit } from '@nextcloud/event-bus'
+import { getCurrentUser } from '@nextcloud/auth'
+import { useTablesStore } from './store.js'
 
 function genStateKey(isView, elementId) {
 	elementId = elementId.toString()
 	return isView ? 'view-' + elementId : elementId
+}
+
+const VIEW_COUNT_REFRESH_DELAY = 500
+const viewCountRefreshTimers = new Map()
+
+function canManageTable(table) {
+	if (!table.isShared) {
+		return true
+	}
+	return !!table.onSharePermissions?.manage || table.ownership === getCurrentUser()?.uid
 }
 
 export const useDataStore = defineStore('data', {
@@ -234,6 +246,30 @@ export const useDataStore = defineStore('data', {
 		},
 
 		// ROWS
+		syncElementRowsCount({ isView, elementId }) {
+			const stateId = genStateKey(isView, elementId)
+			const count = (this.rows[stateId] ?? []).length
+			useTablesStore().setElementRowsCount({ isView, elementId, count })
+		},
+
+		refreshTableViewCounts(tableId) {
+			if (!tableId) {
+				return
+			}
+			const table = useTablesStore().getTable(tableId)
+			if (!table || !canManageTable(table)) {
+				return
+			}
+			const existingTimer = viewCountRefreshTimers.get(tableId)
+			if (existingTimer) {
+				clearTimeout(existingTimer)
+			}
+			viewCountRefreshTimers.set(tableId, setTimeout(() => {
+				viewCountRefreshTimers.delete(tableId)
+				useTablesStore().reloadViewsOfTable({ tableId })
+			}, VIEW_COUNT_REFRESH_DELAY))
+		},
+
 		async loadRowsFromBE({ tableId, viewId }) {
 			const stateId = genStateKey(!!(viewId), viewId ?? tableId)
 			this.loading[stateId] = true
@@ -252,6 +288,7 @@ export const useDataStore = defineStore('data', {
 
 			set(this.rows, stateId, res.data)
 			this.loading[stateId] = false
+			this.syncElementRowsCount({ isView: !!viewId, elementId: viewId ?? tableId })
 			return true
 		},
 
@@ -299,6 +336,9 @@ export const useDataStore = defineStore('data', {
 				const updatedRows = this.rows[stateId].map(r => r.id === row.id ? row : r)
 				set(this.rows, stateId, updatedRows)
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
+				this.syncElementRowsCount({ isView, elementId })
+				const parentTableId = row?.tableId ?? (isView ? useTablesStore().getView(elementId)?.tableId : elementId)
+				this.refreshTableViewCounts(parentTableId)
 			}
 
 			return true
@@ -339,6 +379,13 @@ export const useDataStore = defineStore('data', {
 				const newIndex = this.rows[stateId].length
 				set(this.rows[stateId], newIndex, row)
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
+				this.syncElementRowsCount({ isView: !!viewId, elementId: viewId ?? tableId })
+				const tablesStore = useTablesStore()
+				const parentTableId = viewId ? (row?.tableId ?? tablesStore.getView(viewId)?.tableId) : tableId
+				if (viewId && parentTableId) {
+					tablesStore.addToTableRowsCount({ tableId: parentTableId, delta: 1 })
+				}
+				this.refreshTableViewCounts(parentTableId)
 			}
 
 			return true
@@ -386,6 +433,13 @@ export const useDataStore = defineStore('data', {
 			if (stateId && this.rows[stateId]) {
 				const filteredRows = this.rows[stateId].filter(r => r.id !== rowId)
 				set(this.rows, stateId, filteredRows)
+				this.syncElementRowsCount({ isView, elementId })
+				const tablesStore = useTablesStore()
+				const parentTableId = viewId ? tablesStore.getView(viewId)?.tableId : elementId
+				if (viewId && parentTableId) {
+					tablesStore.addToTableRowsCount({ tableId: parentTableId, delta: -1 })
+				}
+				this.refreshTableViewCounts(parentTableId)
 			}
 			return true
 		},

--- a/src/store/data.js
+++ b/src/store/data.js
@@ -10,10 +10,22 @@ import { parseCol } from '../shared/components/ncTable/mixins/columnParser.js'
 import { MetaColumns } from '../shared/components/ncTable/mixins/metaColumns.js'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
+import { getCurrentUser } from '@nextcloud/auth'
+import { useTablesStore } from './store.js'
 
 function genStateKey(isView, elementId) {
 	elementId = elementId.toString()
 	return isView ? 'view-' + elementId : elementId
+}
+
+const VIEW_COUNT_REFRESH_DELAY = 500
+const viewCountRefreshTimers = new Map()
+
+function canManageTable(table) {
+	if (!table.isShared) {
+		return true
+	}
+	return !!table.onSharePermissions?.manage || table.ownership === getCurrentUser()?.uid
 }
 
 export const useDataStore = defineStore('data', {
@@ -233,6 +245,30 @@ export const useDataStore = defineStore('data', {
 		},
 
 		// ROWS
+		syncElementRowsCount({ isView, elementId }) {
+			const stateId = genStateKey(isView, elementId)
+			const count = (this.rows[stateId] ?? []).length
+			useTablesStore().setElementRowsCount({ isView, elementId, count })
+		},
+
+		refreshTableViewCounts(tableId) {
+			if (!tableId) {
+				return
+			}
+			const table = useTablesStore().getTable(tableId)
+			if (!table || !canManageTable(table)) {
+				return
+			}
+			const existingTimer = viewCountRefreshTimers.get(tableId)
+			if (existingTimer) {
+				clearTimeout(existingTimer)
+			}
+			viewCountRefreshTimers.set(tableId, setTimeout(() => {
+				viewCountRefreshTimers.delete(tableId)
+				useTablesStore().reloadViewsOfTable({ tableId })
+			}, VIEW_COUNT_REFRESH_DELAY))
+		},
+
 		async loadRowsFromBE({ tableId, viewId }) {
 			const stateId = genStateKey(!!(viewId), viewId ?? tableId)
 			this.loading[stateId] = true
@@ -251,6 +287,7 @@ export const useDataStore = defineStore('data', {
 
 			this.rows[stateId] = res.data
 			this.loading[stateId] = false
+			this.syncElementRowsCount({ isView: !!viewId, elementId: viewId ?? tableId })
 			return true
 		},
 
@@ -298,6 +335,9 @@ export const useDataStore = defineStore('data', {
 				const updatedRows = this.rows[stateId].map(r => r.id === row.id ? row : r)
 				this.rows[stateId] = updatedRows
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
+				this.syncElementRowsCount({ isView, elementId })
+				const parentTableId = row?.tableId ?? (isView ? useTablesStore().getView(elementId)?.tableId : elementId)
+				this.refreshTableViewCounts(parentTableId)
 			}
 
 			return true
@@ -338,6 +378,13 @@ export const useDataStore = defineStore('data', {
 				const newIndex = this.rows[stateId].length
 				this.rows[stateId][newIndex] = row
 				await this.removeRowIfNotInView({ rowId: row?.id, viewId, stateId })
+				this.syncElementRowsCount({ isView: !!viewId, elementId: viewId ?? tableId })
+				const tablesStore = useTablesStore()
+				const parentTableId = viewId ? (row?.tableId ?? tablesStore.getView(viewId)?.tableId) : tableId
+				if (viewId && parentTableId) {
+					tablesStore.addToTableRowsCount({ tableId: parentTableId, delta: 1 })
+				}
+				this.refreshTableViewCounts(parentTableId)
 			}
 
 			return true
@@ -382,6 +429,13 @@ export const useDataStore = defineStore('data', {
 			if (stateId && this.rows[stateId]) {
 				const filteredRows = this.rows[stateId].filter(r => r.id !== rowId)
 				this.rows[stateId] = filteredRows
+				this.syncElementRowsCount({ isView, elementId })
+				const tablesStore = useTablesStore()
+				const parentTableId = viewId ? tablesStore.getView(viewId)?.tableId : elementId
+				if (viewId && parentTableId) {
+					tablesStore.addToTableRowsCount({ tableId: parentTableId, delta: -1 })
+				}
+				this.refreshTableViewCounts(parentTableId)
 			}
 			return true
 		},

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -648,5 +648,19 @@ export const useTablesStore = defineStore('store', {
 			}
 		},
 
+		setElementRowsCount({ isView, elementId, count }) {
+			const element = isView ? this.getView(elementId) : this.getTable(elementId)
+			if (element) {
+				element.rowsCount = count
+			}
+		},
+
+		addToTableRowsCount({ tableId, delta }) {
+			const table = this.getTable(tableId)
+			if (table && typeof table.rowsCount === 'number') {
+				table.rowsCount += delta
+			}
+		},
+
 	},
 })

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -645,5 +645,19 @@ export const useTablesStore = defineStore('store', {
 			}
 		},
 
+		setElementRowsCount({ isView, elementId, count }) {
+			const element = isView ? this.getView(elementId) : this.getTable(elementId)
+			if (element) {
+				element.rowsCount = count
+			}
+		},
+
+		addToTableRowsCount({ tableId, delta }) {
+			const table = this.getTable(tableId)
+			if (table && typeof table.rowsCount === 'number') {
+				table.rowsCount += delta
+			}
+		},
+
 	},
 })

--- a/tests/unit/Db/Row2MapperFilterTest.php
+++ b/tests/unit/Db/Row2MapperFilterTest.php
@@ -311,4 +311,12 @@ class Row2MapperFilterTest extends \OCA\Tables\Tests\Unit\Database\DatabaseTestC
 
 		$this->assertSame(5, $this->mapper->countRowsForView($view, 'test_user'), 'View without filters should count all table rows');
 	}
+
+	public function testCountRowsForTables(): void {
+		$this->assertSame([], $this->mapper->countRowsForTables([]), 'Empty input should return an empty map');
+
+		$counts = $this->mapper->countRowsForTables([self::$testTableId, 999999]);
+		$this->assertSame(5, $counts[self::$testTableId] ?? 0, 'Batch count should match the table row count');
+		$this->assertArrayNotHasKey(999999, $counts, 'Tables without rows should be absent from the map');
+	}
 }

--- a/tests/unit/Db/Row2MapperFilterTest.php
+++ b/tests/unit/Db/Row2MapperFilterTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Tables\Tests\Unit\Db;
 
 use OCA\Tables\Db\Column;
+use OCA\Tables\Db\View;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -268,5 +269,46 @@ class Row2MapperFilterTest extends \OCA\Tables\Tests\Unit\Database\DatabaseTestC
 
 		// Should return all test rows when no filter is applied
 		$this->assertCount(5, $rows, 'Empty filter should return all rows');
+	}
+
+	private function buildConvertedFilter(array $filter): array {
+		$convertedFilter = [];
+		if (isset($filter[0]) && is_array($filter[0]) && isset($filter[0][0])) {
+			foreach ($filter as $filterGroup) {
+				$convertedFilter[] = $this->convertFilterColumnNamesToIds($filterGroup);
+			}
+		} else {
+			$convertedFilter[] = $this->convertFilterColumnNamesToIds($filter);
+		}
+		return $convertedFilter;
+	}
+
+	/**
+	 * @dataProvider filterDataProvider
+	 */
+	public function testCountRowsForViewMatchesFilteredRows($filter, array $expectedNameOrder, string $description): void {
+		$this->setupRealColumnMapper(self::$testTableId);
+
+		$convertedFilter = $this->buildConvertedFilter($filter);
+
+		$view = new View();
+		$view->setTableId(self::$testTableId);
+		$view->setFilterArray($convertedFilter);
+
+		$rows = $this->mapper->findAll(self::$testColumnIds, self::$testTableId, null, null, $convertedFilter, null, 'test_user');
+		$count = $this->mapper->countRowsForView($view, 'test_user');
+
+		$this->assertSame(count($expectedNameOrder), $count, 'countRowsForView should return ' . count($expectedNameOrder) . " for: $description");
+		$this->assertSame(count($rows), $count, "countRowsForView should match findAll row count for: $description");
+	}
+
+	public function testCountRowsForViewWithoutFilter(): void {
+		$this->setupRealColumnMapper(self::$testTableId);
+
+		$view = new View();
+		$view->setTableId(self::$testTableId);
+		$view->setFilterArray([]);
+
+		$this->assertSame(5, $this->mapper->countRowsForView($view, 'test_user'), 'View without filters should count all table rows');
 	}
 }


### PR DESCRIPTION
## Summary

Fixes stale row counters in Tables after row changes.

- Update the active table/view counter immediately after row load, create, update, or delete.
- Refresh affected sibling view counters after row changes, debounced per table.
- Count filtered view rows directly in SQL instead of materializing all matching row IDs in PHP.
- Batch table row counts when listing tables to avoid one count query per table.

Closes #451
Related: #725, #731

## Performance impact

This should be a net improvement for counter-heavy paths:

- Table list row counts go from one `COUNT(*)` query per table to one grouped `COUNT(*) ... GROUP BY table_id` query for all readable tables, chunked at 1000 IDs.
- Filtered view row counts now return a scalar SQL `COUNT(*)`; previously they loaded all matching row IDs into PHP and counted the array.
- Row create/update/delete adds at most one debounced view-list refresh per table per 500ms burst, instead of requiring a full page reload for fresh counters.

## Tests

- Added unit coverage for `countRowsForView()` matching filtered `findAll()` results.
- Added unit coverage for batched table row counts.
- Added Playwright coverage for navigation table/view counters after adding a row.