### PR TITLE
[stable1.0] fix public share

### DIFF
--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -272,6 +272,7 @@ class ShareService extends SuperService {
 	 * @param string $receiverType
 	 *
 	 * @throws InternalError
+	 * @throws PermissionError
 	 *
 	 * @return Share
 	 */
@@ -285,6 +286,14 @@ class ShareService extends SuperService {
 			$e = new \Exception('No user given.');
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new InternalError(get_class($this) . ' - ' . __FUNCTION__ . ': ' . $e->getMessage());
+		}
+		$allowedReceiverTypes = [
+			ShareReceiverType::USER,
+			ShareReceiverType::GROUP,
+			ShareReceiverType::CIRCLE,
+		];
+		if (!in_array($receiverType, $allowedReceiverTypes, true)) {
+			throw new PermissionError('Invalid share receiver type.');
 		}
 		if ($receiverType === ShareReceiverType::GROUP && !$this->shareManager->allowGroupSharing()) {
 			throw new PermissionError('Group sharing is disabled by your administrator.');

--- a/tests/unit/Service/ShareServiceTest.php
+++ b/tests/unit/Service/ShareServiceTest.php
@@ -106,4 +106,26 @@ class ShareServiceTest extends TestCase {
 		$this->expectException(PermissionError::class);
 		$this->shareService->updatePermission(1, 'manage', true);
 	}
+
+	public function testCreateThrowsForUnsupportedReceiverType(): void {
+		$this->mapper->expects($this->never())->method('insert');
+
+		$this->expectException(PermissionError::class);
+		$this->expectExceptionMessage('Invalid share receiver type.');
+
+		$this->shareService->create(
+			new ShareCreate(
+				1,
+				'table',
+				'',
+				'link',
+				true,
+				false,
+				false,
+				false,
+				false,
+				0,
+			)
+		);
+	}
 }


### PR DESCRIPTION
Backport of: https://github.com/nextcloud/tables/pull/2854
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
