### PR TITLE
fix: date-only column display shifted one day behind in non-UTC timezones

### DIFF
--- a/src/shared/components/ncTable/mixins/columnsTypes/datetimeDate.js
+++ b/src/shared/components/ncTable/mixins/columnsTypes/datetimeDate.js
@@ -15,7 +15,7 @@ export default class DatetimeDateColumn extends AbstractDatetimeColumn {
 	}
 
 	formatValue(value) {
-		return Moment(value, 'YYYY-MM-DD HH:mm:ss').format('ll')
+		return Moment(value, 'YYYY-MM-DD').format('ll')
 	}
 
 	sort(mode, nextSorts) {


### PR DESCRIPTION
## Bug

The discovery of this bug and code to fix it were assisted by AI: GLM 5.2

Date-only columns display the date one day behind the entered value for users in timezones behind UTC (e.g. America/Toronto UTC-4).

**Steps to reproduce:**
1. Create a date-only column (not datetime, just date)
2. Enter a date (e.g. 2025-08-25)
3. The table view shows the previous day (e.g. Aug 24, 2025)
4. Clicking to edit shows the correct date — the bug is only in the display

## Root cause

In `datetimeDate.js`, `formatValue` parsed date-only values (e.g. `"2025-08-25"`) using the **datetime** format `'YYYY-MM-DD HH:mm:ss'`:

```js
formatValue(value) {
    return Moment(value, 'YYYY-MM-DD HH:mm:ss').format('ll')
}
```

Since the input string doesn't match the format (no time component), Moment.js falls back to ISO 8601 parsing, which interprets date-only strings as **UTC midnight**. When `.format('ll')` then converts to the user's local timezone, the date shifts back one day for users behind UTC.

## Fix

Use `'YYYY-MM-DD'` as the Moment parse format — this matches the actual stored value format and ensures local-timezone parsing:

```js
formatValue(value) {
    return Moment(value, 'YYYY-MM-DD').format('ll')
}
```

This is consistent with `getDateFormat()` in `TableCellDateTime.vue`, which already uses `'YYYY-MM-DD'` for the edit mode — explaining why editing showed the correct date while the cell display didn't.

Fixes #2705