### PR TITLE
fix: set default cell value using column's parseValue function

### DIFF
--- a/src/shared/components/ncTable/NcTable.vue
+++ b/src/shared/components/ncTable/NcTable.vue
@@ -334,12 +334,9 @@ export default {
 						cell = row.data.find(item => item && item.columnId === column.id)
 					}
 
-					// if we don't have a value for this cell
 					if (cell === undefined) {
-						if (searchString) {
-							searchStatus = false
-						}
-						cell = { columnId: column.id, value: null }
+						const defaultValue = typeof column.default === 'function' ? column.default() : null
+						cell = { columnId: column.id, value: column.parseValue(defaultValue) }
 					}
 					// cleanup possible old markers
 					delete cell.searchStringFound


### PR DESCRIPTION
A cell that has never been given a value has no stored entry and inherits the column default when read. The display (`TableRow.vue` `getCellValue`) and the server-side View filter (`Row2Mapper.php` `includeDefault`) both honor that default, but the quick filter and search in the default table view (`NcTable.vue` `getSearchedAndFilteredRows`) did not. They read an unset cell as `null`, so rows that visibly show their default value were dropped, and the same filter returned fewer rows in the table than in an equivalent View. The fix falls back to the column default for an unset cell, the same way the display does. `parseValue` converts the stored default form (e.g. `"0"`) into the cell form (`0`) so lookups and comparisons match. Client-side only, no backend or migration change.

##### to reproduce:

1. Create a table and add several rows.
2. Add a selection column "Status" with options "Active" and "Inactive" and a default of "Active". Add it after the rows already exist, so those rows have no stored value for it and all display "Active".
3. Set two rows explicitly to "Active" and one to "Inactive". Leave the rest untouched.
4. In the default table view, filter Status "is equal" to "Active". Only the two explicit rows appear.
5. Apply the same filter in a View. Every row showing "Active" appears, including the untouched ones.

With 10 untouched rows, 2 explicit "Active", and 1 explicit "Inactive", the table filter returns 2 while the View returns 12. After the fix both return 12.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1691" height="899" alt="Capture d’écran 2026-08-24 à 20 37 22" src="https://github.com/user-attachments/assets/e62ba8a8-c776-4649-aa22-3d846acf28b4" />  |  <img width="1691" height="899" alt="Capture d’écran 2026-08-24 à 20 33 25" src="https://github.com/user-attachments/assets/5f4bf366-0a43-48b8-ab5a-a3c851bda5b9" />


### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
