### PR TITLE
chore: add playwright to .nextcloudignore

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 /build/
 /cypress/
+/playwright/
+/playwright.config.ts
 /.devcontainer/
 /.git
 /.github


### PR DESCRIPTION
Same thing as cypress, do not ship tests to production
