### PR TITLE
fix(rows): let file picker and smart picker open above row modals #2515

### DIFF
--- a/src/modules/modals/CreateRow.vue
+++ b/src/modules/modals/CreateRow.vue
@@ -204,10 +204,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.modal-mask {
-	z-index: 9999;
-}
-
 .modal__content {
 	padding: 20px;
 

--- a/src/modules/modals/EditRow.vue
+++ b/src/modules/modals/EditRow.vue
@@ -294,10 +294,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.modal-mask {
-	z-index: 9999;
-}
-
 .modal__content {
 	padding: 20px;
 


### PR DESCRIPTION
The row modals overrode .modal-mask to z-index `9999`, one level above the NcModal default of `9998`. Since NcModal teleports to body, pickers opened from a rich text cell shared that stacking context and always painted underneath. `CreateRow.vue` carried the same override as `EditRow.vue`.

Fixes #2515

Assisted-by: ClaudeCode:claude-opus-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
