### PR TITLE
fix(tests): toggle link providers by their switch role

### DIFF
--- a/playwright/support/commands.ts
+++ b/playwright/support/commands.ts
@@ -605,22 +605,22 @@ export async function createTextLinkColumn(
 		.click()
 	await expect(page.getByText('Allowed types')).toBeVisible()
 
-	await setCheckboxState(
-		page.getByRole('checkbox', { name: /^URL$/i }),
-		false,
-	)
-	await setCheckboxState(
-		page.getByRole('checkbox', { name: /^Files$/i }),
-		false,
-	)
+	const providerSwitches = page.locator('.typeSelection').getByRole('switch')
+	await expect(providerSwitches.first()).toBeVisible()
+
+	const providerCount = await providerSwitches.count()
+	for (let index = 0; index < providerCount; index++) {
+		await setCheckboxState(providerSwitches.nth(index), false)
+	}
 
 	for (const provider of ressourceProvider) {
-		await setCheckboxState(
-			page.getByRole('checkbox', {
+		const providerSwitch = page
+			.locator('.typeSelection')
+			.getByRole('switch', {
 				name: new RegExp(`^${escapeRegExp(provider)}$`, 'i'),
-			}),
-			true,
-		)
+			})
+		await expect(providerSwitch).toHaveCount(1)
+		await setCheckboxState(providerSwitch, true)
 	}
 	await page
 		.locator('.modal-container button')


### PR DESCRIPTION
`createTextLinkColumn()` looked the "Allowed types" provider toggles up with `getByRole('checkbox', …)`, but the accessibility tree shows they expose the **switch** role, so the locator matched nothing and `setCheckboxState()` returned without toggling anything. Every pre-activated provider therefore stayed enabled (`preActivatedProviders` is `url, files, contacts`), so a URL-only column rendered the provider `NcSelect` instead of the plain `NcTextField`, the value typed by `.fill()` went into the select's search box and was never committed, and the row saved without it - which is why `column-text-link.spec.ts:16` fails on `main` across all four Nextcloud versions. 

The toggles are now addressed by their switch role and the requested provider is asserted to exist, so a future role change fails the test loudly instead of silently disabling the column setup. 

This is a test-side fix only; no application code is touched.

### 🏁 Checklist
 
- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stableX.X`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI