### PR TITLE
perf: Don't fetch full group information

### DIFF
--- a/lib/Helper/UserHelper.php
+++ b/lib/Helper/UserHelper.php
@@ -8,7 +8,6 @@
 namespace OCA\Tables\Helper;
 
 use OCA\Tables\Errors\InternalError;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -50,28 +49,14 @@ class UserHelper {
 
 	/**
 	 * @param string $userId
-	 * @return IGroup[]
-	 * @throws InternalError
-	 */
-	public function getGroupsForUser(string $userId): array {
-		$user = $this->getUser($userId);
-		return $this->groupManager->getUserGroups($user);
-	}
-
-	/**
-	 * @param string $userId
 	 * @return array|null
 	 */
 	public function getGroupIdsForUser(string $userId): ?array {
 		try {
-			$userGroups = $this->getGroupsForUser($userId);
+			$user = $this->getUser($userId);
+			return $this->groupManager->getUserGroupIds($user);
 		} catch (InternalError $e) {
 			return null;
 		}
-
-		$groupArray = array_map(function (IGroup $group) {
-			return $group->getGID();
-		}, $userGroups);
-		return $groupArray;
 	}
 }

--- a/lib/Service/PermissionsService.php
+++ b/lib/Service/PermissionsService.php
@@ -438,9 +438,9 @@ class PermissionsService {
 
 		if ($share->getReceiverType() === 'group') {
 			try {
-				$userGroups = $this->userHelper->getGroupsForUser($userId);
-				foreach ($userGroups as $userGroup) {
-					if ($userGroup->getGID() === $share->getReceiver()) {
+				$userGroups = $this->userHelper->getGroupIdsForUser($userId);
+				foreach ($userGroups as $userGroupId) {
+					if ($userGroupId === $share->getReceiver()) {
 						return true;
 					}
 				}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -39,7 +39,6 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\DB\Exception;
 use OCP\IDBConnection;
-use OCP\IGroup;
 use OCP\IUserManager;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
@@ -234,8 +233,7 @@ class ShareService extends SuperService {
 		try {
 			$shares['user'] = $this->mapper->findAllSharesFor($elementType, [$userId], $userId);
 
-			$userGroups = $this->userHelper->getGroupsForUser($userId);
-			$userGroupIds = array_map(static fn (IGroup $group) => $group->getGid(), $userGroups);
+			$userGroupIds = $this->userHelper->getGroupIdsForUser($userId);
 			$shares['groups'] = $this->mapper->findAllSharesFor($elementType, $userGroupIds, $userId, ShareReceiverType::GROUP);
 
 			$userCircles = $this->circleHelper->getUserCircles($userId);


### PR DESCRIPTION
This is expensive particularly when multiple group backends are enabled



### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
