### PR TITLE
fix: align share response with documented response definition

### DIFF
--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -501,7 +501,7 @@ class Api1Controller extends ApiController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function getShare(int $shareId): DataResponse {
 		try {
-			return new DataResponse($this->shareService->find($shareId)->jsonSerialize());
+			return new DataResponse($this->shareService->formatForOutput($this->shareService->find($shareId))->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
@@ -608,7 +608,7 @@ class Api1Controller extends ApiController {
 	): DataResponse {
 		try {
 			return new DataResponse(
-				$this->shareService->create(new ShareCreate(
+				$this->shareService->formatForOutput($this->shareService->create(new ShareCreate(
 					$nodeId,
 					$nodeType,
 					$receiver,
@@ -619,7 +619,7 @@ class Api1Controller extends ApiController {
 					$permissionDelete,
 					$permissionManage,
 					$displayMode
-				))->jsonSerialize()
+				)))->jsonSerialize()
 			);
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
@@ -652,7 +652,7 @@ class Api1Controller extends ApiController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function deleteShare(int $shareId): DataResponse {
 		try {
-			return new DataResponse($this->shareService->delete($shareId)->jsonSerialize());
+			return new DataResponse($this->shareService->formatForOutput($this->shareService->delete($shareId))->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
@@ -686,7 +686,7 @@ class Api1Controller extends ApiController {
 	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT)]
 	public function updateSharePermissions(int $shareId, string $permissionType, bool $permissionValue): DataResponse {
 		try {
-			return new DataResponse($this->shareService->updatePermission($shareId, [$permissionType => $permissionValue])->jsonSerialize());
+			return new DataResponse($this->shareService->formatForOutput($this->shareService->updatePermission($shareId, [$permissionType => $permissionValue]))->jsonSerialize());
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);
 			$message = ['message' => $e->getMessage()];
@@ -1651,7 +1651,7 @@ class Api1Controller extends ApiController {
 	public function createTableShare(int $tableId, string $receiver, string $receiverType, bool $permissionRead, bool $permissionCreate, bool $permissionUpdate, bool $permissionDelete, bool $permissionManage): DataResponse {
 		try {
 			return new DataResponse(
-				$this->shareService->create(new ShareCreate(
+				$this->shareService->formatForOutput($this->shareService->create(new ShareCreate(
 					$tableId,
 					'table',
 					$receiver,
@@ -1662,7 +1662,7 @@ class Api1Controller extends ApiController {
 					$permissionDelete,
 					$permissionManage,
 					Application::NAV_ENTRY_MODE_ALL
-				))->jsonSerialize()
+				)))->jsonSerialize()
 			);
 		} catch (PermissionError $e) {
 			$this->logger->warning('A permission error occurred: ' . $e->getMessage(), ['exception' => $e]);

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -97,7 +97,7 @@ class ShareService extends SuperService {
 	 * @return TablesShare[]
 	 */
 	public function formatShares(array $items): array {
-		return array_map(static fn (Share $item) => $item->jsonSerialize(), $items);
+		return array_map(fn (Share $item) => $this->formatForOutput($item)->jsonSerialize(), $items);
 	}
 
 	public function formatForOutput(Share $share): Share {


### PR DESCRIPTION
Any related output of the Api1Controller goes through `formatForOutput` now. It masks the password hash (sets it to 'yes' if present), which ain't an issue for any use case. It's fine to keep that on the server.