### PR TITLE
fix(federation): avoid empty body on signed requests

### DIFF
--- a/lib/Federation/FederationProxy.php
+++ b/lib/Federation/FederationProxy.php
@@ -160,7 +160,7 @@ class FederationProxy {
 
 	private function prepareSignedRequestOptions(string $verb, string $url, ?string $accessToken, array $parameters = []): array {
 		$options = $this->generateDefaultRequestOptions($accessToken);
-		$options['body'] = !empty($parameters) ? json_encode($parameters) : '';
+		$options['body'] = !empty($parameters) ? json_encode($parameters) : '{}';
 
 		$options = $this->signatureManager->signOutgoingRequestIClientPayload(
 			$this->signatoryManager,


### PR DESCRIPTION
## Summary
Federated signed requests with empty body are sent with `content-length: 0`.
On some setups this header doesn't reach the receiving instance, which then rejects the requests with error `missing content-length in header`.

## Solution
Send a minimal non-empty body `{}` instead of an empty string.

This is a limitation in core `IncomingSignedRequest::verifyHeaders()`, which requires the `content-length` header even when the body is empty. Working around it here because a core fix would need its own PR in `nextcloud/server`.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
