### PR TITLE
Fix sort stars and select (#8)

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/numberStars.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/numberStars.js
@@ -14,7 +14,7 @@ export default class NumberStarsColumn extends AbstractNumberColumn {
 	}
 
 	sort(mode, nextSorts) {
-		const factor = mode === 'DESC' ? 1 : -1
+		const factor = mode === 'DESC' ? -1 : 1
 		return (rowA, rowB) => {
 			const tmpA = rowA.data.find(item => item.columnId === this.id)?.value
 			const valueA = Number.isNaN(parseInt(tmpA)) ? -1 : parseInt(tmpA)

--- a/src/shared/components/ncTable/mixins/columnsTypes/selectionCheck.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/selectionCheck.js
@@ -14,7 +14,7 @@ export default class SelectionCheckColumn extends AbstractSelectionColumn {
 	}
 
 	sort(mode, nextSorts) {
-		const factor = mode === 'DESC' ? 1 : -1
+		const factor = mode === 'DESC' ? -1 : 1
 		return (rowA, rowB) => {
 			const tmpA = rowA.data.find(item => item.columnId === this.id)?.value || ''
 			const valueA = (tmpA === true || tmpA === 'true')


### PR DESCRIPTION
* Fix sort order factor for number stars
* Fix sort order in selectionCheck mixin

Fixes #2702 

All the other columnstypes are like that one liner. This also remove discrepancy between public and private view when using preSort

---------



### 🖼️ Screenshots

Showing ascending order 1,2,3,4 
🏚️ Before | 🏡 After
---|---
<img width="1300" height="651" alt="Screenshot 2026-07-21 at 21-40-23 Test sort - Tableaux - Nextcloud" src="https://github.com/user-attachments/assets/b6cc6885-9bfd-4336-8f38-05d6149488c0" /> | <img width="1300" height="651" alt="Screenshot 2026-07-21 at 21-07-11 Test sort - Tableaux - Nextcloud" src="https://github.com/user-attachments/assets/c594b7ce-9252-4846-9793-3cf529448768" />
<img width="1300" height="651" alt="Screenshot 2026-07-21 at 21-40-36 Test sort - Tableaux - Nextcloud" src="https://github.com/user-attachments/assets/d914dbc4-517e-4848-8cb9-68b1f18155dc" /> | <img width="1300" height="651" alt="Screenshot 2026-07-21 at 21-06-55 Test sort - Tableaux - Nextcloud" src="https://github.com/user-attachments/assets/7b11dacf-401b-4000-8396-38907c7c1da1" />

### 🏁 Checklist
 
- [X] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [X] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
