### PR TITLE
Fix: Fix column ignorance on import

### DIFF
--- a/cypress/e2e/tables-import.cy.js
+++ b/cypress/e2e/tables-import.cy.js
@@ -136,6 +136,38 @@ describe('Import csv', () => {
 		cy.get('[data-cy="importResultRowErrors"]').should('contain.text', '0')
 	})
 
+	it('Import small csv from device with an extra ignored column', () => {
+		const csv = [
+			['What', 'How to do', 'Ease of use', 'Done', 'Extra column to ignore'],
+			['A1', 'A2', '0', 'true', 'ignore1'],
+			['B1', 'B2', '2', 'true', 'ignore2'],
+			['C1', 'C2', '5', 'false', 'ignore3'],
+		]
+		cy.writeFile('cypress/fixtures/test-import-with-extra.csv', csv.map(row => row.join(',')).join('\n'))
+
+		cy.loadTable('Welcome to Nextcloud Tables!')
+		cy.clickOnTableThreeDotMenu('Import')
+		cy.get('.modal__content button').contains('Upload from device').click()
+		cy.get('input[type="file"]').selectFile('cypress/fixtures/test-import-with-extra.csv', { force: true })
+
+		cy.get('.modal__content input[type="checkbox"]').first().uncheck({ force: true })
+
+		cy.intercept({ method: 'POST', url: '**/apps/tables/importupload-preview/**' }).as('importPreviewUploadExtra')
+		cy.get('.modal__content button').contains('Preview').click()
+		cy.wait('@importPreviewUploadExtra')
+		cy.get('.file_import__preview tbody tr', { timeout: 20000 }).should('have.length', 5)
+
+		cy.intercept({ method: 'POST', url: '**/apps/tables/v2/importupload/table/*' }).as('importUploadReqExtra')
+		cy.get('.modal__content button').contains('Import').click()
+		cy.wait('@importUploadReqExtra')
+		cy.get('[data-cy="importResultColumnsFound"]', { timeout: 20000 }).should('contain.text', '4')
+		cy.get('[data-cy="importResultColumnsMatch"]').should('contain.text', '4')
+		cy.get('[data-cy="importResultColumnsCreated"]').should('contain.text', '0')
+		cy.get('[data-cy="importResultRowsInserted"]').should('contain.text', '3')
+		cy.get('[data-cy="importResultParsingErrors"]').should('contain.text', '0')
+		cy.get('[data-cy="importResultRowErrors"]').should('contain.text', '0')
+	})
+
 })
 
 describe('Import csv from Files file action', () => {

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -388,7 +388,7 @@ class ImportService extends SuperService {
 		}
 
 		return [
-			'found_columns_count' => count($this->columns),
+			'found_columns_count' => count(array_filter($this->columns, fn ($column): bool => $column instanceof Column)),
 			'matching_columns_count' => $this->countMatchingColumns,
 			'created_columns_count' => $this->countCreatedColumns,
 			'inserted_rows_count' => $this->countInsertedRows,
@@ -527,7 +527,7 @@ class ImportService extends SuperService {
 		}
 
 		return new ImportStats(
-			count($this->columns),
+			count(array_filter($this->columns, fn ($column): bool => $column instanceof Column)),
 			$this->countMatchingColumns,
 			$this->countCreatedColumns,
 			$this->countInsertedRows,
@@ -763,8 +763,6 @@ class ImportService extends SuperService {
 
 				if (!$this->columnsConfig && mb_strtolower($title) === Column::META_ID_TITLE) {
 					$this->idColumnIndex = $index;
-					$this->countMatchingColumns++;
-					$shouldImport = false;
 				} elseif (isset($this->columnsConfig[$index])) {
 					if ($this->columnsConfig[$index]['action'] === 'ignore') {
 						$shouldImport = false;
@@ -836,9 +834,10 @@ class ImportService extends SuperService {
 		try {
 			$result = $this->columnService->findOrCreateColumnsByTitleForTableAsArray($this->tableId, $this->viewId, $titles, $dataTypes, $this->userId, $this->createUnknownColumns, $this->countCreatedColumns, $this->countMatchingColumns);
 			foreach ($result as $resultIndex => $column) {
-				if ($column instanceof Column) {
-					$this->columns[$columnFileIndices[$resultIndex]] = $column;
-				}
+				$this->columns[$columnFileIndices[$resultIndex]] = $column;
+			}
+			if ($this->idColumnIndex !== null && (!isset($this->columns[$this->idColumnIndex]) || !$this->columns[$this->idColumnIndex] instanceof Column)) {
+				$this->countMatchingColumns++;
 			}
 			if (!empty($this->columnsConfig)) {
 				$this->countMatchingColumns = $countMatchingColumnsFromConfig;

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -205,7 +205,7 @@ class ImportService extends SuperService {
 		$this->getColumns($firstRow, $secondRow);
 
 		foreach ($this->rawColumnTitles as $colIndex => $title) {
-			if ($this->columns[$colIndex] !== '') {
+			if (isset($this->columns[$colIndex]) && $this->columns[$colIndex] !== '') {
 				/** @var Column $column */
 				$column = $this->columns[$colIndex];
 				$columns[] = $column;
@@ -623,20 +623,14 @@ class ImportService extends SuperService {
 					continue;
 				}
 
-				$columnKey = $i;
-				if ($this->columnsConfig && $this->idColumnIndex !== null && $i > $this->idColumnIndex) {
-					// if we have an ID column, we need to adjust the index
-					$columnKey = $i - 1;
-				}
-
 				// only add the dataset if column is known
-				if (!isset($this->columns[$columnKey]) || $this->columns[$columnKey] === '') {
+				if (!isset($this->columns[$i]) || $this->columns[$i] === '') {
 					$this->logger->debug('Column unknown while fetching rows data for importing.');
 					continue;
 				}
 
 				/** @var Column $column */
-				$column = $this->columns[$columnKey];
+				$column = $this->columns[$i];
 
 				// if cell is empty
 				if (!$cell || $cell->getValue() === null) {
@@ -750,57 +744,76 @@ class ImportService extends SuperService {
 		$secondRowCellIterator = $secondRow->getCellIterator();
 		$titles = [];
 		$dataTypes = [];
+		$rawColumnTitles = [];
+		$rawColumnDataTypes = [];
+		$columnFileIndices = [];
 		$index = 0;
 		$countMatchingColumnsFromConfig = 0;
 		$countCreatedColumnsFromConfig = 0;
 		$lastCellWasEmpty = false;
 		$hasGapInTitles = false;
+		$this->columns = [];
+
 		foreach ($cellIterator as $cell) {
 			if ($cell && $cell->getValue() !== null && $cell->getValue() !== '') {
 				$title = $cell->getValue();
+				$titleRaw = $title;
+				$dataType = $this->parseColumnDataType($secondRowCellIterator->current());
+				$shouldImport = true;
 
 				if (!$this->columnsConfig && mb_strtolower($title) === Column::META_ID_TITLE) {
 					$this->idColumnIndex = $index;
-					$titles[] = $title;
-					$dataTypes[] = $this->parseColumnDataType($secondRowCellIterator->current());
-					$secondRowCellIterator->next();
-					$index++;
-					continue;
-				}
-				if (isset($this->columnsConfig[$index]) && $this->columnsConfig[$index]['action'] === 'exist' && $this->columnsConfig[$index]['existColumn']) {
-					$title = $this->columnsConfig[$index]['existColumn']['label'];
-					$countMatchingColumnsFromConfig++;
-
-					// no need to create the ID (Meta) column as it used for update
-					if ($this->columnsConfig[$index]['existColumn']['id'] === Column::TYPE_META_ID) {
+					$this->countMatchingColumns++;
+					$shouldImport = false;
+				} elseif (isset($this->columnsConfig[$index])) {
+					if ($this->columnsConfig[$index]['action'] === 'ignore') {
+						$shouldImport = false;
+					} elseif (
+						$this->columnsConfig[$index]['action'] === 'exist'
+						&& isset($this->columnsConfig[$index]['existColumn'])
+						&& $this->columnsConfig[$index]['existColumn']['id'] === Column::TYPE_META_ID
+					) {
 						$this->idColumnIndex = $index;
-						$secondRowCellIterator->next();
-						$index++;
-						continue;
+						$countMatchingColumnsFromConfig++;
+						$shouldImport = false;
+					} elseif (
+						$this->columnsConfig[$index]['action'] === 'exist'
+						&& $this->columnsConfig[$index]['existColumn']
+					) {
+						$title = $this->columnsConfig[$index]['existColumn']['label'];
+						$countMatchingColumnsFromConfig++;
+					} elseif (
+						$this->columnsConfig[$index]['action'] === 'new'
+						&& $this->createUnknownColumns
+					) {
+						$column = $this->columnService->create(
+							$this->userId,
+							$this->tableId,
+							$this->viewId,
+							ColumnDto::createFromArray($this->columnsConfig[$index]),
+							$this->columnsConfig[$index]['selectedViewIds'] ?? []
+						);
+						$title = $column->getTitle();
+						$countCreatedColumnsFromConfig++;
 					}
 				}
-				if (isset($this->columnsConfig[$index]) && $this->columnsConfig[$index]['action'] === 'new' && $this->createUnknownColumns) {
-					$column = $this->columnService->create(
-						$this->userId,
-						$this->tableId,
-						$this->viewId,
-						ColumnDto::createFromArray($this->columnsConfig[$index]),
-						$this->columnsConfig[$index]['selectedViewIds'] ?? []
-					);
-					$title = $column->getTitle();
-					$countCreatedColumnsFromConfig++;
-				}
-				$titles[] = $title;
 
-				// Convert data type to our data type
-				$dataTypes[] = $this->parseColumnDataType($secondRowCellIterator->current());
+				$rawColumnTitles[] = $titleRaw;
+				$rawColumnDataTypes[] = $dataType;
+
+				if ($shouldImport) {
+					$titles[] = $title;
+					$dataTypes[] = $dataType;
+					$columnFileIndices[] = $index;
+				}
+
 				if ($lastCellWasEmpty) {
 					$hasGapInTitles = true;
 				}
 				$lastCellWasEmpty = false;
 			} else {
 				$this->logger->debug('No cell given or cellValue is empty while loading columns for importing');
-				if ($cell->getDataType() === 'null') {
+				if ($cell && $cell->getDataType() === 'null') {
 					// LibreOffice generated XLSX doc may have more empty columns in the first row.
 					// Continue without increasing error count, but leave a marker to detect gaps in titles.
 					$lastCellWasEmpty = true;
@@ -817,11 +830,16 @@ class ImportService extends SuperService {
 			$this->countErrors++;
 		}
 
-		$this->rawColumnTitles = $titles;
-		$this->rawColumnDataTypes = $dataTypes;
+		$this->rawColumnTitles = $rawColumnTitles;
+		$this->rawColumnDataTypes = $rawColumnDataTypes;
 
 		try {
-			$this->columns = $this->columnService->findOrCreateColumnsByTitleForTableAsArray($this->tableId, $this->viewId, $titles, $dataTypes, $this->userId, $this->createUnknownColumns, $this->countCreatedColumns, $this->countMatchingColumns);
+			$result = $this->columnService->findOrCreateColumnsByTitleForTableAsArray($this->tableId, $this->viewId, $titles, $dataTypes, $this->userId, $this->createUnknownColumns, $this->countCreatedColumns, $this->countMatchingColumns);
+			foreach ($result as $resultIndex => $column) {
+				if ($column instanceof Column) {
+					$this->columns[$columnFileIndices[$resultIndex]] = $column;
+				}
+			}
 			if (!empty($this->columnsConfig)) {
 				$this->countMatchingColumns = $countMatchingColumnsFromConfig;
 				$this->countCreatedColumns = $countCreatedColumnsFromConfig;


### PR DESCRIPTION
## Reproducer
1. create table with 2 columns
2. start import csv file with 3 columns (2 match to existing columns, 1 extra). Unselect "create new columns"
3. ignore 3rd column
4. import

Expected result: file imported, ignored column not imported

Actual result: http 500 with an error `Call to a member function getId() on string in file '/var/www/html/apps/tables/lib/Service/ImportService.php' line 565`

https://github.com/user-attachments/assets/c8b01900-4158-4213-b635-9344f197e283

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
