### PR TITLE
fix(relation): edit row modal error and inline relation label display

### DIFF
--- a/src/modules/main/sections/MainWrapper.vue
+++ b/src/modules/main/sections/MainWrapper.vue
@@ -73,7 +73,7 @@ export default {
 		// To make nested dynamic keys reactive, you need to use a computed property or watch for changes.
 		const rows = computed(() => getRows.value(props.isView, props.element.id))
 		const columns = computed(() => getColumns.value(props.isView, props.element.id))
-		return { rows, columns }
+		return { rows, columns, dataStore: store }
 	},
 
 	data() {
@@ -195,7 +195,10 @@ export default {
 					isView: this.isView,
 				}
 				if (this.activeRowId) {
-					emit('tables:row:edit', { row: this.rows.find(r => r.id === this.activeRowId), columns: this.columns, isView: this.isView, elementId: this.element.id, element: this.element })
+					const row = this.dataStore.getRows(this.isView, this.element.id).find(r => r.id === this.activeRowId)
+					if (row) {
+						emit('tables:row:edit', { row, columns: this.dataStore.getColumns(this.isView, this.element.id), isView: this.isView, elementId: this.element.id, element: this.element })
+					}
 				}
 				this.localLoading = false
 			}

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<NcDialog v-if="showModal"
+	<NcDialog v-if="showModal && localRow"
 		data-cy="editRowModal"
 		:name="t('tables', 'Edit row')"
 		size="large"
@@ -172,9 +172,11 @@ export default {
 					return
 				}
 				if (this.$route.path.includes('/row/')) {
-					this.$router.replace(this.$route.path.split('/row/')[0])
+					const basePath = this.$route.path.split('/row/')[0]
+					this.$router.replace(basePath + '/row/' + newRow.id)
+				} else {
+					this.$router.push(this.$route.path + '/row/' + newRow.id)
 				}
-				this.$router.push(this.$route.path + '/row/' + newRow.id)
 				this.setActiveRowId(null)
 				this.loadValues()
 			}

--- a/src/shared/components/ncTable/partials/TableCellRelation.vue
+++ b/src/shared/components/ncTable/partials/TableCellRelation.vue
@@ -91,7 +91,7 @@ export default {
 		relationOptions() {
 			const activeElement = this.activeView || this.activeTable
 			if (activeElement) {
-				return Object.values(this.allRelations || {})
+				return Object.values(this.allRelations || {}).map(option => ({ ...option, id: parseInt(option.id) }))
 			}
 			return []
 		},
@@ -124,6 +124,17 @@ export default {
 			this.startEditing()
 			// Stop the event from propagating to avoid immediate click outside
 			event.stopPropagation()
+		},
+
+		startEditing() {
+			if (!this.canEditCell()) {
+				return false
+			}
+			this.isEditing = true
+			this.editValue = this.value ? parseInt(this.value) : null
+			this.$nextTick(() => {
+				this.$refs.editingContainer?.focus()
+			})
 		},
 
 		async saveChanges() {


### PR DESCRIPTION
This PR fixes two UX issues around relation columns:

### Bug 1
Opening a table URL that directly references a row in a relation table no longer throws the `fallbackFocus` focus-trap error. The edit row dialog now waits for the row data to be loaded, ensuring the modal has tabbable content before focus-trap activates.

#### Reproducer
1. Create a table with relation column
2. Open edit row, url is something like https://nextcloud.test/apps/tables/#/table/32/row/21905
3. Reload page or duplicate tab

Expected result: table loaded, modal edit opened for a row
Actual result: error, no modal edit opened, extra `/row/21905` appended to the url

### Bug 2
Inline editing a relation cell now shows the selected relation label instead of the raw row id. The editor parses the cell value and normalizes option ids to the same numeric type, aligning inline editing with the modal editor.

#### Reproducer
1. Create a table with relation column
2. Add a row with selected relation
3. Reload page
4. Start inline edit for relation column

Expected result: we can see label for selected relation
Actual result: there is an id of selected relation without label


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1d6ddca1-b5c2-4ff5-b45c-b7e1a873e7e1" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/9aa297af-9fee-422e-ad4b-5de283b7a5ee" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ab2589b9-c3f4-45da-8bd1-66742c78f551" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/239f9883-557b-4073-8656-1a094ddc3ba6" />



### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
