### PR TITLE
docs: describe the Vue 3 stack in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,9 @@ Routes are defined in `appinfo/routes.php` (~100 routes covering the full REST A
 
 ### Frontend (Vue.js — `src/`)
 
-Single-page app built with **Vue 2.7**, **Vue Router 3**, and **Pinia** (state management). Compiled with **Vite**.
+Single-page app built with **Vue 3**, **Vue Router 4**, and **Pinia** (state management). Compiled with **Vite**.
+
+Components use the Options API. Lifecycle hooks follow the Vue 3 names — use `beforeUnmount`, not the Vue 2 `beforeDestroy`.
 
 - **`src/store/store.js`** — Primary Pinia store (tables, columns, views, shares, contexts).
 - **`src/store/data.js`** — Row/cell data state.


### PR DESCRIPTION
Follow-up to #2836.

`AGENTS.md` still described the frontend as **Vue 2.7** with **Vue Router 3**. That stopped being true when #2836 migrated the app to Vue 3 — `package.json` now pins `vue@^3.5.13` and `vue-router@^4.5.1`.

Also notes that lifecycle hooks use the Vue 3 names. This is the part that bites: an agent following the outdated description writes `beforeDestroy`, which Vue 3 simply never calls — no error, no warning, just a subscription that is never cleaned up. All 12 components in `src/` already use `beforeUnmount`.

Docs only, no code change.

## AI tool use

This change was prepared with Claude Code (`claude-opus-5`) and is disclosed via the `Assisted-by` trailer on the commit, per the [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md). It was reviewed and submitted by me.
