### PR TITLE
fix(import): avoid crash when table or view is deleted before import job runs

### DIFF
--- a/lib/BackgroundJob/ImportTableJob.php
+++ b/lib/BackgroundJob/ImportTableJob.php
@@ -12,6 +12,7 @@ use OCA\Tables\Db\TableMapper;
 use OCA\Tables\Db\ViewMapper;
 use OCA\Tables\Notification\NotificationHelper;
 use OCA\Tables\Service\ImportService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\QueuedJob;
 use OCP\IUserManager;
@@ -74,14 +75,20 @@ class ImportTableJob extends QueuedJob {
 			$this->userSession->setUser($oldUser);
 		}
 
-		if (!$tableId && $viewId) {
-			$tableId = $this->viewMapper->find($viewId)->getTableId();
+		try {
+			if (!$tableId && $viewId) {
+				$tableId = $this->viewMapper->find($viewId)->getTableId();
+			}
+			$table = $this->tableMapper->find($tableId);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Could not trigger import-finished activity, table or view no longer exists: ' . $e->getMessage(), ['exception' => $e]);
+			return;
 		}
 
 		if ($importSuccess) {
 			$this->activityManager->triggerEvent(
 				objectType: ActivityManager::TABLES_OBJECT_TABLE,
-				object: $this->tableMapper->find($tableId),
+				object: $table,
 				subject: ActivityManager::SUBJECT_IMPORT_FINISHED,
 				additionalParams: [
 					'importStats' => $importStats,

--- a/lib/BackgroundJob/ImportTableJob.php
+++ b/lib/BackgroundJob/ImportTableJob.php
@@ -48,6 +48,20 @@ class ImportTableJob extends QueuedJob {
 		$userId = $argument['user_id'];
 		$tableId = $argument['table_id'];
 		$viewId = $argument['view_id'];
+
+		try {
+			$view = $viewId ? $this->viewMapper->find($viewId) : null;
+			$targetTableId = $view?->getTableId() ?? $tableId;
+			if ($targetTableId === null) {
+				$this->logger->error('Import job was scheduled without a table or view id, skipping.');
+				return;
+			}
+			$table = $this->tableMapper->find($targetTableId);
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Import skipped, table or view no longer exists: ' . $e->getMessage(), ['exception' => $e]);
+			return;
+		}
+
 		$oldUser = $this->userSession->getUser();
 		$importSuccess = false;
 
@@ -75,16 +89,6 @@ class ImportTableJob extends QueuedJob {
 			$this->userSession->setUser($oldUser);
 		}
 
-		try {
-			if (!$tableId && $viewId) {
-				$tableId = $this->viewMapper->find($viewId)->getTableId();
-			}
-			$table = $this->tableMapper->find($tableId);
-		} catch (DoesNotExistException $e) {
-			$this->logger->warning('Could not trigger import-finished activity, table or view no longer exists: ' . $e->getMessage(), ['exception' => $e]);
-			return;
-		}
-
 		if ($importSuccess) {
 			$this->activityManager->triggerEvent(
 				objectType: ActivityManager::TABLES_OBJECT_TABLE,
@@ -100,17 +104,17 @@ class ImportTableJob extends QueuedJob {
 			$notifySubject = ActivityManager::SUBJECT_IMPORT_FAILED;
 		}
 
-		if ($viewId) {
+		if ($view !== null) {
 			$this->notificationHelper->sendNotification(
 				objectType: ActivityManager::TABLES_OBJECT_VIEW,
-				object: $this->viewMapper->find($viewId),
+				object: $view,
 				subject: $notifySubject,
 				author: $userId
 			);
 		} else {
 			$this->notificationHelper->sendNotification(
 				objectType: ActivityManager::TABLES_OBJECT_TABLE,
-				object: $this->tableMapper->find($tableId),
+				object: $table,
 				subject: $notifySubject,
 				author: $userId
 			);


### PR DESCRIPTION
The `ImportTableJob` was throwing the following error multiple times:   
```
Did expect one result but found none when executing: query
  "SELECT * FROM tables_tables WHERE id = :dcValue1"
```
If the table (or the view whose table this resolves) is deleted between when the import job is queued and when the background worker picks it up, `TableMapper::find()/ViewMapper::find()` throws `DoesNotExistException`, which propagates uncaught out of `run()`.

Wrap the table/view lookup in a try/catch so a deleted table or view is logged as a warning and the import-finished activity is skipped instead of throwing.

### 🏁 Checklist
 
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
