### PR TITLE
fix: preserve view descriptions on scheme import

### DIFF
--- a/lib/Controller/ApiTablesController.php
+++ b/lib/Controller/ApiTablesController.php
@@ -262,6 +262,7 @@ class ApiTablesController extends AOCSController {
 
 				$this->viewService->update($newView->getId(), ViewUpdateInput::fromInputArray(
 					array_merge($inputColumnsArray, [
+						'description' => $view['description'] ?? '',
 						'sort' => $newSort,
 						'filter' => $newFilter,
 					])

--- a/lib/Model/ViewUpdateInput.php
+++ b/lib/Model/ViewUpdateInput.php
@@ -40,7 +40,7 @@ class ViewUpdateInput {
 		if ($this->technicalName !== null) {
 			yield ViewUpdatableParameters::TECHNICAL_NAME => $this->technicalName;
 		}
-		if ($this->description) {
+		if ($this->description !== null) {
 			yield ViewUpdatableParameters::DESCRIPTION => $this->description;
 		}
 		if ($this->emoji) {

--- a/tests/unit/Model/ViewUpdateInputTest.php
+++ b/tests/unit/Model/ViewUpdateInputTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Tests\Unit\Model;
+
+use OCA\Tables\Constants\ViewUpdatableParameters;
+use OCA\Tables\Model\ViewUpdateInput;
+use PHPUnit\Framework\TestCase;
+
+class ViewUpdateInputTest extends TestCase {
+
+	public function testUpdateDetailIncludesDescription(): void {
+		$input = ViewUpdateInput::fromInputArray(['description' => 'Imported view description']);
+		$updates = [];
+
+		foreach ($input->updateDetail() as $parameter => $value) {
+			$updates[$parameter->value] = $value;
+		}
+
+		$this->assertSame('Imported view description', $updates[ViewUpdatableParameters::DESCRIPTION->value]);
+	}
+
+	public function testUpdateDetailIncludesEmptyDescription(): void {
+		$input = ViewUpdateInput::fromInputArray(['description' => '']);
+		$updates = [];
+
+		foreach ($input->updateDetail() as $parameter => $value) {
+			$updates[$parameter->value] = $value;
+		}
+
+		$this->assertArrayHasKey(ViewUpdatableParameters::DESCRIPTION->value, $updates);
+		$this->assertSame('', $updates[ViewUpdatableParameters::DESCRIPTION->value]);
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve view descriptions when importing a table scheme via `createFromScheme()`.
- Treat empty-string descriptions as intentional updates in `ViewUpdateInput`, with unit coverage.

Fixes #2478

## Test plan
- [ ] Export a table with a view that has a description; import the scheme — view description should survive.
- [ ] Empty view description still clears/updates as intended.
- [ ] Run unit tests for `ViewUpdateInput` when PHP/Composer available.
