### PR TITLE
Fix: add contains-item filter support in views

### DIFF
--- a/lib/Constants/FilterOperator.php
+++ b/lib/Constants/FilterOperator.php
@@ -12,6 +12,7 @@ enum FilterOperator: string {
 	case BEGINS_WITH = 'begins-with';
 	case ENDS_WITH = 'ends-with';
 	case CONTAINS = 'contains';
+	case CONTAINS_ITEM = 'contains-item';
 	case DOES_NOT_CONTAIN = 'does-not-contain';
 	case IS_EQUAL = 'is-equal';
 	case IS_NOT_EQUAL = 'is-not-equal';

--- a/lib/Controller/Api1Controller.php
+++ b/lib/Controller/Api1Controller.php
@@ -398,7 +398,7 @@ class Api1Controller extends ApiController {
 	 *      columns?: list<int>,
 	 *      columnSettings?: list<array{columnId?: int, order?: int, readonly?: bool, mandatory?: bool}>,
 	 *      sort?: list<array{columnId: int, mode: 'ASC'|'DESC'}>,
-	 *      filter?: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}>>
+	 *      filter?: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'contains-item'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float|list<array{id: int, label: string, uuid?: string}>}>>
 	 *  } $data fields of the view with their new values
 	 * @return DataResponse<Http::STATUS_OK, TablesView, array{}>|DataResponse<Http::STATUS_FORBIDDEN|Http::STATUS_NOT_FOUND|Http::STATUS_BAD_REQUEST|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -342,6 +342,9 @@ class Row2Mapper {
 	private function replacePlaceholderValues(array &$filters, string $userId): void {
 		foreach ($filters as &$filterGroup) {
 			foreach ($filterGroup as &$filter) {
+				if (is_array($filter['value'])) {
+					continue;
+				}
 				if (str_starts_with((string)$filter['value'], '@')) {
 					$columnId = (int)($filter['columnId'] ?? 0);
 					$column = $columnId > 0 ? $this->columnMapper->find($columnId) : null;
@@ -489,11 +492,24 @@ class Row2Mapper {
 						$filterItems = [(string)$value];
 					}
 				}
+
+				// The value may be a list of option objects (e.g. from the UI)
+				// or a list of plain ids. Make sure we work with the option ids.
+				$filterItems = array_map(static function ($filterItem) {
+					if (is_array($filterItem) && isset($filterItem['id'])) {
+						return (string)$filterItem['id'];
+					}
+					if (is_object($filterItem) && isset($filterItem->id)) {
+						return (string)$filterItem->id;
+					}
+					return (string)$filterItem;
+				}, $filterItems);
+
 				$filterExpressions = [];
 				$includeDefault = false;
 				foreach ($filterItems as $filterItem) {
 					if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
-						$filterItem = str_replace(['"', '\''], '', (string)$filterItem);
+						$filterItem = str_replace(['"', '\''], '', $filterItem);
 						$filterExpressions[] = $qb2->expr()->orX(
 							$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($filterItem) . ']')),
 							$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($filterItem) . ',%')),

--- a/lib/Db/Row2Mapper.php
+++ b/lib/Db/Row2Mapper.php
@@ -478,6 +478,36 @@ class Row2Mapper {
 				}
 				$filterExpression = $qb->expr()->iLike('value', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($value) . '%', $paramType));
 				break;
+			case 'contains-item':
+				$filterItems = $value;
+				if (!is_array($filterItems)) {
+					$filterItems = json_decode((string)$filterItems, true) ?? null;
+					if (is_string($filterItems)) {
+						$filterItems = json_decode($filterItems, true) ?? null;
+					}
+					if (!is_array($filterItems) || $filterItems === []) {
+						$filterItems = [(string)$value];
+					}
+				}
+				$filterExpressions = [];
+				$includeDefault = false;
+				foreach ($filterItems as $filterItem) {
+					if ($column->getType() === 'selection' && $column->getSubtype() === 'multi') {
+						$filterItem = str_replace(['"', '\''], '', (string)$filterItem);
+						$filterExpressions[] = $qb2->expr()->orX(
+							$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($filterItem) . ']')),
+							$qb->expr()->iLike('value', $qb->createNamedParameter('[' . $this->db->escapeLikeParameter($filterItem) . ',%')),
+							$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($filterItem) . ']%')),
+							$qb->expr()->iLike('value', $qb->createNamedParameter('%,' . $this->db->escapeLikeParameter($filterItem) . ',%'))
+						);
+						$includeDefault = $includeDefault || str_contains((string)($defaultValue ?? ''), $filterItem);
+					} else {
+						$filterExpressions[] = $qb->expr()->eq('value', $qb->createNamedParameter($filterItem, $paramType));
+						$includeDefault = $includeDefault || ((string)($defaultValue ?? '') === (string)$filterItem);
+					}
+				}
+				$filterExpression = $qb2->expr()->orX(...$filterExpressions);
+				break;
 			case 'does-not-contain':
 				if (is_array($value) && $column->getType() === Column::TYPE_USERGROUP) {
 					$filterExpressions = [];

--- a/lib/Db/View.php
+++ b/lib/Db/View.php
@@ -185,7 +185,7 @@ class View extends EntitySuper implements JsonSerializable {
 
 	/**
 	 * @psalm-suppress MismatchingDocblockReturnType
-	 * @return list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}>>
+	 * @return list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'contains-item'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float|list<array{id: int, label: string, uuid?: string}>}>>
 	 */
 	public function getFilterArray():array {
 		$rawFilters = $this->getArray($this->getFilter());

--- a/lib/Model/ViewUpdateInput.php
+++ b/lib/Model/ViewUpdateInput.php
@@ -70,7 +70,7 @@ class ViewUpdateInput {
 	 *     columns?: list<int>,
 	 *     columnSettings?: list<array{columnId?: int, order?: int, readonly?: bool, mandatory?: bool}>,
 	 *     sort?: list<array{columnId: int, mode: 'ASC'|'DESC'}>,
-	 *     filter?: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}>>,
+	 *     filter?: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'contains-item'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float|list<array{id: int, label: string, uuid?: string}>}>>,
 	 *     sidebarOrder?: int
 	 * } $data
 	 * @param array $columnsMap

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -31,7 +31,7 @@ namespace OCA\Tables;
  *  columns: list<int>,
  *  columnSettings:list<array{columnId: int, order: int, readonly: bool}>,
  *  sort: list<array{columnId: int, mode: 'ASC'|'DESC'}>,
- *  filter: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float}>>,
+ *  filter: list<list<array{columnId: int, operator: 'begins-with'|'ends-with'|'contains'|'does-not-contain'|'contains-item'|'is-equal'|'is-not-equal'|'is-greater-than'|'is-greater-than-or-equal'|'is-lower-than'|'is-lower-than-or-equal'|'is-empty', value: string|int|float|list<array{id: int, label: string, uuid?: string}>}>>,
  * 	isShared: bool,
  *	favorite: bool,
  * 	onSharePermissions: ?array{

--- a/lib/Service/ValueObject/Filter.php
+++ b/lib/Service/ValueObject/Filter.php
@@ -16,7 +16,7 @@ class Filter implements JsonSerializable {
 	public function __construct(
 		protected readonly int $columnId,
 		protected readonly FilterOperator $operator,
-		protected readonly string $value,
+		protected readonly mixed $value,
 	) {
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -1144,6 +1144,7 @@
                                             "ends-with",
                                             "contains",
                                             "does-not-contain",
+                                            "contains-item",
                                             "is-equal",
                                             "is-not-equal",
                                             "is-greater-than",
@@ -1165,6 +1166,28 @@
                                             {
                                                 "type": "number",
                                                 "format": "double"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "id",
+                                                        "label"
+                                                    ],
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                        },
+                                                        "label": {
+                                                            "type": "string"
+                                                        },
+                                                        "uuid": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         ]
                                     }
@@ -2385,6 +2408,7 @@
                                                                     "ends-with",
                                                                     "contains",
                                                                     "does-not-contain",
+                                                                    "contains-item",
                                                                     "is-equal",
                                                                     "is-not-equal",
                                                                     "is-greater-than",
@@ -2406,6 +2430,28 @@
                                                                     {
                                                                         "type": "number",
                                                                         "format": "double"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "required": [
+                                                                                "id",
+                                                                                "label"
+                                                                            ],
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "integer",
+                                                                                    "format": "int64"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "uuid": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
                                                                     }
                                                                 ]
                                                             }

--- a/playwright/e2e/view-filtering-selection.spec.ts
+++ b/playwright/e2e/view-filtering-selection.spec.ts
@@ -25,7 +25,7 @@ const tableTitle = 'View filtering test table'
 interface FilterConfig {
   column: string;
   operator: string;
-  value: string;
+  value: string | string[];
 }
 
 type FilterGroup = FilterConfig[];
@@ -72,12 +72,15 @@ async function setupFilteringTable(page: Page) {
 	await addRow('sevenths row', 'sel2', ['A', 'C', 'B', 'D'], false)
 }
 
-async function selectFilterOption(page: Page, index: number, title: string) {
+async function selectFilterOption(page: Page, index: number, title: string | string[]) {
+	const titles = Array.isArray(title) ? title : [title]
 	await page
 		.locator('.modal-container .filter-group .v-select.select')
 		.nth(index)
 		.click()
-	await page.locator(`ul.vs__dropdown-menu li span[title="${title}"]`).click()
+	for (const t of titles) {
+		await page.locator(`ul.vs__dropdown-menu li span[title="${t}"]`).click()
+	}
 }
 
 async function createFilteredView(
@@ -352,6 +355,72 @@ test.describe('Filtering in a view by selection columns', () => {
 			'sevenths row',
 		])
 		await expectMissingRows(page, ['second row', 'fourth row'])
+	})
+
+	test('Filter view for single selection - contains items with one value', async () => {
+		await loadTable(page, tableTitle)
+		await createFilteredView(page, 'Filter single selection contains items 1', [
+			[{ column: 'selection', operator: 'Contains items', value: 'sel2' }],
+		])
+
+		await expectVisibleRows(page, ['second row', 'sevenths row'])
+		await expectMissingRows(page, [
+			'first row',
+			'third row',
+			'fourth row',
+			'fifths row',
+			'sixths row',
+		])
+	})
+
+	test('Filter view for single selection - contains items with few values', async () => {
+		await loadTable(page, tableTitle)
+		await createFilteredView(page, 'Filter single selection contains items 2', [
+			[{ column: 'selection', operator: 'Contains items', value: ['sel1', 'sel2'] }],
+		])
+
+		await expectVisibleRows(page, [
+			'first row',
+			'second row',
+			'sixths row',
+			'sevenths row',
+		])
+		await expectMissingRows(page, [
+			'third row',
+			'fourth row',
+			'fifths row',
+		])
+	})
+
+	test('Filter view for multi selection - contains items with one value', async () => {
+		await loadTable(page, tableTitle)
+		await createFilteredView(page, 'Filter multi selection contains items 1', [
+			[{ column: 'multi selection', operator: 'Contains items', value: 'A' }],
+		])
+
+		await expectVisibleRows(page, ['first row', 'fourth row', 'sevenths row'])
+		await expectMissingRows(page, [
+			'second row',
+			'third row',
+			'fifths row',
+			'sixths row',
+		])
+	})
+
+	test('Filter view for multi selection - contains items with few values', async () => {
+		await loadTable(page, tableTitle)
+		await createFilteredView(page, 'Filter multi selection contains items 2', [
+			[{ column: 'multi selection', operator: 'Contains items', value: ['A', 'B'] }],
+		])
+
+		await expectVisibleRows(page, [
+			'first row',
+			'second row',
+			'third row',
+			'fourth row',
+			'sevenths row',
+		])
+		await expectMissingRows(page, ['fifths row', 'sixths row'])
 	})
 
 	test('Filter view for selection check', async () => {

--- a/playwright/e2e/view-filtering-selection.spec.ts
+++ b/playwright/e2e/view-filtering-selection.spec.ts
@@ -74,11 +74,12 @@ async function setupFilteringTable(page: Page) {
 
 async function selectFilterOption(page: Page, index: number, title: string | string[]) {
 	const titles = Array.isArray(title) ? title : [title]
-	await page
-		.locator('.modal-container .filter-group .v-select.select')
-		.nth(index)
-		.click()
 	for (const t of titles) {
+		await page
+			.locator('.modal-container .filter-group .v-select.select')
+			.nth(index)
+			.locator('.vs__open-indicator')
+			.click()
 		await page.locator(`ul.vs__dropdown-menu li span[title="${t}"]`).click()
 	}
 }

--- a/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
+++ b/src/modules/main/partials/editViewPartials/filter/FilterEntry.vue
@@ -30,6 +30,7 @@
 				v-model="searchValue"
 				class="select-field"
 				:options="magicFields"
+				:multiple="isContainsItemOperator"
 				:loading="relationsLoading"
 				:aria-label-combobox="getValuePlaceholder"
 				:placeholder="getValuePlaceholder"
@@ -73,6 +74,7 @@ import Moment from '@nextcloud/moment'
 import DeleteOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { ColumnTypes } from '../../../../../shared/components/ncTable/mixins/columnHandler.js'
 import { AdditionalInputTypes } from '../../../../../shared/components/ncTable/mixins/magicFields.js'
+import { FilterIds } from '../../../../../shared/components/ncTable/mixins/filter.js'
 import { useDataStore } from '../../../../../store/data.js'
 
 export default {
@@ -119,6 +121,11 @@ export default {
 		},
 		searchValue: {
 			get() {
+				// ContainsItem expects an array of selected option objects
+				if (this.isContainsItemOperator) {
+					return Array.isArray(this.filterEntry?.value) ? this.filterEntry.value : []
+				}
+
 				// if no value is set, just return ''
 				if (this.filterEntry?.value === null || this.filterEntry?.value === '') {
 					return ''
@@ -133,7 +140,9 @@ export default {
 				return this.filterEntry.value
 			},
 			set(searchValue) {
-				if (typeof searchValue === 'object' && searchValue?.id) {
+				if (this.isContainsItemOperator) {
+					this.mutableFilterEntry.value = Array.isArray(searchValue) ? searchValue : []
+				} else if (typeof searchValue === 'object' && searchValue?.id) {
 					this.mutableFilterEntry.value = searchValue.id
 				} else if (typeof searchValue === 'string') {
 					this.mutableFilterEntry.value = searchValue
@@ -173,6 +182,9 @@ export default {
 				return []
 			}
 		},
+		isContainsItemOperator() {
+			return this.selectedOperator?.id === FilterIds.ContainsItem
+		},
 		relationsLoading() {
 			if (this.selectedColumn?.type === ColumnTypes.Relation && this.columns?.length > 0) {
 				const dataStore = useDataStore()
@@ -199,6 +211,9 @@ export default {
 					return fields
 				}
 			} else if (this.selectedColumn && this.selectedColumn.type.substr(0, 9) === 'selection') {
+				if (this.isContainsItemOperator) {
+					return this.selectedColumn.selectionOptions || []
+				}
 				const options = []
 				this.selectedColumn.selectionOptions?.forEach(item => {
 					options.push({
@@ -278,7 +293,7 @@ export default {
 	},
 	methods: {
 		getMagicFieldId() {
-			if (!this.filterEntry?.value) return null
+			if (!this.filterEntry?.value || typeof this.filterEntry.value !== 'string') return null
 			return this.filterEntry.value.split(':')[0]
 		},
 		applyAdditionalInput() {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -1387,8 +1387,13 @@ export type components = {
                 /** Format: int64 */
                 readonly columnId: number;
                 /** @enum {string} */
-                readonly operator: "begins-with" | "ends-with" | "contains" | "does-not-contain" | "is-equal" | "is-not-equal" | "is-greater-than" | "is-greater-than-or-equal" | "is-lower-than" | "is-lower-than-or-equal" | "is-empty";
-                readonly value: string | number;
+                readonly operator: "begins-with" | "ends-with" | "contains" | "does-not-contain" | "contains-item" | "is-equal" | "is-not-equal" | "is-greater-than" | "is-greater-than-or-equal" | "is-lower-than" | "is-lower-than-or-equal" | "is-empty";
+                readonly value: string | number | readonly {
+                    /** Format: int64 */
+                    readonly id: number;
+                    readonly label: string;
+                    readonly uuid?: string;
+                }[];
             }[])[];
             readonly isShared: boolean;
             readonly favorite: boolean;
@@ -2078,8 +2083,13 @@ export interface operations {
                             /** Format: int64 */
                             readonly columnId: number;
                             /** @enum {string} */
-                            readonly operator: "begins-with" | "ends-with" | "contains" | "does-not-contain" | "is-equal" | "is-not-equal" | "is-greater-than" | "is-greater-than-or-equal" | "is-lower-than" | "is-lower-than-or-equal" | "is-empty";
-                            readonly value: string | number;
+                            readonly operator: "begins-with" | "ends-with" | "contains" | "does-not-contain" | "contains-item" | "is-equal" | "is-not-equal" | "is-greater-than" | "is-greater-than-or-equal" | "is-lower-than" | "is-lower-than-or-equal" | "is-empty";
+                            readonly value: string | number | readonly {
+                                /** Format: int64 */
+                                readonly id: number;
+                                readonly label: string;
+                                readonly uuid?: string;
+                            }[];
                         }[])[];
                     };
                 };

--- a/tests/integration/features/APIv1.feature
+++ b/tests/integration/features/APIv1.feature
@@ -600,6 +600,63 @@ Feature: APIv1
       | Banana  |
       | Orange  |
 
+  @api1 @views @view-filters
+  Scenario: Save and apply contains-item filter for single selection column
+    Given table "Team Features" with emoji "✨" exists for user "participant1" as "team-features"
+    Then column "team" exists with following properties
+      | type             | selection                                                                                   |
+      | mandatory        | 1                                                                                           |
+      | description      | The team responsible                                                                        |
+      | selectionOptions | [{"id":0,"label":"Office team"},{"id":1,"label":"Dev team"},{"id":2,"label":"Design team"}] |
+    Then row exists with following values
+      | team | 0 |
+    Then row exists with following values
+      | team | 1 |
+    Then row exists with following values
+      | team | 2 |
+    And user "participant1" create view "Office or Design" with emoji "👔" for "team-features" as "single-team-view"
+    When user "participant1" sets columnSettings "team" to view "single-team-view"
+    And user "participant1" sets filter to view "single-team-view"
+      | column | operator      | value                                                           |
+      | team   | contains-item | [{"id":0,"label":"Office team"},{"id":2,"label":"Design team"}] |
+    Then view "single-team-view" has exactly the following rows
+      | team |
+      | 0    |
+      | 2    |
+
+  @api1 @views @view-filters
+  Scenario: Save and apply contains-item filter for multi selection column
+    Given table "Team Skills" with emoji "🛠" exists for user "participant1" as "team-skills"
+    Then column "member" exists with following properties
+      | type        | text            |
+      | subtype     | line            |
+      | mandatory   | 1               |
+      | description | The team member |
+    Then column "skills" exists with following properties
+      | type             | selection                                                                                                    |
+      | subtype          | multi                                                                                                        |
+      | mandatory        | 1                                                                                                            |
+      | description      | The skills available                                                                                         |
+      | selectionOptions | [{"id":0,"label":"Backend"},{"id":1,"label":"Frontend"},{"id":2,"label":"DevOps"},{"id":3,"label":"Design"}] |
+    Then row exists with following values
+      | member | Alice          |
+      | skills | Backend,DevOps |
+    Then row exists with following values
+      | member | Bob             |
+      | skills | Frontend,DevOps |
+    Then row exists with following values
+      | member | Charlie         |
+      | skills | Frontend,Design |
+    And user "participant1" create view "Backend or DevOps" with emoji "👷" for "team-skills" as "backend-devops-view"
+    When user "participant1" sets columnSettings "member" to view "backend-devops-view"
+    And user "participant1" sets filter to view "backend-devops-view"
+      | column | operator      | value                                                  |
+      | skills | contains-item | [{"id":0,"label":"Backend"},{"id":2,"label":"DevOps"}] |
+    Then view "backend-devops-view" has exactly the following rows
+      | member |
+      | Alice  |
+      | Bob    |
+
   @api1 @views @technical-name
   Scenario: Create and update view with technical name
     Given table "View technical name test" with emoji "🔧" exists for user "participant1" as "tech-name-table"

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1580,9 +1580,12 @@ class FeatureContext implements Context {
 	 */
 	public function createRow(?TableNode $properties = null): void {
 		$props = [];
+		$expectedValues = [];
 		foreach ($properties->getRows() as $row) {
-			$columnId = $this->collectionManager->getByAlias('column', $row[0])['id'];
+			$column = $this->collectionManager->getByAlias('column', $row[0]);
+			$columnId = $column['id'];
 			$props[$columnId] = $row[1];
+			$expectedValues[$columnId] = $this->normalizeExpectedCellValue($column, $row[1]);
 		}
 
 		$this->sendRequest(
@@ -1596,7 +1599,7 @@ class FeatureContext implements Context {
 
 		Assert::assertEquals(200, $this->response->getStatusCode());
 		foreach ($newRow['data'] as $cell) {
-			Assert::assertEquals($props[$cell['columnId']], $cell['value']);
+			$this->assertRowCellValue($expectedValues[$cell['columnId']], $cell['value']);
 		}
 
 		$this->sendRequest(
@@ -1607,18 +1610,45 @@ class FeatureContext implements Context {
 		$rowToVerify = $this->getDataFromResponse($this->response);
 		Assert::assertEquals(200, $this->response->getStatusCode());
 		foreach ($rowToVerify['data'] as $cell) {
-			// I am afraid this is usergroupcolumn specific, but not generic
-			if (is_array($cell['value'])) {
-				$retrieved = json_encode(array_reduce($cell['value'], function (array $carry, string $item): array {
-					$carry[] = json_decode($item, true);
-					return $carry;
-				}, []));
-			} else {
-				$retrieved = $cell['value'];
-			}
-
-			Assert::assertEquals($props[$cell['columnId']], $retrieved);
+			$this->assertRowCellValue($expectedValues[$cell['columnId']], $cell['value']);
 		}
+	}
+
+	/**
+	 * @param array $column
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	private function normalizeExpectedCellValue(array $column, mixed $value): mixed {
+		if (($column['type'] ?? null) === 'selection' && ($column['subtype'] ?? null) === 'multi' && is_string($value)) {
+			$labels = array_map('trim', explode(',', $value));
+			$ids = [];
+			foreach ($column['selectionOptions'] ?? [] as $option) {
+				if (in_array($option['label'], $labels, true)) {
+					$ids[] = (int)$option['id'];
+				}
+			}
+			sort($ids, SORT_NUMERIC);
+			return $ids;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param mixed $expected
+	 * @param mixed $actual
+	 * @return void
+	 */
+	private function assertRowCellValue(mixed $expected, mixed $actual): void {
+		if (is_array($actual) && !is_array($expected)) {
+			$actual = json_encode(array_reduce($actual, function (array $carry, string $item): array {
+				$carry[] = json_decode($item, true);
+				return $carry;
+			}, []));
+		}
+
+		Assert::assertEquals($expected, $actual);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -3198,11 +3198,18 @@ class FeatureContext implements Context {
 			$columnId = $this->collectionManager->getByAlias('column', $row[0])['id'];
 
 			// Add filter condition to array
+			$value = $row[2];
+			if (str_starts_with((string)$value, '[') || str_starts_with((string)$value, '{')) {
+				$decoded = json_decode((string)$value, true);
+				if (json_last_error() === JSON_ERROR_NONE) {
+					$value = $decoded;
+				}
+			}
 			$filterArray[] = [
 				[
 					'columnId' => $columnId,
 					'operator' => $row[1],
-					'value' => $row[2]
+					'value' => $value
 				]
 			];
 		}

--- a/tests/unit/Db/Row2MapperFilterTest.php
+++ b/tests/unit/Db/Row2MapperFilterTest.php
@@ -230,15 +230,27 @@ class Row2MapperFilterTest extends \OCA\Tables\Tests\Unit\Database\DatabaseTestC
 			],
 
 			'status contains-item Active,Pending' => [
-				[['columnId' => 'status', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				[['columnId' => 'status', 'operator' => 'contains-item', 'value' => '[{"id":0,"label":"Active"},{"id":2,"label":"Pending"}]']],
 				['Alice', 'Charlie', 'Diana', 'Eve'],
 				'Filter status containing one of Active (0) or Pending (2)'
 			],
 
 			'skills contains-item PHP,SQL' => [
-				[['columnId' => 'skills', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				[['columnId' => 'skills', 'operator' => 'contains-item', 'value' => '[{"id":0,"label":"PHP"},{"id":2,"label":"SQL"}]']],
 				['Alice'],
 				'Filter skills containing one of PHP (0) or SQL (2)'
+			],
+
+			'status contains-item Active,Pending by ids' => [
+				[['columnId' => 'status', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				['Alice', 'Charlie', 'Diana', 'Eve'],
+				'Filter status containing one of Active (0) or Pending (2) by plain ids'
+			],
+
+			'skills contains-item PHP,SQL by ids' => [
+				[['columnId' => 'skills', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				['Alice'],
+				'Filter skills containing one of PHP (0) or SQL (2) by plain ids'
 			],
 
 			// Selection checkbox column (is_available)

--- a/tests/unit/Db/Row2MapperFilterTest.php
+++ b/tests/unit/Db/Row2MapperFilterTest.php
@@ -229,6 +229,18 @@ class Row2MapperFilterTest extends \OCA\Tables\Tests\Unit\Database\DatabaseTestC
 				'Filter non-empty skills'
 			],
 
+			'status contains-item Active,Pending' => [
+				[['columnId' => 'status', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				['Alice', 'Charlie', 'Diana', 'Eve'],
+				'Filter status containing one of Active (0) or Pending (2)'
+			],
+
+			'skills contains-item PHP,SQL' => [
+				[['columnId' => 'skills', 'operator' => 'contains-item', 'value' => '[0,2]']],
+				['Alice'],
+				'Filter skills containing one of PHP (0) or SQL (2)'
+			],
+
 			// Selection checkbox column (is_available)
 			'available is checked' => [
 				[['columnId' => 'is_available', 'operator' => 'is-equal', 'value' => '@checked']],


### PR DESCRIPTION
This is a follow-up for the #2387. I've realized that BE support is missing for `contains-item` filter.


### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
