### PR TITLE
fix: make delete table actions use destructive styling

### DIFF
--- a/src/modules/modals/EditTable.vue
+++ b/src/modules/modals/EditTable.vue
@@ -60,12 +60,12 @@
 			</div>
 			<div class="row">
 				<div class="fix-col-4 space-T justify-between">
-					<NcButton v-if="!prepareDeleteTable" type="error" data-cy="editTableDeleteBtn" @click="prepareDeleteTable = true">
+					<NcButton v-if="!prepareDeleteTable" variant="error" data-cy="editTableDeleteBtn" @click="prepareDeleteTable = true">
 						{{ t('tables', 'Delete') }}
 					</NcButton>
 					<NcButton v-if="prepareDeleteTable"
 						:wide="true"
-						type="error"
+						variant="error"
 						data-cy="editTableConfirmDeleteBtn"
 						@click="actionDeleteTable">
 						{{ t('tables', 'I really want to delete this table!') }}

--- a/src/modules/navigation/partials/NavigationTableItem.vue
+++ b/src/modules/navigation/partials/NavigationTableItem.vue
@@ -127,7 +127,10 @@
 			</NcActionButton>
 
 			<!-- DELETE -->
-			<NcActionButton v-if="canManageElement(table)" :close-after-click="true" @click="deleteTable()">
+			<NcActionButton v-if="canManageElement(table)"
+				class="action--error"
+				:close-after-click="true"
+				@click="deleteTable()">
 				{{ t('tables', 'Delete table') }}
 				<template #icon>
 					<DeleteOutline :size="20" />
@@ -414,5 +417,11 @@ export default {
 
 .view-drop-target {
 	border-top: 2px solid var(--color-primary-element);
+}
+
+.action--error {
+	:deep(.action-button) {
+		color: var(--color-text-error, var(--color-error));
+	}
 }
 </style>

--- a/src/shared/modals/DialogConfirmation.vue
+++ b/src/shared/modals/DialogConfirmation.vue
@@ -12,10 +12,10 @@
 			</div>
 		</div>
 		<template #actions>
-			<NcButton :aria-label="cancelTitle" :type="cancelClass" @click="$emit('cancel')">
+			<NcButton :aria-label="cancelTitle" :variant="cancelClass" @click="$emit('cancel')">
 				{{ cancelTitle }}
 			</NcButton>
-			<NcButton :type="confirmClass" :aria-label="confirmTitle" @click="$emit('confirm')">
+			<NcButton :variant="confirmClass" :aria-label="confirmTitle" @click="$emit('confirm')">
 				{{ confirmTitle }}
 			</NcButton>
 		</template>
@@ -59,7 +59,9 @@ export default {
 		},
 		confirmClass: {
 			type: String,
-			default: 'success', // primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success
+			// NcButton visual variant: primary, secondary, tertiary, tertiary-no-background,
+			// tertiary-on-primary, error, warning, success
+			default: 'success',
 		},
 	},
 	emits: ['cancel', 'confirm'],


### PR DESCRIPTION
Fixes #2920

Make delete-table actions clearly destructive across the UI:

- Confirmation dialog Cancel/Delete buttons use NcButton `variant` (required in `@nextcloud/vue` v9; `type` is the native HTML button type)
- Table settings → Manage delete buttons use `variant="error"`
- Sidebar ⋯ → “Delete table” menu entry uses error text color

### 🖼️ Screenshots

<img width="1175" height="834" alt="53e230ff-07cb-459c-aae4-1deb220503bd" src="https://github.com/user-attachments/assets/08245658-2701-4859-ad16-48bd066e8d15" />
<img width="922" height="446" alt="9d1f4bb5-4efa-4651-9ac4-6ef13c21029a" src="https://github.com/user-attachments/assets/ba0b30c1-c8e6-4dc7-a301-a25b9e66288f" />
<img width="401" height="485" alt="d164cf5b-a86c-4b3f-ac19-906f2f6b0862" src="https://github.com/user-attachments/assets/149427eb-5b12-4299-827d-cd184fa4fe3b" />




