### PR TITLE
fix(search): search as the user the provider is given

### DIFF
--- a/lib/Search/SearchTablesProvider.php
+++ b/lib/Search/SearchTablesProvider.php
@@ -79,7 +79,7 @@ class SearchTablesProvider implements IProvider {
 		);
 
 		// look for tables
-		$tables = $this->tableService->search($term, $limit, $offset);
+		$tables = $this->tableService->search($term, $limit, $offset, $user->getUID());
 		$formattedTablesResults = array_map(fn (Table $table): SearchResultEntry => new SearchResultEntry(
 			$appIconUrl,
 			$table->getEmoji() . ' ' . $table->getTitle(),
@@ -90,7 +90,7 @@ class SearchTablesProvider implements IProvider {
 		), $tables);
 
 		// look for views
-		$views = $this->viewService->search($term, $limit, $offset);
+		$views = $this->viewService->search($term, $limit, $offset, $user->getUID());
 		$formattedViewResults = array_map(fn (View $view): SearchResultEntry => new SearchResultEntry(
 			$viewIconUrl,
 			$view->getEmoji() . ' ' . $view->getTitle(),

--- a/tests/unit/Search/SearchTablesProviderTest.php
+++ b/tests/unit/Search/SearchTablesProviderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Tables\Search;
+
+use OCA\Tables\Service\TableService;
+use OCA\Tables\Service\ViewService;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\ISearchQuery;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SearchTablesProviderTest extends TestCase {
+	private SearchTablesProvider $provider;
+	private MockObject $tableService;
+	private MockObject $viewService;
+	private MockObject $appManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->tableService = $this->createMock(TableService::class);
+		$this->viewService = $this->createMock(ViewService::class);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$l10n->method('n')->willReturnArgument(0);
+
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('imagePath')->willReturn('');
+		$urlGenerator->method('getAbsoluteURL')->willReturn('');
+		$urlGenerator->method('linkToRoute')->willReturn('');
+
+		$this->provider = new SearchTablesProvider(
+			$this->appManager,
+			$l10n,
+			$this->viewService,
+			$this->tableService,
+			$urlGenerator,
+		);
+	}
+
+	private function query(): MockObject {
+		$query = $this->createMock(ISearchQuery::class);
+		$query->method('getLimit')->willReturn(10);
+		$query->method('getTerm')->willReturn('budget');
+		$query->method('getCursor')->willReturn(null);
+
+		return $query;
+	}
+
+	private function user(string $uid): MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return $user;
+	}
+
+	/**
+	 * The provider is handed the user to search as, and both services accept one. Without passing
+	 * it they fall back to the session user, so a caller searching on behalf of someone else
+	 * silently gets its own results.
+	 */
+	public function testSearchesAsTheGivenUser(): void {
+		$this->appManager->method('isEnabledForUser')->willReturn(true);
+
+		$this->tableService->expects($this->once())
+			->method('search')
+			->with('budget', 10, 0, 'alice')
+			->willReturn([]);
+
+		$this->viewService->expects($this->once())
+			->method('search')
+			->with('budget', 10, 0, 'alice')
+			->willReturn([]);
+
+		$this->provider->search($this->user('alice'), $this->query());
+	}
+
+	public function testReturnsNothingWhenTheAppIsDisabledForTheUser(): void {
+		$this->appManager->method('isEnabledForUser')->willReturn(false);
+
+		$this->tableService->expects($this->never())->method('search');
+		$this->viewService->expects($this->never())->method('search');
+
+		$result = $this->provider->search($this->user('alice'), $this->query());
+
+		$this->assertSame([], $result->jsonSerialize()['entries']);
+	}
+}


### PR DESCRIPTION
Both services already take the parameter, so this passes the argument that already exists rather than changing any API.

## The problem

SearchTablesProvider receives the account to search as, but calls TableService::search() and ViewService::search() without it. Both accept an optional $userId and fall back to PermissionsService::preCheckUserId(null), which resolves the session user so any caller searching on behalf of someone else silently received its own results instead.

I assume this is not intentional, just 'good enough' for unified search.

Some more details: 

- `lib/Search/SearchTablesProvider.php:82` and `:93` call  `TableService::search($term, $limit, $offset)` and `ViewService::search($term, $limit, $offset)`.
- Both signatures end in `?string $userId = null` and, when null, call  `PermissionsService::preCheckUserId(null)` → `$this->userId`, the session user.
- The provider's own `search(IUser $user, ISearchQuery $query)` is handed the account to search as, and already uses it for the `isEnabledForUser()` check on the line above.

Through the unified search UI the session user and `$user` are always the same, so nothing is visibly broken today. But it breaks when you need to search on behalf of another account, like a background job, or a compliance tool that must search within a defined set of accounts.

## this PR

The change in this PR is very simple:

Pass `$user->getUID()` to both calls. No API change; both services already accept it.

## Tests

New `tests/unit/Search/SearchTablesProviderTest.php`:
- asserts both services are called with the given uid
- asserts neither is called when the app is disabled for that user

Verified the test fails against the unfixed provider and passes with it.

**Checks run**

- `phpunit -c tests/unit/phpunit.xml --filter SearchTablesProviderTest` → 2 passed (run inside the dev container; the bootstrap needs a database)
- `php -l` on both files
- `php-cs-fixer --dry-run` on both files → no violations

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

The change and its test were produced with Claude Code (claude-opus-5).
